### PR TITLE
Add sqlite backend option

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -80,6 +80,7 @@ function language_hook($PALANG, $language) {
 // mysql = MySQL 3.23 and 4.0, 4.1 or 5
 // mysqli = MySQL 4.1+ or MariaDB
 // pgsql = PostgreSQL
+// sqlite = SQLite 3
 $CONF['database_type'] = 'mysqli';
 $CONF['database_host'] = 'localhost';
 $CONF['database_user'] = 'postfix';
@@ -90,6 +91,8 @@ $CONF['database_name'] = 'postfix';
 // If you need to specify a different port for POSTGRESQL database connection
 //   uncomment and change the following
 // $CONF['database_port'] = '5432';
+// If sqlite is used, specify the database file path:
+//   $CONF['database_name'] = '/etc/postfix/sqlite/postfixadmin.db'
 
 // Here, if you need, you can customize table names.
 $CONF['database_prefix'] = '';

--- a/model/FetchmailHandler.php
+++ b/model/FetchmailHandler.php
@@ -21,7 +21,7 @@ class FetchmailHandler extends PFAHandler {
         $this->struct=array(
             # field name                allow       display in...   type    $PALANG label                     $PALANG description                 default / options / ...
             #                           editing?    form    list
-            'id'            => pacol(   0,          0,      1,      'num' , ''                              , ''                                ),
+            'id'            => pacol(   0,          0,      1,      'num' , ''                              , ''                                , '', array(), 0, 1),
             'domain'        => pacol(   0,          0,      1,      'text', ''                              , ''                                ),
             'mailbox'       => pacol(   1,          1,      1,      'enum', 'pFetchmail_field_mailbox'      , 'pFetchmail_desc_mailbox'         ), # mailbox list
             'src_server'    => pacol(   1,          1,      1,      'text', 'pFetchmail_field_src_server'   , 'pFetchmail_desc_src_server'      ),

--- a/model/PFAHandler.php
+++ b/model/PFAHandler.php
@@ -567,6 +567,10 @@ abstract class PFAHandler {
         if (db_pgsql()) {
             $formatted_date = "TO_DATE(text(###KEY###), '" . escape_string(Config::Lang('dateformat_pgsql')) . "')";
             $base64_decode = "DECODE(###KEY###, 'base64')";
+        } elseif (db_sqlite()) {
+            $formatted_date = "strftime(###KEY###, '" . escape_string(Config::Lang('dateformat_mysql')) . "')";
+            $base64_decode = "base64_decode(###KEY###)";
+
         } else {
             $formatted_date = "DATE_FORMAT(###KEY###, '"   . escape_string(Config::Lang('dateformat_mysql')) . "')";
             $base64_decode = "FROM_BASE64(###KEY###)";

--- a/setup.php
+++ b/setup.php
@@ -47,6 +47,7 @@ $f_get_magic_quotes_gpc = function_exists ("get_magic_quotes_gpc");
 $f_mysql_connect = function_exists ("mysql_connect");
 $f_mysqli_connect = function_exists ("mysqli_connect");
 $f_pg_connect = function_exists ("pg_connect");
+$f_sqlite_open = class_exists("SQLite3");
 $f_session_start = function_exists ("session_start");
 $f_preg_match = function_exists ("preg_match");
 $f_mb_encode_mimeheader = function_exists ("mb_encode_mimeheader");
@@ -162,7 +163,7 @@ if (!is_writeable($incpath.'/templates_c'))
 //
 // Check if there is support for at least 1 database
 //
-if (($f_mysql_connect == 0) and ($f_mysqli_connect == 0) and ($f_pg_connect == 0))
+if (($f_mysql_connect == 0) and ($f_mysqli_connect == 0) and ($f_pg_connect == 0) and ($f_sqlite_open == 0))
 {
     print "<li><b>Error: There is no database support in your PHP setup</b><br />\n";
     print "To install MySQL 3.23 or 4.0 support on FreeBSD:<br />\n";
@@ -216,6 +217,15 @@ if ($f_pg_connect == 1)
     print "<li>Depends on: PostgreSQL - OK \n";
     if ( !($config_loaded && $CONF['database_type'] == 'pgsql') ) {
         print "<br>(change the database_type to 'pgsql' in config.inc.php if you want to use PostgreSQL)\n";
+    }
+    print "</li>";
+}
+
+if ($f_sqlite_open == 1)
+{
+    print "<li>Depends on: SQLite - OK \n";
+    if ( !($config_loaded && db_sqlite()) ) {
+        print "<br>(change the database_type to 'sqlite' in config.inc.php if you want to use SQLite)\n";
     }
     print "</li>";
 }


### PR DESCRIPTION
This PR adds the possibility to use SQLite3 as a backend for postfixadmin. Since Postfix and Dovecot both already support it, postfixadmin is the last piece of the SQLite puzzle.

I had to introduce some special cases for sqlite here and there, but mostly it's just another case, where there is already a distinction from mysql and postgres.

Other times I had to work around missing features in sqlite (especially the `..._num_rows` function).

Each translation file now also includes a `dateformat_sqlite` entry.

One of the bigger changes is in `upgrade.php`, where I renamed all the upgrade functions that were used for both mysql and postgres with a suffix `_mysql_pgsql`, so that they are only run for mysql and postgres, but not for sqlite. I also introduced the current database schema in only one function for sqlite, since there is no need for older database schemas for sqlite.

The only thing that does not currently match its mysql counter part is the `cache` column in the `vacation` table, as I added a default value (there is a bug report on this on the tracker for mysql as well).

So, if I missed anything or violated any style guidelines, please let me know and I'll fix it.