### PR TITLE
css id update-check added to footer.tpl

### DIFF
--- a/templates/footer.tpl
+++ b/templates/footer.tpl
@@ -1,8 +1,8 @@
 <!-- {$smarty.template} -->
 <div id="footer">
 	<a target="_blank" href="http://postfixadmin.sf.net/">Postfix Admin {$version}</a>
-	&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
-	<a target="_blank" href="http://postfixadmin.sf.net/update-check.php?version={$version|escape:"url"}">{$PALANG.check_update}</a>
+	<span id="update-check">&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
+	<a target="_blank" href="http://postfixadmin.sf.net/update-check.php?version={$version|escape:"url"}">{$PALANG.check_update}</a></span>
     {if isset($smarty.session.sessid)}
         {if $smarty.session.sessid.username}
             &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;	


### PR DESCRIPTION
Simplify hiding the software update check from display. Not really for security. More for aesthetics; and keeping the more basic users from questioning it. Add #update-check {display: none;} to your custom css. See related feature patch: https://sourceforge.net/p/postfixadmin/patches/134/