### PR TITLE
Fix security hole in AliasHandler

### DIFF
--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -126,6 +126,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias-а беше добавен ус
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'За да създадете catch-all използвайте "*" за alias. За пренасочване на домейн към домейн използвайте "*@domain.tld" в полето Към.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Редактиране на alias за вашия домейн.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Един запис на ред.'; # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -124,6 +124,7 @@ $PALANG['pCreate_alias_result_success'] = 'L\'àlies ha estat creat correctament
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Per crear un àlies general usi "*" com a àlies. Per una redirecció de domini a domini, usi "*@domain.tld" com a Destí.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Editi un àlies pel seu domini.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Una entrada per línia.'; # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = '添加别名成功!'; # XXX text chan
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = '要将所有的邮件全部转发请使用"*"作为别名. 域到域的转发请使用"*@domain.tld".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = '编辑你域名中的别名.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = '每行一条记录.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -131,6 +131,7 @@ $PALANG['pCreate_alias_result_success'] = 'Přesměrování %s bylo uspěšně p
 $PALANG['alias_updated'] = 'Přesměrování %s bylo upraveno!';
 $PALANG['pCreate_alias_catchall_text'] = 'Pro vytvoření doménového koše použijte * jako alias. Pro přesměrování doména -> doména použijte *@domain.tld jako cíl.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Toto přesměrování je svázáno s emailem a nemůže být proto vymazáno!';
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Upravit nastavení přesměrování.';
 $PALANG['pEdit_alias_help'] = 'Je možné zadat více cílových adres, jeden záznam na řádek.';

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -130,6 +130,7 @@ $PALANG['pCreate_alias_result_success'] = 'Aliaset er blevet tilføjet alias-tab
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'For at tilføje et stjerne-alias, brug en "*" som alias. For domæne til domæne-videresending brug "*@domæne.tld" som modtager.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Rediger alias.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'En modtager pr. linje.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -127,6 +127,7 @@ $PALANG['pCreate_alias_result_success'] = 'Der Alias %s wurde erstellt!';
 $PALANG['alias_updated'] = 'Der Alias %s wurde geändert.';
 $PALANG['pCreate_alias_catchall_text'] = 'Um alle Adressen abzudecken benutzen Sie einen "*" als Alias. Um ganze Domains an andere Domains weiterzuleiten benutzen Sie "*@domain.tld" im "An"-Feld.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Dieser Alias gehört zu einer Mailbox und kann nicht gelöscht werden!';
+$PALANG['protected_alias_cant_be_deleted'] = 'Der Alias %s ist geschützt und kann nur von einem Superadmin gelöscht werden.';
 
 $PALANG['pEdit_alias_welcome'] = 'Weiterleitungs-Einstellungen ändern';
 $PALANG['pEdit_alias_help'] = 'Angabe mehrerer Ziele möglich, ein Eintrag pro Zeile.';

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -128,6 +128,7 @@ $PALANG['pCreate_alias_result_success'] = 'The alias %s has been created!';
 $PALANG['alias_updated'] = 'The alias %s has been updated!';
 $PALANG['pCreate_alias_catchall_text'] = 'To create a catch-all use an "*" as alias.'; # XXX don't propagate usage of *@target-domain.com for domain-aliasing any longer
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!';
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin';
 
 $PALANG['pEdit_alias_welcome'] = 'Edit forwarding settings';
 $PALANG['pEdit_alias_help'] = 'Accepts multiple targets, one entry per line.';

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = '¡El alias ha sido añadido a la tabl
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Para crear un alias general use "*" como alias. Para una redirección de dominio a dominio, use "*@domain.tld" como Destino.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Edite un alias para su dominio.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Una entrada por línea.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias lisati aliaste tabelisse!'; # X
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Loomaks püüa-kõik aadressi kasuta aliasena "*". Domeenilt domeenile edasisaatmiseks kasuta kellele väljal "*@domeen.xx".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Muuda aliast.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Üks kirje rea kohta.'; # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -123,6 +123,7 @@ $PALANG['pCreate_alias_result_success'] = 'Aliasa alias taulan gehituta!'; # XXX
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Alias orokor bat sortzeko "*" erabil ezazu alias gisa. Domeinuz domeinurako birbideraketa baterako Norako gisa "*@domain.tld" erabil ezazu.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Domeinuarentzat aliasa aldatu.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Lerroko sarrera bat.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -126,6 +126,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias on lisätty!'; # XXX text chang
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Jos haluat luoda catch-all osoitteen käytä "*" merkkiä aliaksena. Ohjaus domainista domainiin tapahtuu käyttämällä "*@domain.tld" Kenelle: -osoitteena.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 $PALANG['pEdit_alias_welcome'] = 'Muokkaa aliasta.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Yksi kohta per rivi.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'
 $PALANG['alias'] = 'Alias';

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = 'Dulnevni er stovnað!'; # XXX text ch
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Fyri at stovna eitt ið fangar alt, brúka eina "*" sum dulnevni. Fyri navnaøki til navnaøki víðarisending brúka "*@navnaøki.fo" til hetta.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Broyt eitt dulnevni á tínum navnaøki.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Eina adressu pr. linju.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -126,6 +126,7 @@ $PALANG['pCreate_alias_result_success'] = 'L\'alias %s a été ajouté !';
 $PALANG['alias_updated'] = 'L\'alias %s a été mis à jour!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Pour ajouter un alias global, utilisez "*". Pour un transfert de domaine à domaine, utilisez "*@domain.tld" dans le champs A.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Cet alias appartient à un compte courriel et ne peut être supprimé!';
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Modifier les paramètres de transfert.';
 $PALANG['pEdit_alias_help'] = 'Cibles multiples acceptées, une entrée par ligne.';

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -124,6 +124,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias je dodan u tablicu aliasa!'; # 
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Ukoliko elite stvoriti "sveprimajući" alias, upotrijebite "*" umjesto aliasa. Za preusmjeravanje iz domene na domenu, upotrijebite "*@domena.tld" u "Za" polju.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Uredi alias za domenu.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Jedan unos po liniji.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -127,6 +127,7 @@ $PALANG['pCreate_alias_result_success'] = 'Az aliast felvettük az alias táblá
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'A catch-all (*@valami.hu) beállításához használj "*" -ot az alias mezõnél. A domain-domain közötti átirányításhoz használd a "*@akarmi.hu" címet.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Alias szerkesztése a domainhez.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Soronként egy.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = 'Nýr alias hefur verið bætt við al
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Til að útbúa alias fyrir öll netföng í léninu, þá geturðu útbúið "*" alias. Til að áframsenda með alias á annað lén eða pósthólf, notaðu "*@domain.tld í til.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Breyta alias í léninu.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Ein færsla í einu.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -126,6 +126,7 @@ $PALANG['pCreate_alias_result_success'] = 'L\'alias è stato aggiunto alla tabel
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Per creare un account universale, usare "*" come alias. Per inoltri da dominio a dominio, usare "*@domain.tld" come campo "a".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Modifica un alias per il tuo dominio.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Un indirizzo per linea.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -127,6 +127,7 @@ $PALANG['pCreate_alias_result_success'] = '転送先を追加しました。'; #
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'すべてのメールを受け取るには、転送元に "*" を使います。 別のドメインにすべて転送するには、転送先に "*.domain.tld" を使います。'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = '転送先アドレスの編集'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = '1行に1エントリです。'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = 'Sinonimas užregistruotas!'; # XXX te
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Jei norite sukurti sinonimą, kuris gautų visas žinutes neegzistuojantiems adresatams, naudokite "*".';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 
 $PALANG['pEdit_alias_welcome'] = 'Keisti persiuntimo nustatymus';

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = 'Алијасот е додаден н
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'За да креираш catch-all користи "*" како алијас.  За препраќање од домен на домен користи "*@domain.tld" како ДО.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Едитирање на алијас за вашиот домен.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Еден запис по линија.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -127,6 +127,7 @@ $PALANG['pCreate_alias_result_success'] = 'Aliaset er blitt lagt til i alias-tab
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'For å opprette et "catch-all"-alias, bruk "*" som alias. For domene-til-domene-videresending, bruk "*@domene.tld" i Til-feltet.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 $PALANG['pEdit_alias_welcome'] = 'Endre et alias.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Én e-postadresse per linje.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'
 $PALANG['alias'] = 'Alias';

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -126,6 +126,7 @@ $PALANG['pCreate_alias_result_success'] = 'De alias %s is toegevoegd.'; # XXX te
 $PALANG['alias_updated'] = 'De alias %s is bijgewerkt!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Om een catch-all te gebruiken, dient u een "*" (asteric) in te vullen als alias. Voor domein naar domein forwarding gebruik "*@domein.tld" als naar.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'De alias maakt onderdeel uit van mailbox en kan niet worden verwijderd!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Bewerk een alias voor uw domein.';
 $PALANG['pEdit_alias_help'] = 'Meerdere e-mailadressen toegestaan. Slechts één alias per regel.';

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = 'Aliaset er lagt til i alias-tabellen!
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'For å opprette et alias som "mottar alt" bruk "*" som alias. For domene-til-domene videresending bruk "*@domene.tld" som mottaker.';  # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 $PALANG['pEdit_alias_welcome'] = 'Endre et alias.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'En mottaker per linje.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'
 $PALANG['alias'] = 'Alias';

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -128,6 +128,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias został dodany do tabeli alias�
 $PALANG['alias_updated'] = 'Alias %s został zaktualizowany!';
 $PALANG['pCreate_alias_catchall_text'] = 'Aby utworzyć domyślne konto dla domeny (catch-all) podaj "*" (gwiazdkę) jako alias. Jeśli chcesz przekazywać całość poczty do innej domeny, wpisz jako alias "*@domena.tld".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 $PALANG['pEdit_alias_welcome'] = 'Edytuj alias dla Twojej domeny.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Jeden wpis na linię.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'
 $PALANG['alias'] = 'Alias';

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -129,6 +129,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias criado!'; # XXX text change: 'T
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Para criar um alias global, use "*" no campo Alias. Para encaminhar de um domínio para outro, use "*@dominio.tld" no campo Para.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Edição de alias do domínio.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Uma entrada por linha.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -127,6 +127,7 @@ $PALANG['pCreate_alias_result_success'] = 'Aliasul %s a fost creat!';
 $PALANG['alias_updated'] = 'Aliasul %s a fost modificat!';
 $PALANG['pCreate_alias_catchall_text'] = 'Puteti crea un alias pentru adrese multiple prin folosirea "*".'; # XXX don't propagate usage of *@target-domain.com for domain-aliasing any longer
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Acest alias apartine unei casute si nu poate fi sters!';
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Editeaza setarile de redirectionare';
 $PALANG['pEdit_alias_help'] = 'Se accepta inregistrari multiple, cate una pe linie.';

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -129,6 +129,7 @@ $PALANG['pCreate_alias_result_success'] = 'Алиас был успешно со
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Для создания catch-all почтового ящика используйте "*" в качестве имени алиаса.'; # XXX don't propagate usage of *@target-domain.com for domain-aliasing any longer
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Редактирование настроек пересылки';
 $PALANG['pEdit_alias_help'] = 'Можно указать несколько целей, одна запись на строку.';

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -126,6 +126,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias bol pridaný do tabuľky!'; # X
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Pre vytvorenie doménového koša použite * ako alias. Pre alias doména-doména použite *@domain.tld ako cieľ.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Upraviť aliasy'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Jeden záznam na riadku'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias je bil uspešno dodan!'; # XXX 
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Če želite ustvariti "vseobsegajoči" alias, uporabite "*" namesto aliasa. Za posredovanje iz domene na domeno, uporabite "*@domena.si" v "Za" polju.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Uredi alias za določeno domeno.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'V posamezni vrstici je lahko samo en naslov.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -128,6 +128,7 @@ $PALANG['pCreate_alias_result_success'] = 'Aliaset har skapats i aliastabellen! 
 $PALANG['alias_updated'] = 'Aliaset %s är uppdaterat!';
 $PALANG['pCreate_alias_catchall_text'] = 'För att skapa en catch-all anges ett "*" som alias.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Detta alias tillhör en brevlåda och kan inte tas bort!';
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Inställningar för vidarebefordring.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Ett alias per rad.'; # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -125,6 +125,7 @@ $PALANG['pCreate_alias_result_success'] = 'Alias tabloya eklendi!'; # XXX text c
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Hepsini-yakala yaratmak için alias olarak "*" kullanýn. Domain yönlendirme domaini için kime kýsmýnda "*@domain.tld" kullanýn.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'domaniniz için bir domain\'i düzenleyin. '; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Satýr baþýna bir giriþ.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -126,6 +126,7 @@ $PALANG['pCreate_alias_result_success'] = '添加別名成功!'; # XXX text chan
 $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = '要將所有的郵件全部轉發請使用"*"作為別名. 網域到網域的轉發請使用"*@domain.tld".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
+$PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = '編輯你網域中的別名.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = '每行一條記錄.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/model/AliasHandler.php
+++ b/model/AliasHandler.php
@@ -441,6 +441,11 @@ class AliasHandler extends PFAHandler {
             return false;
         }
 
+        if ($this->can_delete) {
+            $this->errormsg[] = Config::Lang_f('protected_alias_cant_be_deleted', $this->id);
+            return false;
+        }
+
         db_delete('alias', 'address', $this->id);
 
         list(/*NULL*/,$domain) = explode('@', $this->id);

--- a/model/AliasHandler.php
+++ b/model/AliasHandler.php
@@ -441,7 +441,7 @@ class AliasHandler extends PFAHandler {
             return false;
         }
 
-        if ($this->can_delete) {
+        if (!$this->can_delete) {
             $this->errormsg[] = Config::Lang_f('protected_alias_cant_be_deleted', $this->id);
             return false;
         }


### PR DESCRIPTION
Without this fix it is possible to delete a protected alias via editing
the request parameter of the alias to delete.

A simple example: If the alias abuse@example.com is defined as default alias and the alias other@example.com exists, you can just change the parameter in the delete url:

The delete url for other@example.com will probably look like this:
`https://pfadmin.example.com/delete.php?table=alias&delete=other%40example.com&token=<CSRF-Token>`

You can just change the request to 
`https://pfadmin.example.com/delete.php?table=alias&delete=abuse%40example.com&token=<CSRF-Token>`
and Postfixadmin will delete the default alias.

The suggested fix just adds a condition to the delete function in AliasHandler which will fail if `$this->can_delete` is false.