### PR TITLE
added config option to disable "edit_alias" function for users

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -410,6 +410,10 @@ $CONF['fetchmail'] = 'YES';
 // This should be set to NO, except if you *really* trust *all* your users.
 $CONF['fetchmail_extra_options'] = 'NO';
 
+// Edit alias
+// If you don't want edit alias tab (user mode) set this to 'NO';
+$CONF['edit_alias'] = 'YES';
+
 // Header
 $CONF['show_header_text'] = 'NO';
 $CONF['header_text'] = ':: Postfix Admin ::';

--- a/templates/users_main.tpl
+++ b/templates/users_main.tpl
@@ -6,10 +6,12 @@
 		<td>{$tummVacationtext}</td>
 	</tr>
 {/if}
+{if $CONF.edit_alias===YES}
 	<tr>
 		<td nowrap="nowrap"><a target="_top" href="edit-alias.php">{$PALANG.pUsersMenu_edit_alias}</a></td>
 		<td>{$PALANG.pUsersMain_edit_alias}</td>
 	</tr>
+{/if}
 	<tr>
 		<td nowrap="nowrap"><a target="_top" href="password.php">{$PALANG.change_password}</a></td>
 		<td>{$PALANG.pUsersMain_password}</td>

--- a/templates/users_menu.tpl
+++ b/templates/users_menu.tpl
@@ -4,7 +4,9 @@
 {if $CONF.vacation===YES}
 	<li><a target="_top" href="{#url_user_vacation#}">{$PALANG.pUsersMenu_vacation}</a></li>
 {/if}
+{if $CONF.edit_alias===YES}
 	<li><a target="_top" href="{#url_user_edit_alias#}">{$PALANG.pUsersMenu_edit_alias}</a></li>
+{/if}
 	<li><a target="_top" href="{#url_user_password#}">{$PALANG.change_password}</a></li>
 	<li class="logout"><a target="_top" href="{#url_user_logout#}">{$PALANG.pMenu_logout}</a></li>
 </ul>

--- a/users/edit-alias.php
+++ b/users/edit-alias.php
@@ -22,14 +22,14 @@ $rel_path = '../';
 require_once('../common.php');
 $smarty->assign ('smarty_template', 'users_edit-alias');
 
-// is edit-alias support enabled in $CONF ?
-if($CONF['edit_alias'] == 'NO') {
-  header ("Location: $Return_url");
-  exit(0);
-}
-
 authentication_require_role('user');
 $USERID_USERNAME = authentication_get_username();
+
+// is edit-alias support enabled in $CONF ?
+if (! Config::bool('edit_alias')) {  
+  header ("Location: main.php");
+  exit(0);
+}
 
 $ah = new AliasHandler();
 $ah->init($USERID_USERNAME);

--- a/users/edit-alias.php
+++ b/users/edit-alias.php
@@ -22,6 +22,12 @@ $rel_path = '../';
 require_once('../common.php');
 $smarty->assign ('smarty_template', 'users_edit-alias');
 
+// is edit-alias support enabled in $CONF ?
+if($CONF['edit_alias'] == 'NO') {
+  header ("Location: $Return_url");
+  exit(0);
+}
+
 authentication_require_role('user');
 $USERID_USERNAME = authentication_get_username();
 


### PR DESCRIPTION
This commit adds the possibility to prevent users from setting aliases.