### PR TITLE
 Updated version of virtual vacation script with Email::Sender

### DIFF
--- a/VIRTUAL_VACATION/INSTALL.TXT
+++ b/VIRTUAL_VACATION/INSTALL.TXT
@@ -90,7 +90,7 @@ Define the transport type in the Postfix master file:
 
 #/etc/postfix/master.cf:
 vacation    unix  -       n       n       -       -       pipe
-  flags=Rq user=vacation argv=/usr/lib/postfixadmin/vacation.pl -f ${sender} -- ${recipient}
+  flags=Rq user=vacation argv=/usr/lib/postfixadmin/vacation.pl -f ${sender} -d ${recipient}
 
 5. Setup the transport maps file
 --------------------------------


### PR DESCRIPTION
Mail::Server  ==> Email::Server
Main update.
MAIL::Server is deprecated and the script neeeded the new library.

GetOpt::Std ==> GetOpt::Long
On my Ubuntu 16.04 servers with Perl 5.22 I had problems to install GetOpt::Std, cpan request was to force update to Perl 5.26, which I didn't want to.
I changed the usage syntax, which now is: vacation.pl [-t] -f {sender} -d {recipient}

Logger initialization
I changed the logger initialization and put it into the config section

Version update
I choosed to start a version 5.0 of the script since the updates are rather deep.