### PR TITLE
Update broadcast-message.php to send broadcast message to active users only

### DIFF
--- a/broadcast-message.php
+++ b/broadcast-message.php
@@ -61,9 +61,9 @@ if ($_SERVER['REQUEST_METHOD'] == "POST")
 
       $recipients = [];
 
-      $q = "SELECT username from $table_mailbox WHERE ".db_in_clause("domain", $wanted_domains);
+      $q = "SELECT username, active from $table_mailbox WHERE active=1 AND ".db_in_clause("domain", $wanted_domains);
       if (intval(safepost('mailboxes_only')) == 0) {
-         $q .= " UNION SELECT goto FROM $table_alias WHERE ".db_in_clause("domain", $wanted_domains)."AND goto NOT IN ($q)";
+         $q .= " UNION SELECT goto, active FROM $table_alias WHERE ".db_in_clause("domain", $wanted_domains)."AND goto NOT IN ($q)";
       }
       $result = db_query($q);
       if($result['rows'] > 0) {


### PR DESCRIPTION
Send broadcast message to active users only. 
Without "active=1" condition in WHERE will clause a lot of "Recipient address rejected: User unknown in virtual mailbox table."