### PR TITLE
Replace Deprecated Mail::Sender by Email::Sender

### DIFF
--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -X
+#!/usr/bin/perl
 # Note  - 2017/02/08 DG :
 # Yes - I know -X (^) is not ideal.
 #       Patches are welcome to remove the dependency on Mail::Sender. 
@@ -86,6 +86,11 @@
 #             Add capability to include the subject of the original mail in the subject of the vacation message.
 #             A good vacation subject could be: 'Re: $SUBJECT'
 #             Also corrected log entry about "Already informed ..." to show the $orig_from, not $email
+# 
+# 2017-07-14  Thomas Kempf <tkempf@hueper.de>
+#			  Add configuration parameter $novacation_pattern in order to exlude specific alias-recipients from 
+# 			  sending vacation mails, even if one or multiple of the recipients the alias points to has vacation
+#             currently active
 #
 
 # Requirements - the following perl modules are required:
@@ -206,6 +211,13 @@ our $interval = 0;
 # default = 0
 our $custom_noreply_pattern = 0;
 our $noreply_pattern = 'bounce|do-not-reply|facebook|linkedin|list-|myspace|twitter'; 
+
+# Never send vacation mails for the following recipient email addresses.
+# Useful e.g. aliases pointing to multiple recipients which have vacation
+# which should not trigger vacation messages.
+# By default vacation email addresses will be sent for all recipients.
+# default = ''
+our $novacation_pattern = ''; 
 
 
 # instead of changing this script, you can put your settings to /etc/mail/postfixadmin/vacation.conf
@@ -695,6 +707,12 @@ if(!$from || !$to || !$messageid || !$smtp_sender || !$smtp_recipient) {
     exit(0);
 }
 $logger->debug("Email headers have to: '$to' and From: '$from'");
+
+if ($to =~ ~ /^.*($novacation_pattern).*/i) { 
+   $logger->debug("Will not send vacation reply for messages to $to");
+   exit(0); 
+}
+
 $to = strip_address($to);
 $cc = strip_address($cc);
 $from = check_and_clean_from_address($from);

--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -222,7 +222,7 @@ our $noreply_pattern = 'bounce|do-not-reply|facebook|linkedin|list-|myspace|twit
 # default = ''
 # preventing vacation notifications for recipient info@example.org would look like this:
 # our $no_vacation_pattern = 'info\@example\.org';
-our $no_vacation_pattern = ''; 
+our $no_vacation_pattern = 'info\@example\.org'; 
 
 
 # instead of changing this script, you can put your settings to /etc/mail/postfixadmin/vacation.conf

--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -91,7 +91,7 @@
 
 # Requirements - the following perl modules are required:
 # DBD::Pg or DBD::mysql
-# EMail::Sender,Email::Simple,Email::Valid,Try::Tiny,MIME::Charset, Log::Log4perl, Log::Dispatch, MIME::EncWords and GetOpt::Std
+# EMail::Sender,Email::Simple,Email::Valid,Try::Tiny,MIME::Charset, Log::Log4perl, Log::Dispatch, and GetOpt::Std
 #
 # You may install these via CPAN, or through your package tool.
 # CPAN: 'perl -MCPAN -e shell', then 'install Module::Whatever'
@@ -107,7 +107,6 @@
 #   liblog-dispatch-perl
 #   libgetopt-argvfile-perl
 #   libmime-charset-perl
-#   libmime-encwords-perl 
 #
 # Note: When you use this module, you may start seeing error messages
 # like "Cannot insert a duplicate key into unique index
@@ -123,9 +122,7 @@
 #
 use utf8;
 use DBI;
-use MIME::Base64 qw(encode_base64);
-use Encode qw(encode decode);
-use MIME::EncWords qw(:all);
+use Encode qw(decode);
 use Email::Valid;
 use strict;
 use Getopt::Std;

--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -168,7 +168,12 @@ our $smtp_client = 'localhost';
 
 # send mail encrypted or plaintext
 # if 'starttls', use STARTTLS; if 'ssl' (or 1), connect securely; otherwise, no security
-our $smtp_ssl = '';
+our $smtp_ssl = 'starttls';
+
+# passed to Net::SMTP constructor for 'ssl' connections or to starttls for 'starttls' connections; should contain extra options for IO::Socket::SSL
+our $ssl_options = {
+	SSL_verifycn_name => $smtp_server
+};
 
 # maximum time in secs to wait for server; default is 120
 our $smtp_timeout = '120';
@@ -556,6 +561,7 @@ sub send_vacation_email {
 		my $smtp_params = {
 			host => $smtp_server,
             port => $smtp_server_port,
+            ssl_options => $ssl_options,
 			ssl  => $smtp_ssl,
 			timeout => $smtp_timeout,
 			localaddr => $smtp_client,

--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -91,7 +91,7 @@
 
 # Requirements - the following perl modules are required:
 # DBD::Pg or DBD::mysql
-# EMail::Sender,Email::Simple,Email::Valid,Try::Tiny,MIME::Charset, Log::Log4perl, Log::Dispatch, and GetOpt::Std
+# EMail::Sender,Email::Simple,Email::Valid,Try::Tiny,MIME::Charset, MIME::EncWords, Log::Log4perl, Log::Dispatch, and GetOpt::Std
 #
 # You may install these via CPAN, or through your package tool.
 # CPAN: 'perl -MCPAN -e shell', then 'install Module::Whatever'
@@ -107,6 +107,7 @@
 #   liblog-dispatch-perl
 #   libgetopt-argvfile-perl
 #   libmime-charset-perl
+#   libmime-encwords-perl
 #
 # Note: When you use this module, you may start seeing error messages
 # like "Cannot insert a duplicate key into unique index
@@ -579,7 +580,7 @@ sub send_vacation_email {
             header => [
                 To      => $to,
                 From    => $from,
-                Subject => $subject,
+                Subject => encode_mimewords($subject, 'Charset', 'UTF-8'),
                 Precedence => 'junk',
                 'Content-Type' => "text/plain; charset=utf-8",
                 'X-Loop' => 'Postfix Admin Virtual Vacation',

--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -223,6 +223,8 @@ our $noreply_pattern = 'bounce|do-not-reply|facebook|linkedin|list-|myspace|twit
 # hence an email to the alias should not trigger vacation messages.
 # By default vacation email addresses will be sent for all recipients.
 # default = ''
+# preventing vacation notifications for recipient info@example.org would look like this:
+# our $novacation_pattern = 'info\@example\.org';
 our $novacation_pattern = ''; 
 
 

--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -124,6 +124,7 @@
 use utf8;
 use DBI;
 use Encode qw(decode);
+use MIME::EncWords qw(:all);
 use Email::Valid;
 use strict;
 use Getopt::Std;

--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -582,11 +582,12 @@ sub send_vacation_email {
             header => [
                 To      => $to,
                 From    => $from,
-                Subject => encode_mimewords($subject, 'Charset', 'UTF-8'),
+                Subject => $subject,
                 Precedence => 'junk',
+                'Content-Type' => "text/plain; charset=utf-8",
                 'X-Loop' => 'Postfix Admin Virtual Vacation',
             ],
-            body => encode("UTF-8", $body),
+            body => $body,
         );
 		
         if($test_mode == 1) {

--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -83,9 +83,9 @@
 #             Also corrected log entry about "Already informed ..." to show the $orig_from, not $email
 # 
 # 2017-07-14  Thomas Kempf <tkempf@hueper.de>
-#			  Replacing deprecated Mail::Sender by Email::Sender
-#			  Add configuration parameter $novacation_pattern in order to exlude specific alias-recipients from 
-# 			  sending vacation mails, even if one or multiple of the recipients the alias points to has vacation
+#             Replacing deprecated Mail::Sender by Email::Sender
+#             Add configuration parameter $no_vacation_pattern in order to exlude specific alias-recipients from 
+#             sending vacation mails, even if one or multiple of the recipients the alias points to has vacation
 #             currently active. 
 #
 
@@ -100,7 +100,7 @@
 #   libemail-sender-perl
 #   libemail-simple-perl
 #   libemail-valid-perl
-#	libtry-tiny-perl
+#   libtry-tiny-perl
 #   libdbd-pg-perl
 #   libmime-perl
 #   liblog-log4perl-perl
@@ -169,7 +169,7 @@ our $smtp_ssl = 'starttls';
 
 # passed to Net::SMTP constructor for 'ssl' connections or to starttls for 'starttls' connections; should contain extra options for IO::Socket::SSL
 our $ssl_options = {
-	SSL_verifycn_name => $smtp_server
+    SSL_verifycn_name => $smtp_server
 };
 
 # maximum time in secs to wait for server; default is 120
@@ -221,8 +221,8 @@ our $noreply_pattern = 'bounce|do-not-reply|facebook|linkedin|list-|myspace|twit
 # By default vacation email addresses will be sent for all recipients.
 # default = ''
 # preventing vacation notifications for recipient info@example.org would look like this:
-# our $novacation_pattern = 'info\@example\.org';
-our $novacation_pattern = ''; 
+# our $no_vacation_pattern = 'info\@example\.org';
+our $no_vacation_pattern = ''; 
 
 
 # instead of changing this script, you can put your settings to /etc/mail/postfixadmin/vacation.conf
@@ -557,25 +557,25 @@ sub send_vacation_email {
         my $from = $email;
         my $to = $orig_from;
 
-		my $smtp_params = {
-			host => $smtp_server,
+        my $smtp_params = {
+            host => $smtp_server,
             port => $smtp_server_port,
             ssl_options => $ssl_options,
-			ssl  => $smtp_ssl,
-			timeout => $smtp_timeout,
-			localaddr => $smtp_client,
+            ssl  => $smtp_ssl,
+            timeout => $smtp_timeout,
+            localaddr => $smtp_client,
             debug => 0,
-		};
+        };
 
-		if($smtp_authid ne ''){
-			$smtp_params->{sasl_username}=$smtp_authid;
-			$smtp_params->{sasl_password}=$smtp_authpwd;
+        if($smtp_authid ne ''){
+            $smtp_params->{sasl_username}=$smtp_authid;
+            $smtp_params->{sasl_password}=$smtp_authpwd;
             $logger->info("Doing SASL Authentication with user $smtp_params->{sasl_username}\n");
-		};
-		
+        };
+
         my $transport = Email::Sender::Transport::SMTP->new($smtp_params);
-		
-		$email = Email::Simple->create(
+
+        $email = Email::Simple->create(
             header => [
                 To      => $to,
                 From    => $from,
@@ -586,7 +586,7 @@ sub send_vacation_email {
             ],
             body => $body,
         );
-		
+
         if($test_mode == 1) {
             $logger->info("** TEST MODE ** : Vacation response sent to $to from $from subject $subject (not) sent\n");
             $logger->info($email);
@@ -599,10 +599,10 @@ sub send_vacation_email {
             if (@_) {
                 $logger->error("Failed to send vacation response to $to from $from subject $subject: @_");
             } else {
-            	$logger->debug("Vacation response sent to $to from $from subject $subject sent\n");
-        	}
-    	}
-	}
+             $logger->debug("Vacation response sent to $to from $from subject $subject sent\n");
+            }
+        }
+    }
 }
 
 # Convert a (list of) email address(es) from RFC 822 style addressing to
@@ -723,7 +723,7 @@ if(!$from || !$to || !$messageid || !$smtp_sender || !$smtp_recipient) {
 }
 $logger->debug("Email headers have to: '$to' and From: '$from'");
 
-if ($to =~ /^.*($novacation_pattern).*/i) { 
+if ($to =~ /^.*($no_vacation_pattern).*/i) { 
    $logger->debug("Will not send vacation reply for messages to $to");
    exit(0); 
 }


### PR DESCRIPTION
Replaces the deprecated Mail::Sender with Email::Sender without the need of changing master.cf.
Works with TLS on Debian Stretch
Adds a regexp novacation_pattern to define adresses where vacation E-mails never should be sent
