### PR TITLE
Fix unquoted string array index in viewlog.php

### DIFF
--- a/viewlog.php
+++ b/viewlog.php
@@ -60,9 +60,9 @@ $tLog = array();
 if ($error != 1)
 {
    $table_log = table_by_key('log');
-   $query = "SELECT timestamp,username,domain,action,data FROM $table_log WHERE domain='$fDomain' ORDER BY timestamp DESC LIMIT " . intval($CONF[page_size]);
+   $query = "SELECT timestamp,username,domain,action,data FROM $table_log WHERE domain='$fDomain' ORDER BY timestamp DESC LIMIT " . intval($CONF['page_size']);
    if (db_pgsql()) {
-      $query = "SELECT extract(epoch from timestamp) as timestamp,username,domain,action,data FROM $table_log WHERE domain='$fDomain' ORDER BY timestamp DESC LIMIT " . intval($CONF[page_size]);
+      $query = "SELECT extract(epoch from timestamp) as timestamp,username,domain,action,data FROM $table_log WHERE domain='$fDomain' ORDER BY timestamp DESC LIMIT " . intval($CONF['page_size']);
    }
    $result=db_query($query);
    if ($result['rows'] > 0)


### PR DESCRIPTION
`$CONF[page_size]` was working, but throwing E_NOTICE, so I propose changing it to `$CONF['page_size']`.