### PR TITLE
Add support for MySQL connections over SSL

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -87,6 +87,14 @@ $CONF['database_user'] = 'postfix';
 $CONF['database_password'] = 'postfixadmin';
 $CONF['database_name'] = 'postfix';
 
+// Database SSL Config
+$CONF['database_use_ssl'] = false;
+$CONF['database_ssl_key'] = NULL;
+$CONF['database_ssl_cert'] = NULL;
+$CONF['database_ssl_ca'] = NULL;
+$CONF['database_ssl_ca_path'] = NULL;
+$CONF['database_ssl_cipher'] = NULL;
+
 // If you need to specify a different port for a MYSQL database connection, use e.g.
 //   $CONF['database_host'] = '172.30.33.66:3308';
 //


### PR DESCRIPTION
Allows for the configuration of MySQL SSL related options and passes them accordingly to the underlying library.

Fixes: #91 