### PR TITLE
Update functions.inc.php

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1802,7 +1802,7 @@ function table_by_key ($table_key) {
         $table = $CONF['database_tables'][$table_key];
     }
 
-    return $CONF['database_prefix'].$table;
+    return $CONF['database_prefix']."`".$table."`";
 }
 
 /*


### PR DESCRIPTION
I found that Mysql 8 don't like table names without `` in requests. So i make changes in function table_by_key in functions.inc.php and in upgrade.php . Now it works.  FreeBSD 11.1 Apache/2.4.29 (FreeBSD) PHP/7.1.11 Mysql 8