### PR TITLE
Password reset  - fix invalid DB query (double backtick)

### DIFF
--- a/users/password-recover.php
+++ b/users/password-recover.php
@@ -63,7 +63,7 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
     if ($token !== false) {
 
         $table = table_by_key($context === 'users' ? 'mailbox' : 'admin');
-        $result = db_query("SELECT * FROM `$table` WHERE username='$tUsername'");
+        $result = db_query("SELECT * FROM $table WHERE username='$tUsername'");
         $row = db_array($result['result']);
 
         $email_other = trim($row['email_other']);


### PR DESCRIPTION
When restoring admin's password, double backtick results in a query error

> PHP message: Invalid query: Incorrect table name ''
> PHP message: caused by query: SELECT * FROM ``admin`` WHERE username='sitilge@example.com'"