### PR TITLE
Making virtualmaidel.php remove Sieve filters if they exist

### DIFF
--- a/ADDITIONS/virtualmaildel.php
+++ b/ADDITIONS/virtualmaildel.php
@@ -9,6 +9,7 @@
 
  Changes:
     2017.08.31 updated to use PHP mysqli extension.
+    2018.02.23 removing Sieve filters if exists.
         Tadas Ustinavičius <tadas at ring dot lt> ( https://github.com/postfixadmin/postfixadmin/pull/70 )
 
 */
@@ -165,10 +166,20 @@ if (is_array($dir)) {
             foreach ($value as $user => $value2) {
                 // Nuke.. need any more explanations?
                 $path = $homedir . '/' . $key . '/' . $user;
+                $sieve_path = $homedir . '/.sieve/' . $key . '/' . $user;
+                $sieve_exists = false;
+                // check if user has Sieve filters created
+                if (file_exists($sieve_path)) {
+                    $sieve_exists = true;
+                }
                 if ($MAKE_CHANGES) {
                     deldir($path);
+                    deldir($sieve_path);
                 } else {
                     echo " - Would recursively delete : $path \n";
+                    if ($sieve_exists) {
+                        echo " - Would recursively delete Sieve filters : $sieve_path \n";
+                    }
                 }
             }
         }

--- a/ADDITIONS/virtualmaildel.php
+++ b/ADDITIONS/virtualmaildel.php
@@ -174,7 +174,9 @@ if (is_array($dir)) {
                 }
                 if ($MAKE_CHANGES) {
                     deldir($path);
-                    deldir($sieve_path);
+                    if ($sieve_exists) {
+                        deldir($sieve_path);
+                    }
                 } else {
                     echo " - Would recursively delete : $path \n";
                     if ($sieve_exists) {


### PR DESCRIPTION
Hello,
this patch makes virtualmaildel.php remove Sieve filters for mailbox being deleted. 
This solves issue, where newly created mailbox with the same name may inherit filters from the old, deleted mailbox.