### PR TITLE
Add predefined quota on mailbox creation page

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -321,6 +321,8 @@ $CONF['quota'] = 'NO';
 $CONF['domain_quota'] = 'YES';
 // You can either use '1024000' or '1048576'
 $CONF['quota_multiplier'] = '1024000';
+// Quota for create mailbox page
+$CONF['mailbox_default_quota'] = '';
 
 // Transport
 // If you want to define additional transport options for a domain set this to 'YES'.

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -46,7 +46,7 @@ class MailboxHandler extends PFAHandler {
                 /*select*/ 'password as password2'
             ),
             'name'          => pacol(1, 1, 1, 'text', 'name', 'pCreate_mailbox_name_text', ''),
-            'quota'         => pacol(1, 1, 1, 'int', 'pEdit_mailbox_quota', 'pEdit_mailbox_quota_text', ''), # in MB
+            'quota'         => pacol(1, 1, 1, 'int', 'pEdit_mailbox_quota', 'pEdit_mailbox_quota_text', Config::read('mailbox_default_quota')), # in MB
             # read_from_db_postprocess() also sets 'quotabytes' for use in init()
             # TODO: read used quota from quota/quota2 table
             'active'        => pacol(1, 1, 1, 'bool', 'active', '', 1),


### PR DESCRIPTION
Filling Quota on mailbox creation page with value, defined in $CONF['mailbox_default_quota'].
It's useful for creating mailboxes with same quota.
When  $CONF['mailbox_default_quota'] is empty (by default), mailbox creation page works as before - with empty Quota.