### PR TITLE
'row' is a reserved word in MySQL 8.0

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -537,7 +537,7 @@ function create_page_browser($idxfield, $querypart) {
     $page_size_zerobase = $page_size - 1;
     $query = "
         SELECT * FROM (
-            SELECT $idxfield AS label, @row := @row + 1 AS row $querypart
+            SELECT $idxfield AS label, @row := @row + 1 AS 'row' $querypart
         ) idx WHERE MOD(idx.row, $page_size) IN (0,$page_size_zerobase) OR idx.row = $count_results
     ";
 


### PR DESCRIPTION
Got this issue when I upgraded to MySQL 8.0. The rest seens to be working fine here. Couldn't find a good reference from when this changed to reserved word (mysql 5.6 works fine) but on 8 it gives error close to row. Changing to 'row' make it work in both versions...

Test query:

#### Does not work in MySQL 8
```sql
SELECT address AS label, @row := @row + 1 AS row FROM `alias` LEFT JOIN ( SELECT 1 as __is_mailbox, username as __mailbox_username FROM `mailbox` WHERE username IS NOT NULL AND domain IN ('domain.com') ) AS __mailbox ON __mailbox_username = address WHERE 1=1;
```


#### Works in MySQL 8
```sql
SELECT address AS label, @row := @row + 1 AS 'row' FROM `alias` LEFT JOIN ( SELECT 1 as __is_mailbox, username as __mailbox_username FROM `mailbox` WHERE username IS NOT NULL AND domain IN ('domain.com') ) AS __mailbox ON __mailbox_username = address WHERE 1=1;
```

That was breaking when entering in some of the domains contents, probably those with aliases.

Tested with PHP 7.0 FPM , NGINX and MySQL 8.0