### PR TITLE
Add support for difficulty setting for php_crypt

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -174,19 +174,17 @@ $CONF['smtp_client'] = '';
 // mysql_encrypt = useful for PAM integration
 // authlib = support for courier-authlib style passwords - also set $CONF['authlib_default_flavor']
 // dovecot:CRYPT-METHOD = use dovecotpw -s 'CRYPT-METHOD'. Example: dovecot:CRAM-MD5
-// php_crypt:CRYPT-METHOD = use PHP built in crypt()-function; methods supported: DES, MD5, BLOWFISH, SHA256, SHA512
+// php_crypt:CRYPT-METHOD:DIFFICULTY = use PHP built in crypt()-function. Example: php_crypt:SHA512:50000
+// - php_crypt CRYPT-METHOD: Supported values are DES, MD5, BLOWFISH, SHA256, SHA512
+// - php_crypt DIFFICULTY: Larger value is more secure, but uses more CPU and time for each login.
+// - php_crypt DIFFICULTY: Set this according to your CPU processing power.
+// - php_crypt DIFFICULTY: Supported values are BLOWFISH:4-31, SHA256:1000-999999999, SHA512:1000-999999999
+// - php_crypt DIFFICULTY: leave empty to use default values (BLOWFISH:10, SHA256:5000, SHA512:5000). Example: php_crypt:SHA512
 //     IMPORTANT:
 //     - don't use dovecot:* methods that include the username in the hash - you won't be able to login to PostfixAdmin in this case
 //     - you'll need at least dovecot 2.1 for salted passwords ('doveadm pw' 2.0.x doesn't support the '-t' option)
 //     - dovecot 2.0.0 - 2.0.7 is not supported
 $CONF['encrypt'] = 'md5crypt';
-
-// What difficulty to use with the password hashing? (integer)
-// Valid ranges = BLOWFISH: 4-31, SHA256: 1000-999999999, SHA512: 1000-999999999
-// Empty string = use the default value (BLOWFISH: 10, SHA256: 5000, SHA512: 5000)
-//     - larger value is more secure, but uses more CPU and time for each login. Set this according to your CPU processing power.
-//     - only supported with php_crypt, php_crypt:BLOWFISH, php_crypt:SHA256 and php_crypt:SHA512 encrypt methods
-$CONF['encrypt_difficulty'] = '';
 
 // In what flavor should courier-authlib style passwords be encrypted?
 // (only used if $CONF['encrypt'] == 'authlib')

--- a/config.inc.php
+++ b/config.inc.php
@@ -174,11 +174,19 @@ $CONF['smtp_client'] = '';
 // mysql_encrypt = useful for PAM integration
 // authlib = support for courier-authlib style passwords - also set $CONF['authlib_default_flavor']
 // dovecot:CRYPT-METHOD = use dovecotpw -s 'CRYPT-METHOD'. Example: dovecot:CRAM-MD5
+// php_crypt:CRYPT-METHOD = use PHP built in crypt()-function; methods supported: DES, MD5, BLOWFISH, SHA256, SHA512
 //     IMPORTANT:
 //     - don't use dovecot:* methods that include the username in the hash - you won't be able to login to PostfixAdmin in this case
 //     - you'll need at least dovecot 2.1 for salted passwords ('doveadm pw' 2.0.x doesn't support the '-t' option)
 //     - dovecot 2.0.0 - 2.0.7 is not supported
 $CONF['encrypt'] = 'md5crypt';
+
+// What difficulty to use with the password hashing? (integer)
+// Valid ranges = BLOWFISH: 4-31, SHA256: 1000-999999999, SHA512: 1000-999999999
+// Empty string = use the default value (BLOWFISH: 10, SHA256: 5000, SHA512: 5000)
+//     - larger value is more secure, but uses more CPU and time for each login. Set this according to your CPU processing power.
+//     - only supported with php_crypt, php_crypt:BLOWFISH, php_crypt:SHA256 and php_crypt:SHA512 encrypt methods
+$CONF['encrypt_difficulty'] = '';
 
 // In what flavor should courier-authlib style passwords be encrypted?
 // (only used if $CONF['encrypt'] == 'authlib')

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1106,7 +1106,10 @@ function _php_crypt_generate_crypt_salt($hash_type='SHA512') {
 
     case 'BLOWFISH':
         $length = 22;
-        $cost = 10;
+        $cost = (int)$CONF['php_crypt_difficulty'];
+        if ($cost < 4 || $cost > 31) {
+            die('invalid $CONF["php_crypt_difficulty"] setting: ' . $CONF['php_crypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 4-31');
+        }
         if (version_compare(PHP_VERSION, '5.3.7') >= 0) {
             $algorithm = '2y'; // bcrypt, with fixed unicode problem
         } else {
@@ -1118,14 +1121,22 @@ function _php_crypt_generate_crypt_salt($hash_type='SHA512') {
     case 'SHA256':
         $length = 16;
         $algorithm = '5';
+        $rounds = (int)$CONF['php_crypt_difficulty'];
+        if ($rounds < 1000 || $rounds > 999999999) {
+            die('invalid $CONF["php_crypt_difficulty"] setting: ' . $CONF['php_crypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 1000-999999999');
+        }
         $salt = _php_crypt_random_string($alphabet, $length);
-        return sprintf('$%s$%s', $algorithm, $salt);
+        return sprintf('$%s$rounds=%d$%s', $algorithm, $rounds, $salt);
 
     case 'SHA512':
         $length = 16;
         $algorithm = '6';
+        $rounds = (int)$CONF['php_crypt_difficulty'];
+        if ($rounds < 1000 || $rounds > 999999999) {
+            die('invalid $CONF["php_crypt_difficulty"] setting: ' . $CONF['php_crypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 1000-999999999');
+        }
         $salt = _php_crypt_random_string($alphabet, $length);
-        return sprintf('$%s$%s', $algorithm, $salt);
+        return sprintf('$%s$rounds=%d$%s', $algorithm, $rounds, $salt);
 
     default:
         die("unknown hash type: '$hash_type'");

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1106,9 +1106,13 @@ function _php_crypt_generate_crypt_salt($hash_type='SHA512') {
 
     case 'BLOWFISH':
         $length = 22;
-        $cost = (int)$CONF['php_crypt_difficulty'];
-        if ($cost < 4 || $cost > 31) {
-            die('invalid $CONF["php_crypt_difficulty"] setting: ' . $CONF['php_crypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 4-31');
+        if (empty($CONF['encrypt_difficulty'])) {
+            $cost = 10;
+        } else {
+            $cost = (int)$CONF['encrypt_difficulty'];
+            if ($cost < 4 || $cost > 31) {
+                die('invalid $CONF["encrypt_difficulty"] setting: ' . $CONF['encrypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 4-31');
+            }
         }
         if (version_compare(PHP_VERSION, '5.3.7') >= 0) {
             $algorithm = '2y'; // bcrypt, with fixed unicode problem
@@ -1121,9 +1125,13 @@ function _php_crypt_generate_crypt_salt($hash_type='SHA512') {
     case 'SHA256':
         $length = 16;
         $algorithm = '5';
-        $rounds = (int)$CONF['php_crypt_difficulty'];
-        if ($rounds < 1000 || $rounds > 999999999) {
-            die('invalid $CONF["php_crypt_difficulty"] setting: ' . $CONF['php_crypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 1000-999999999');
+        if (empty($CONF['encrypt_difficulty'])) {
+            $rounds = 5000;
+        } else {
+            $rounds = (int)$CONF['encrypt_difficulty'];
+            if ($rounds < 1000 || $rounds > 999999999) {
+                die('invalid $CONF["encrypt_difficulty"] setting: ' . $CONF['encrypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 1000-999999999');
+            }
         }
         $salt = _php_crypt_random_string($alphabet, $length);
         return sprintf('$%s$rounds=%d$%s', $algorithm, $rounds, $salt);
@@ -1131,9 +1139,13 @@ function _php_crypt_generate_crypt_salt($hash_type='SHA512') {
     case 'SHA512':
         $length = 16;
         $algorithm = '6';
-        $rounds = (int)$CONF['php_crypt_difficulty'];
-        if ($rounds < 1000 || $rounds > 999999999) {
-            die('invalid $CONF["php_crypt_difficulty"] setting: ' . $CONF['php_crypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 1000-999999999');
+        if (empty($CONF['encrypt_difficulty'])) {
+            $rounds = 5000;
+        } else {
+            $rounds = (int)$CONF['encrypt_difficulty'];
+            if ($rounds < 1000 || $rounds > 999999999) {
+                die('invalid $CONF["encrypt_difficulty"] setting: ' . $CONF['encrypt_difficulty'] . ', for ' . $hash_type . ' the valid range is 1000-999999999');
+            }
         }
         $salt = _php_crypt_random_string($alphabet, $length);
         return sprintf('$%s$rounds=%d$%s', $algorithm, $rounds, $salt);

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1067,7 +1067,7 @@ function _pacrypt_php_crypt($pw, $pw_db) {
         $salt = $pw_db;
     } else {
         $salt_method = 'SHA512'; // hopefully a reasonable default (better than MD5)
-        $difficulty = '';
+        $hash_difficulty = '';
         // no pw provided. create new password hash
         if (strpos($CONF['encrypt'], ':') !== false) {
             // use specified hash method

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1086,6 +1086,8 @@ function _pacrypt_php_crypt($pw, $pw_db) {
  * @return string
  */
 function _php_crypt_generate_crypt_salt($hash_type='SHA512') {
+    global $CONF;
+
     // generate a salt (with magic matching chosen hash algorithm) for the PHP crypt() function
 
     // most commonly used alphabet


### PR DESCRIPTION
Added difficulty setting for password encryption for php_crypt method. Only supports BLOWFISH, SHA256 and SHA512.

Checks the value and gives out an error if it's not valid. Empty string (default) means use default values, which means 10 for BLOWFISH and 5000 for SHA256 and SHA512.

Verified that it works fine with Dovecot and Roundcube, all others should support the "rounds=xxxx" as well.

I also added documentation for php_crypt in config.inc.php.

100% backwards compatible.