### PR TITLE
Change "characters" to "letters" in EN language file

### DIFF
--- a/languages/en.lang
+++ b/languages/en.lang
@@ -352,7 +352,7 @@ $PALANG['pStatus_custom'] = 'Delivers to ';
 $PALANG['pStatus_popimap'] = 'POP/IMAP ';
 
 $PALANG['password_too_short'] = "Password is too short - requires %s characters";
-$PALANG['password_no_characters'] = "Your password must contain at least %s character(s).";
+$PALANG['password_no_characters'] = "Your password must contain at least %s letters (A-Z, a-z).";
 $PALANG['password_no_digits'] = "Your password must contain at least %s digit(s).";
 $PALANG['pInvalidDomainRegex'] = "Invalid domain name %s, fails regexp check";
 $PALANG['pInvalidDomainDNS'] = "Invalid domain %s, and/or not discoverable in DNS";


### PR DESCRIPTION
A "character" includes letters and numbers. The requirement triggered by line 355 is for "letters". This created confusion in the past.