### PR TITLE
[v3.2] Persistent MySQLi connections: Missing SSL at reconnect

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1462,7 +1462,7 @@ function db_connect($ignore_errors = false) {
             if (function_exists("mysqli_real_connect")) {
                 $link = mysqli_init();
                 $link->ssl_set($CONF['database_ssl_key'], $CONF['database_ssl_cert'], $CONF['database_ssl_ca'], $CONF['database_ssl_ca_path'], $CONF['database_ssl_cipher']);
-                $connected = mysqli_real_connect($link, $CONF['database_host'], $CONF['database_user'], $CONF['database_password'], $CONF['database_name'], $CONF['database_port']);
+                $connected = mysqli_real_connect($link, $CONF['database_host'], $CONF['database_user'], $CONF['database_password'], $CONF['database_name'], $CONF['database_port'], null, constant('MYSQLI_CLIENT_SSL'));
                 $is_connected = $connected;
             } else {
                 $error_text .= "<p />DEBUG INFORMATION:<br />MySQLi 5 functions not available! (php5-mysqli installed?)<br />database_type = 'mysqli' in config.inc.php, are you using a different database? $DEBUG_TEXT";


### PR DESCRIPTION
* Create MySQL user with `REQUIRE SSL`
* Setup Postfixadmin to use MySQLi and SSL:

```php
$CONF['database_type']        = 'mysqli';
$CONF['database_host']        = 'p:example.net'; // <-- "p:" for persistent connection!
$CONF['database_user']        = 'username';
$CONF['database_password']    = 'password';
$CONF['database_name']        = 'database';
$CONF['database_port']        = 3306;

$CONF['database_use_ssl']     = true;
$CONF['database_ssl_ca']      = '.../ca.pem';
$CONF['database_ssl_cert']    = '.../client.pem';
$CONF['database_ssl_key']     = '.../client.key';
$CONF['database_ssl_ca_path'] = null;
$CONF['database_ssl_cipher']  = null;

```

Steps to reproduce:

* Call login.php
* Restart MySQL server
* Call login.php again

Result: Error! 🤓

```
PHP message: PHP Warning:  Packets out of order. Expected 1 received 0. Packet size=30 in […]/functions.inc.php on line 1465
PHP message: PHP Warning:  mysqli_real_connect(): MySQL server has gone away in […]/functions.inc.php on line 1465
PHP message: PHP Warning:  mysqli_real_connect(): (HY000/1045): Access denied for user […] (using password: YES) in […]/functions.inc.php on line 1465
```

Conclusion: PHP tries to reconnect without SSL.

Same test with commit ce65c482383554c5f42b81a86132933b433bb67e:

```
PHP message: PHP Warning:  Packets out of order. Expected 1 received 0. Packet size=30 in […]/functions.inc.php on line 1465
PHP message: PHP Warning:  mysqli_real_connect(): MySQL server has gone away in […]/functions.inc.php on line 1465
```

No error page, everything works as expected. Tested with PHP 7.3.1-3 and PFA 3.2.1-2 from Debian Buster.

Please merge it into branch `postfixadmin_3.2`. Thanks! 🙂

_Related: #91, #92_