### PR TITLE
fix setup db_connect_with_errors PDO exceptions were not caught

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1495,18 +1495,22 @@ function db_connect_with_errors() {
         die("<p style='color: red'>FATAL Error:<br />Invalid \$CONF['database_type']! Please fix your config.inc.php!</p>");
     }
 
-    if ($username_password) {
-        $link = new PDO($dsn, Config::read_string('database_user'), Config::read_string('database_password'), $options);
-    } else {
-        $link = new PDO($dsn, null, null, $options);
-    }
-
-    if (!empty($queries)) {
-        foreach ($queries as $q) {
-            $link->exec($q);
+    try {
+        if ($username_password) {
+            $link = new PDO($dsn, Config::read_string('database_user'), Config::read_string('database_password'), $options);
+        } else {
+            $link = new PDO($dsn, null, null, $options);
         }
-    }
 
+        if (!empty($queries)) {
+            foreach ($queries as $q) {
+                $link->exec($q);
+            }
+        }
+    } catch (PDOException $e) {
+        $error_text = 'PDO exception: '. $e->getMessage();
+        error_log($error_text);
+    }
 
     return array($link, $error_text);
 }


### PR DESCRIPTION
I've noticed that PDO exceptions are not caught on initial setup (setup.php) which breaks the environment check (Checking environment). Adding the try catch solves it.

without:
Checking environment:

Magic Quotes: Disabled - OK
Depends on: presence config.local.php - Found
Database - MySQL (mysqli_ functions) - Not found
Database - PostgreSQL (pg_ functions) - Not found
Database : SQLite support (SQLite3) - Found
(no further logging)

with:
Checking environment:
...
Database : SQLite support (SQLite3) - Found
Error: Can't connect to database
Please check the $CONF['database_*'] parameters in config.local.php. PDO exception: SQLSTATE[HY000] [14] unable to open database file
Depends on: session - OK
....