### PR TITLE
db_connect_with_errors() improvements for SQLite databases

### DIFF
--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -10,7 +10,7 @@ Version X.X - master
 -------------------------------------------------
 
    - Add support for password expiration (see https://github.com/postfixadmin/postfixadmin/pull/200 and README.password_expiration )
-   - Improve ADDITIONS/postfxiadmin-mailbox-postcreate.sh
+   - Improve ADDITIONS/postfixadmin-mailbox-postcreate.sh
    - Add Date header into smtp_from() (see https://github.com/postfixadmin/postfixadmin/issues/203 )
    - PostgreSQL fixes ( 1e158245d613fd1d8d5c1d59e26e940eb71f5b32 )
    - vacation.pl fixes (perl libraries; see https://github.com/postfixadmin/postfixadmin/pull/194 )
@@ -20,7 +20,7 @@ Version X.X - master
    - Update installation instructions. (see: https://github.com/postfixadmin/postfixadmin/issues/189 https://github.com/postfixadmin/postfixadmin/issues/188 )
    - Encryption improvements (see: php_crypt / encrypt_difficulty in sample config)
    - Sqlite improvements (see https://github.com/postfixadmin/postfixadmin/issues/177 and https://github.com/postfixadmin/postfixadmin/issues/176 )
-   - MySQL 8 compatability (see https://github.com/postfixadmin/postfixadmin/pull/175 )
+   - MySQL 8 compatibility (see https://github.com/postfixadmin/postfixadmin/pull/175 )
    - Internally the database functions have been refactored to use PDO rather than the lower level mysql_, mysqli_, pg_ etc functions. ( see: https://github.com/postfixadmin/postfixadmin/pull/231 )
 
 Version 3.2 - 2018/05/02

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1484,7 +1484,19 @@ function db_connect_with_errors() {
         $queries[] = 'SET CHARACTER SET utf8';
         $queries[] = "SET COLLATION_CONNECTION='utf8_general_ci'";
     } elseif (db_sqlite()) {
-        $dsn = "sqlite:{$CONF['database_name']}";
+        $db = $CONF['database_name'];
+
+        if (!file_exists($db)) {
+            $error_text = 'SQLite database missing: '. $db;
+            return array($link, $error_text);
+        }
+
+        if (!is_writeable($db)) {
+            $error_text = 'SQLite database not writeable: '. $db;
+            return array($link, $error_text);
+        }
+
+        $dsn = "sqlite:{$db}";
         $username_password = false;
     } elseif (db_pgsql()) {
         if (!isset($CONF['database_port'])) {
@@ -1509,7 +1521,6 @@ function db_connect_with_errors() {
         }
     } catch (PDOException $e) {
         $error_text = 'PDO exception: '. $e->getMessage();
-        error_log($error_text);
     }
 
     return array($link, $error_text);

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1496,6 +1496,11 @@ function db_connect_with_errors() {
             return array($link, $error_text);
         }
 
+        if (!is_writeable(dirname($db))) {
+            $error_text = 'The directory the SQLite database is in is not writeable: '. dirname($db);
+            return array($link, $error_text);
+        }
+
         $dsn = "sqlite:{$db}";
         $username_password = false;
     } elseif (db_pgsql()) {

--- a/public/setup.php
+++ b/public/setup.php
@@ -32,7 +32,7 @@ require(dirname(__FILE__) . '/../templates/header.php');
 <ul>
 <?php
 //
-// Check for availablilty functions
+// Check for availability functions
 //
 $f_phpversion = function_exists("phpversion");
 $f_apache_get_version = function_exists("apache_get_version");
@@ -190,7 +190,7 @@ if (!empty($link) && $error_text == "") {
     print "<li>Testing database connection (using {$CONF['database_type']}) - Success</li>";
 } else {
     print "<li><b style='color: red'>Error: Can't connect to database</b><br />\n";
-    print "Please check the \$CONF['database_*'] parameters in config.local.php.\n";
+    print "Please check the \$CONF['database_*'] parameters in config.local.php.<br />\n";
     print "$error_text</li>\n";
     $error ++;
 }


### PR DESCRIPTION
added: checks for sqlite databases in db_connect_with_errors():
- check that the database file exists,
- check that the database file is writeable,
- check that the database directory is writeable too (http://php.net/manual/en/ref.pdo-sqlite.php#57356)

removed: error_log() in PDO exception, I had left after debugging.