### PR TITLE
Allow Top-Level-Domain with 1 char

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -224,7 +224,7 @@ function language_selector() {
  * @todo skip DNS check if the domain exists in PostfixAdmin?
  */
 function check_domain($domain) {
-    if (!preg_match('/^([-0-9A-Z]+\.)+' . '([-0-9A-Z]){2,13}$/i', ($domain))) {
+    if (!preg_match('/^([-0-9A-Z]+\.)+' . '([-0-9A-Z]){1,13}$/i', ($domain))) {
         return sprintf(Config::lang('pInvalidDomainRegex'), htmlentities($domain));
     }
 


### PR DESCRIPTION
> Minimum length of a domain name is 1 character, not including extensions. However, all 1 character domain names are reserved by the Registry. 

We are using single char top-level-domains for our internal network. It would be great, if postfix would allow them.

Thanks!