### PR TITLE
Dont swallow database connection exceptions

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1464,11 +1464,10 @@ EOF;
  * @return \PDO
  */
 function db_connect() {
-    list($link, $_) = db_connect_with_errors();
-    unset($_);
+    list($link, $error_text) = db_connect_with_errors();
 
     if (!$link instanceof PDO) {
-        throw new Exception("Database connection failed");
+        throw new Exception("Database connection failed: $error_text");
     }
 
     return $link;
@@ -1545,20 +1544,16 @@ function db_connect_with_errors() {
         die("<p style='color: red'>FATAL Error:<br />Invalid \$CONF['database_type']! Please fix your config.inc.php!</p>");
     }
 
-    try {
-        if ($username_password) {
-            $link = new PDO($dsn, Config::read_string('database_user'), Config::read_string('database_password'), $options);
-        } else {
-            $link = new PDO($dsn, null, null, $options);
-        }
+    if ($username_password) {
+        $link = new PDO($dsn, Config::read_string('database_user'), Config::read_string('database_password'), $options);
+    } else {
+        $link = new PDO($dsn, null, null, $options);
+    }
 
-        if (!empty($queries)) {
-            foreach ($queries as $q) {
-                $link->exec($q);
-            }
+    if (!empty($queries)) {
+        foreach ($queries as $q) {
+            $link->exec($q);
         }
-    } catch (PDOException $e) {
-        $error_text = 'PDO exception: '. $e->getMessage();
     }
 
     return array($link, $error_text);


### PR DESCRIPTION
The current code catches database connection errors, and then completely ignores them, throwing an exception with no details about the original error. It cost me a lot of time until I figured out this problem. This PR just removes the exception handler, as PFA will crash in that case anyway.