### PR TITLE
Use TLS to send emails

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -171,6 +171,9 @@ $CONF['smtp_port'] = '25';
 // Used in the HELO when sending emails from Postfix Admin
 $CONF['smtp_client'] = '';
 
+// Set 'YES' to use TLS when sending emails.
+$CONF['smtp_sendmail_tls'] = 'NO';
+
 // Encrypt
 // In what way do you want the passwords to be crypted?
 // md5crypt = internal postfix admin md5

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1399,7 +1399,7 @@ function smtp_mail($to, $from, $data, $password = "", $body = "") {
     } else {
         smtp_get_response($fh);
 
-        if (Config::read_string('smtp_sendmail_tls') === 'YES') {
+        if (Config::bool('smtp_sendmail_tls')) {
             fputs($fh, "STARTTLS\r\n");
             smtp_get_response($fh);
 

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1398,12 +1398,15 @@ function smtp_mail($to, $from, $data, $password = "", $body = "") {
         return false;
     } else {
         smtp_get_response($fh);
-        fputs($fh, "STARTTLS\r\n");
-        smtp_get_response($fh);
 
-        stream_set_blocking ($fh, true);
-        stream_socket_enable_crypto($fh, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
-        stream_set_blocking ($fh, true);
+        if (Config::read_string('smtp_sendmail_tls') === 'YES') {
+            fputs($fh, "STARTTLS\r\n");
+            smtp_get_response($fh);
+
+            stream_set_blocking ($fh, true);
+            stream_socket_enable_crypto($fh, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
+            stream_set_blocking ($fh, true);
+        }
 
         fputs($fh, "EHLO $smtp_server\r\n");
         smtp_get_response($fh);

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1398,6 +1398,13 @@ function smtp_mail($to, $from, $data, $password = "", $body = "") {
         return false;
     } else {
         smtp_get_response($fh);
+        fputs($fh, "STARTTLS\r\n");
+        smtp_get_response($fh);
+
+        stream_set_blocking ($fh, true);
+        stream_socket_enable_crypto($fh, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
+        stream_set_blocking ($fh, true);
+
         fputs($fh, "EHLO $smtp_server\r\n");
         smtp_get_response($fh);
 


### PR DESCRIPTION
This PR depends on #277. 

The current implementation will use TLS for every connection, and will fail if that is not possible. But I can add a config option for that (maybe `admin_send_tls`?).

I hope you can review this and #277 soon, because otherwise we will have to maintain our own fork.