### PR TITLE
Update postfixadmin-cli

### DIFF
--- a/scripts/postfixadmin-cli
+++ b/scripts/postfixadmin-cli
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script


### PR DESCRIPTION
Make this script platform independent to be usable under e.g. FreeBSD, where bash is located in /usr/local/bin/bash and thus the script fails.