### PR TITLE
POSTFIX_CONF.txt: Add transport map support

### DIFF
--- a/DOCUMENTS/POSTFIX_CONF.txt
+++ b/DOCUMENTS/POSTFIX_CONF.txt
@@ -20,6 +20,14 @@ virtual_mailbox_maps =
    proxy:mysql:/etc/postfix/sql/mysql_virtual_mailbox_maps.cf,
    proxy:mysql:/etc/postfix/sql/mysql_virtual_alias_domain_mailbox_maps.cf
 
+# For transport map support, also use the following configuration:
+
+relay_domains = proxy:mysql:/etc/postfix/sql/mysql_relay_domains.cf
+transport_maps = proxy:mysql:/etc/postfix/sql/mysql_transport_maps.cf
+
+# Also set the config.inc.php setting transport=YES
+# and add the transport choices to transport_options.
+
 # if you let postfix store your mails directly (without using maildrop, dovecot deliver etc.)
 virtual_mailbox_base = /var/mail/vmail
 # or whereever you want to store the mails
@@ -86,6 +94,8 @@ query          = SELECT domain FROM domain WHERE domain='%s' AND active = '1'
 #query          = SELECT domain FROM domain WHERE domain='%s'
 #optional query to use when relaying for backup MX
 #query           = SELECT domain FROM domain WHERE domain='%s' AND backupmx = '0' AND active = '1'
+#optional query to use for transport map support
+#query           = SELECT domain FROM domain WHERE domain='%s' AND active = '1' AND NOT (transport LIKE 'smtp%%' OR transport LIKE 'relay%%')
 #expansion_limit = 100
 
 mysql_virtual_mailbox_maps.cf:
@@ -102,6 +112,20 @@ password = password
 hosts = localhost
 dbname = postfix
 query = SELECT maildir FROM mailbox,alias_domain WHERE alias_domain.alias_domain = '%d' and mailbox.username = CONCAT('%u', '@', alias_domain.target_domain) AND mailbox.active='1' AND alias_domain.active='1'
+
+mysql_relay_domains.cf:
+user = postfix
+password = password
+hosts = localhost
+dbname = postfix
+query = SELECT domain FROM domain WHERE domain='%s' AND active = '1' AND (transport LIKE 'smtp%%' OR transport LIKE 'relay%%')
+
+mysql_transport_maps.cf:
+user = postfix
+password = password
+hosts = localhost
+dbname = postfix
+query = SELECT transport FROM domain WHERE domain='%s' AND active = '1'
 
 
 (See above note re Concat + PostgreSQL)


### PR DESCRIPTION
There is a `domain.transport` field in the database, but it is never used in the configuration.

This pull request suggests some postfix configuration changes for transport map support.

It is not trivial to distinguish the domain class based on the transport field, especially between local and virtual domains. Therefore, only virtual and relay domains are supported.

A cleaner solution would be to add full [address class](http://www.postfix.org/ADDRESS_CLASS_README.html) support by adding a new field in the database.

Example:

```sql
insert into domain (domain, transport) values ('relay-this-domain.test', 'relay');
insert into domain (domain, transport) values ('virtual-domain.test', 'virtual');
insert into domain (domain, transport) values ('dovecot-lda.test', 'dovecot');
insert into domain (domain, transport) values ('forward-this-domain.test', 'smtp:[localhost]:2500');
```

Tests:

```
# virtual domains
$ postmap -q forward-this-domain.test mysql:/etc/postfix/sql/mysql_virtual_domains_maps.cf
$ postmap -q relay-this-domain.test mysql:/etc/postfix/sql/mysql_virtual_domains_maps.cf
$ postmap -q dovecot-lda.test mysql:/etc/postfix/sql/mysql_virtual_domains_maps.cf
dovecot-lda.test
$ postmap -q virtual-domain.test mysql:/etc/postfix/sql/mysql_virtual_domains_maps.cf
virtual-domain.test

# relay domains
$ postmap -q forward-this-domain.test mysql:/etc/postfix/sql/mysql_relay_domains.cf
forward-this-domain.test
$ postmap -q relay-this-domain.test mysql:/etc/postfix/sql/mysql_relay_domains.cf
relay-this-domain.test
$ postmap -q dovecot-lda.test mysql:/etc/postfix/sql/mysql_relay_domains.cf
$ postmap -q virtual-domain.test mysql:/etc/postfix/sql/mysql_relay_domains.cf

# transports
$ postmap -q forward-this-domain.test mysql:/etc/postfix/sql/mysql_transport_maps.cf
smtp:[localhost]:2500
$ postmap -q relay-this-domain.test mysql:/etc/postfix/sql/mysql_transport_maps.cf
relay
$ postmap -q dovecot-lda.test mysql:/etc/postfix/sql/mysql_transport_maps.cf
dovecot
$ postmap -q virtual-domain.test mysql:/etc/postfix/sql/mysql_transport_maps.cf
virtual
```