### PR TITLE
fetchmail dovecot delivery

### DIFF
--- a/ADDITIONS/fetchmail.pl
+++ b/ADDITIONS/fetchmail.pl
@@ -29,6 +29,12 @@ our $db_password="CHANGE_ME!";
 # Where to create a lockfile; please ensure path exists.
 our $run_dir="/var/run/fetchmail";
 
+# in case you want to use dovecot deliver to put the mail directly into the users mailbox,
+# set "mda" in the fetchmail table to the keyword "dovecot".
+
+# Where the delivery binary is located
+$dovecot_deliver = "/usr/lib/dovecot/deliver";
+
 # instead of changing this script, you can put your settings to /etc/mail/postfixadmin/fetchmail.conf
 # just use perl syntax there to fill the variables listed above (without the "our" keyword). Example:
 # $db_username = 'mail';
@@ -108,7 +114,7 @@ map{
 
 	if ($mda) {
 		if ($mda eq "dovecot") {
-			$cmd.=" mda \"/usr/lib/dovecot/deliver -d ${mailbox}\" ";
+			$cmd.=" mda \"${dovecot_deliver} -d ${mailbox}\" ";
 		} else {
 			$cmd.=" mda ".$mda 
 		}

--- a/ADDITIONS/fetchmail.pl
+++ b/ADDITIONS/fetchmail.pl
@@ -105,7 +105,14 @@ map{
 
 	$cmd="user '${src_user}' there with password '".decode_base64($src_password)."'";
 	$cmd.=" folder '${src_folder}'" if ($src_folder);
-	$cmd.=" mda ".$mda if ($mda);
+
+	if ($mda) {
+		if ($mda eq "dovecot") {
+			$cmd.=" mda \"/usr/lib/dovecot/deliver -d ${mailbox}\" ";
+		} else {
+			$cmd.=" mda ".$mda 
+		}
+	}
 
 #	$cmd.=" mda \"/usr/local/libexec/dovecot/deliver -m ${mailbox}\"";
 	$cmd.=" is '${mailbox}' here";

--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -22,6 +22,7 @@ Version X.X - master
    - Sqlite improvements (see https://github.com/postfixadmin/postfixadmin/issues/177 and https://github.com/postfixadmin/postfixadmin/issues/176 )
    - MySQL 8 compatibility (see https://github.com/postfixadmin/postfixadmin/pull/175 )
    - Internally the database functions have been refactored to use PDO rather than the lower level mysql_, mysqli_, pg_ etc functions. ( see: https://github.com/postfixadmin/postfixadmin/pull/231 )
+   - Usage of dovecot deliver as fetchmail mda
 
 Version 3.2 - 2018/05/02
 -------------------------------------------------


### PR DESCRIPTION
Use dovecot lda delivery via the mda setting. Similar to the encrypt setting it requires the usage of a magic keyword.