### PR TITLE
[Travis] Test against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 services:
   - mysql


### PR DESCRIPTION
I keep getting this error in production, hope the test suite raises it:

`Deprecated: Function get_magic_quotes_gpc() is deprecated in ./postfixadmin-postfixadmin-3.2/functions.inc.php on line 317`