### PR TITLE
Make pInvalidDomainDNS more forgiving

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -248,6 +248,8 @@ function check_domain($domain) {
                 $retval = '';
             } elseif (checkdnsrr($domain, 'MX')) {
                 $retval = '';
+            } elseif (checkdnsrr($domain, 'NS')) {
+                $retval = '';
             } else {
                 $retval = sprintf(Config::lang('pInvalidDomainDNS'), htmlentities($domain));
             }


### PR DESCRIPTION
Make the pInvalidDomainDNS check more forgiving to accommodate newly created domains which also do not have an A record for the domain (which is generally not a best practice) or MX configured yet.
This adds a check for an `NS` record; if the NS exists, then the domain is valid and can be assumed to have just not been configured to receive email yet.