### PR TITLE
Add a missing semicolon in mailbox_remover.pl

### DIFF
--- a/ADDITIONS/mailbox_remover.pl
+++ b/ADDITIONS/mailbox_remover.pl
@@ -117,7 +117,7 @@ foreach my $maildir (keys(%directories)) {
     close(TOUCH);
     print "Archiving $maildir\n";
     @args = ($archcmd, "cvzf", $archive, $maildir);
-	system(@args) == 0 or die "Creating archive for $maildir failed: $?"
+    system(@args) == 0 or die "Creating archive for $maildir failed: $?";
 
     rmtree($maildir);
     print localtime() . " $maildir has been deleted.\n";


### PR DESCRIPTION
I got a syntax error when I executed the Perl script mailbox_remover.pl.

```
$ perl ./ADDITIONS/mailbox_remover.pl
Bareword found where operator expected at ./ADDITIONS/mailbox_remover.pl line 122, near "rmtree"
	(Missing semicolon on previous line?)
syntax error at ./ADDITIONS/mailbox_remover.pl line 122, near "rmtree"
Execution of ./ADDITIONS/mailbox_remover.pl aborted due to compilation errors.
```

The script worked well after I added the missing semicolon and set up some variables properly.