### PR TITLE
Disallow alias that points to itself (fixes #358)

### DIFF
--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -127,6 +127,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'За да създадете catch-all използвайте "*" за alias. За пренасочване на домейн към домейн използвайте "*@domain.tld" в полето Към.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Редактиране на alias за вашия домейн.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Един запис на ред.'; # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -125,6 +125,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Per crear un àlies general usi "*" com a àlies. Per una redirecció de domini a domini, usi "*@domain.tld" com a Destí.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Editi un àlies pel seu domini.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Una entrada per línia.'; # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = '要将所有的邮件全部转发请使用"*"作为别名. 域到域的转发请使用"*@domain.tld".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = '编辑你域名中的别名.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = '每行一条记录.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -134,6 +134,7 @@ $PALANG['alias_updated'] = 'Přesměrování %s bylo upraveno!';
 $PALANG['pCreate_alias_catchall_text'] = 'Pro vytvoření doménového koše použijte * jako alias. Pro přesměrování doména -> doména použijte *@domain.tld jako cíl.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Toto přesměrování je svázáno s emailem a nemůže být proto vymazáno!';
 $PALANG['protected_alias_cant_be_deleted'] = 'Tento alias %s je chráněný a může být odstraněn pouze superadministrátorem';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Upravit nastavení přesměrování.';
 $PALANG['pEdit_alias_help'] = 'Je možné zadat více cílových adres, jeden záznam na řádek.';

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -131,6 +131,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'For at tilføje et stjerne-alias, brug en "*" som alias. For domæne til domæne-videresending brug "*@domæne.tld" som modtager.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Rediger alias.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'En modtager pr. linje.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -128,6 +128,7 @@ $PALANG['alias_updated'] = 'Der Alias %s wurde geändert.';
 $PALANG['pCreate_alias_catchall_text'] = 'Um alle Adressen abzudecken benutzen Sie einen "*" als Alias. Um ganze Domains an andere Domains weiterzuleiten benutzen Sie "*@domain.tld" im "An"-Feld.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Dieser Alias gehört zu einer Mailbox und kann nicht gelöscht werden!';
 $PALANG['protected_alias_cant_be_deleted'] = 'Der Alias %s ist geschützt und kann nur von einem Superadmin gelöscht werden.';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Weiterleitungs-Einstellungen ändern';
 $PALANG['pEdit_alias_help'] = 'Angabe mehrerer Ziele möglich, ein Eintrag pro Zeile.';

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -129,6 +129,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!';
 $PALANG['pCreate_alias_catchall_text'] = 'To create a catch-all use an "*" as alias.'; # XXX don't propagate usage of *@target-domain.com for domain-aliasing any longer
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!';
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself';
 
 $PALANG['pEdit_alias_welcome'] = 'Edit forwarding settings';
 $PALANG['pEdit_alias_help'] = 'Accepts multiple targets, one entry per line.';

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Para crear un alias general use "*" como alias. Para una redirección de dominio a dominio, use "*@domain.tld" como Destino.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Edite un alias para su dominio.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Una entrada por línea.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Loomaks püüa-kõik aadressi kasuta aliasena "*". Domeenilt domeenile edasisaatmiseks kasuta kellele väljal "*@domeen.xx".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Muuda aliast.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Üks kirje rea kohta.'; # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -124,6 +124,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Alias orokor bat sortzeko "*" erabil ezazu alias gisa. Domeinuz domeinurako birbideraketa baterako Norako gisa "*@domain.tld" erabil ezazu.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Domeinuarentzat aliasa aldatu.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Lerroko sarrera bat.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -127,6 +127,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Jos haluat luoda catch-all osoitteen käytä "*" merkkiä aliaksena. Ohjaus domainista domainiin tapahtuu käyttämällä "*@domain.tld" Kenelle: -osoitteena.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 $PALANG['pEdit_alias_welcome'] = 'Muokkaa aliasta.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Yksi kohta per rivi.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'
 $PALANG['alias'] = 'Alias';

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Fyri at stovna eitt ið fangar alt, brúka eina "*" sum dulnevni. Fyri navnaøki til navnaøki víðarisending brúka "*@navnaøki.fo" til hetta.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Broyt eitt dulnevni á tínum navnaøki.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Eina adressu pr. linju.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -129,6 +129,7 @@ $PALANG['alias_updated'] = 'L\'alias %s a été mis à jour !';
 $PALANG['pCreate_alias_catchall_text'] = 'Pour ajouter un alias global, utilisez "*". Pour un transfert de domaine à domaine, utilisez "*@domain.tld" dans le champ À.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Cet alias appartient à un compte courriel et ne peut donc pas être supprimé !';
 $PALANG['protected_alias_cant_be_deleted'] = 'L\'alias %s est protégé et ne peut être supprimé que par un Super Administrateur.';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Modifier les paramètres de transfert.';
 $PALANG['pEdit_alias_help'] = 'Destinataires multiples acceptés, une entrée par ligne.';

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -124,6 +124,7 @@ $PALANG['alias_updated'] = 'O alias %s foi actualizado!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Para crear un alias xeral use "*" como alias. Para unha redirección de dominio a dominio, use "*@domain.tld" como Destino.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Este alias pertence a un buzón e non pode borrarse!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'O alias %s está protexido e só pode ser borrado por un superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Edite un alias para o seu dominio.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Unha entrada por liña.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -125,6 +125,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Ukoliko elite stvoriti "sveprimajući" alias, upotrijebite "*" umjesto aliasa. Za preusmjeravanje iz domene na domenu, upotrijebite "*@domena.tld" u "Za" polju.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Uredi alias za domenu.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Jedan unos po liniji.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -128,6 +128,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'A catch-all (*@valami.hu) beállításához használj "*" -ot az alias mezõnél. A domain-domain közötti átirányításhoz használd a "*@akarmi.hu" címet.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Alias szerkesztése a domainhez.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Soronként egy.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Til að útbúa alias fyrir öll netföng í léninu, þá geturðu útbúið "*" alias. Til að áframsenda með alias á annað lén eða pósthólf, notaðu "*@domain.tld í til.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Breyta alias í léninu.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Ein færsla í einu.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -127,6 +127,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Per creare un account universale, usare "*" come alias. Per inoltri da dominio a dominio, usare "*@domain.tld" come campo "a".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Modifica un alias per il tuo dominio.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Un indirizzo per linea.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -128,6 +128,7 @@ $PALANG['alias_updated'] = '転送先 %s を更新しました!';
 $PALANG['pCreate_alias_catchall_text'] = 'すべてのメールを受け取るには、転送元に "*" を使います。 別のドメインにすべて転送するには、転送先に "*.domain.tld" を使います。';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'この転送先は、メールアドレスに紐付いているので、削除することはできません!';
 $PALANG['protected_alias_cant_be_deleted'] = '転送先 %s は保護されており、特権管理者だけが削除できます';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = '転送先設定の編集';
 $PALANG['pEdit_alias_help'] = '複数の転送先を設定できます。1行に1エントリです。';

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Jei norite sukurti sinonimą, kuris gautų visas žinutes neegzistuojantiems adresatams, naudokite "*".';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 
 $PALANG['pEdit_alias_welcome'] = 'Keisti persiuntimo nustatymus';

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'За да креираш catch-all користи "*" како алијас.  За препраќање од домен на домен користи "*@domain.tld" како ДО.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Едитирање на алијас за вашиот домен.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Еден запис по линија.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -128,6 +128,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'For å opprette et "catch-all"-alias, bruk "*" som alias. For domene-til-domene-videresending, bruk "*@domene.tld" i Til-feltet.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 $PALANG['pEdit_alias_welcome'] = 'Endre et alias.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Én e-postadresse per linje.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'
 $PALANG['alias'] = 'Alias';

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -128,6 +128,7 @@ $PALANG['alias_updated'] = 'De alias %s is bijgewerkt!';
 $PALANG['pCreate_alias_catchall_text'] = 'Om een catch-all te gebruiken, dient u een "*" (asteric) in te vullen als alias. Voor domein naar domein forwarding gebruik "*@domein.tld" als naar.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'De alias maakt onderdeel uit van mailbox en kan niet worden verwijderd!';
 $PALANG['protected_alias_cant_be_deleted'] = 'De alias %s is beschermd en kan alleen worden verwijderd door een superadministrator';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Bewerk een alias voor uw domein.';
 $PALANG['pEdit_alias_help'] = 'Meerdere e-mailadressen toegestaan. Slechts één alias per regel.';

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'For å opprette et alias som "mottar alt" bruk "*" som alias. For domene-til-domene videresending bruk "*@domene.tld" som mottaker.';  # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 $PALANG['pEdit_alias_welcome'] = 'Endre et alias.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'En mottaker per linje.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'
 $PALANG['alias'] = 'Alias';

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -129,6 +129,7 @@ $PALANG['alias_updated'] = 'Alias %s został zaktualizowany!';
 $PALANG['pCreate_alias_catchall_text'] = 'Aby utworzyć domyślne konto dla domeny (catch-all) podaj "*" (gwiazdkę) jako alias. Jeśli chcesz przekazywać całość poczty do innej domeny, wpisz jako alias "*@domena.tld".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 $PALANG['pEdit_alias_welcome'] = 'Edytuj alias dla Twojej domeny.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Jeden wpis na linię.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'
 $PALANG['alias'] = 'Alias';

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -130,6 +130,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Para criar um alias global, use "*" no campo Alias. Para encaminhar de um domínio para outro, use "*@dominio.tld" no campo Para.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Edição de alias do domínio.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Uma entrada por linha.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -128,6 +128,7 @@ $PALANG['alias_updated'] = 'Aliasul %s a fost modificat!';
 $PALANG['pCreate_alias_catchall_text'] = 'Puteti crea un alias pentru adrese multiple prin folosirea "*".'; # XXX don't propagate usage of *@target-domain.com for domain-aliasing any longer
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Acest alias apartine unei casute si nu poate fi sters!';
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Editeaza setarile de redirectionare';
 $PALANG['pEdit_alias_help'] = 'Se accepta inregistrari multiple, cate una pe linie.';

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -131,6 +131,7 @@ $PALANG['alias_updated'] = 'Алиас %s успешно обновлен!';
 $PALANG['pCreate_alias_catchall_text'] = 'Для создания catch-all почтового ящика используйте "*" в качестве имени алиаса.'; # XXX don't propagate usage of *@target-domain.com for domain-aliasing any longer
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Указанный алиас ссылается на почтовый ящик и не может быть удален!';
 $PALANG['protected_alias_cant_be_deleted'] = 'Алиас %s защищен и может быть удален только суперадмином';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Редактирование настроек пересылки';
 $PALANG['pEdit_alias_help'] = 'Можно указать несколько целей, по одной записи на строку.';

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -127,6 +127,7 @@ $PALANG['alias_updated'] = 'Alias %s bol aktualizovaný.';
 $PALANG['pCreate_alias_catchall_text'] = 'Pre vytvorenie doménového koša použite * ako alias. Pre alias doména-doména použite *@domain.tld ako cieľ.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Tento alias patrí k schránke a nemôže byť zmazaný!';
 $PALANG['protected_alias_cant_be_deleted'] = 'Alias %s je chránený a môže ho zmazať len superadmin';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Upraviť alias';
 $PALANG['pEdit_alias_help'] = 'Jeden záznam na riadok.';

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = 'Če želite ustvariti "vseobsegajoči" alias, uporabite "*" namesto aliasa. Za posredovanje iz domene na domeno, uporabite "*@domena.si" v "Za" polju.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Uredi alias za določeno domeno.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'V posamezni vrstici je lahko samo en naslov.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -129,6 +129,7 @@ $PALANG['alias_updated'] = 'Aliaset %s är uppdaterat!';
 $PALANG['pCreate_alias_catchall_text'] = 'För att skapa en catch-all anges ett "*" som alias.';
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Detta alias tillhör en brevlåda och kan inte tas bort!';
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Inställningar för vidarebefordring.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Ett alias per rad.'; # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -126,6 +126,7 @@ $PALANG['alias_updated'] = '%s aliasınız güncellendi!';
 $PALANG['pCreate_alias_catchall_text'] = 'Tümünü-yakala oluşturmak için alias olarak "*" kullanın. Domain yönlendirme domaini için kime kısmında "*@domain.tld" kullanın.'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'Bu alias, sistemde kayıtlı bir e-posta hesabına ait ve silinemez!';
 $PALANG['protected_alias_cant_be_deleted'] = '%s isimli alias korumalı olarak ayarlı ve ancak bir süper yönetici tarafından silinebilir';
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = 'Yönlendirme ayarlarını düzenleyin. '; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = 'Her bir satıra bir giriş şeklinde, çoklu hedefler kabul edilir.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -127,6 +127,7 @@ $PALANG['alias_updated'] = 'The alias %s has been updated!'; # XXX
 $PALANG['pCreate_alias_catchall_text'] = '要將所有的郵件全部轉發請使用"*"作為別名. 網域到網域的轉發請使用"*@domain.tld".'; # XXX check/beautify - was split in two lines before
 $PALANG['mailbox_alias_cant_be_deleted'] = 'This alias belongs to a mailbox and can\'t be deleted!'; # XXX
 $PALANG['protected_alias_cant_be_deleted'] = 'The alias %s is protected and can only be deleted by a superadmin'; # XXX
+$PALANG['alias_points_to_itself'] = 'Alias may not point to itself'; # XXX
 
 $PALANG['pEdit_alias_welcome'] = '編輯你網域中的別名.'; # XXX Text change to: 'Edit forwarding settings'
 $PALANG['pEdit_alias_help'] = '每行一條記錄.'; # XXX # XXX Text change to: 'Accepts multiple targets, one entry per line.'

--- a/model/AliasHandler.php
+++ b/model/AliasHandler.php
@@ -401,6 +401,11 @@ class AliasHandler extends PFAHandler {
                     $errors[] = "$singlegoto: $email_check";
                 }
             }
+            if($this->called_by != "MailboxHandler" && $this->id == $singlegoto) {
+                // The MailboxHandler needs to create an alias that points to itself (for the mailbox)
+                // Otherwise, disallow such aliases as they cause severe trouble in the mail system
+                $errors[] = "$singlegoto: " . Config::Lang('alias_points_to_itself');
+            }
         }
 
         if (count($errors)) {


### PR DESCRIPTION
So, hopefully this is better (followup to c3d5b26740d2461f86a18f718bffc7db26cf49c5).

The basic issue is described in #358: Aliases that "loop-back" should only be used if there is a corresponding mailbox at that address. Otherwise Postfix might fail to correctly alias the recipient address, causing mail delivery errors and late bounces (backscatter).

The new behavior prevents the user from creating such invalid aliases. The MailboxHandler is still able to create "loop-back" aliases, because those are required when adding a new mailbox. The behavior is not configurable, because I couldn't find a single setup where loopback aliases where actually serving any purpose and without causing severe trouble.

The error message is now translatable (this wasn't the case in the original commit).

The original commit was tested (in production) on my own instances. This new commit received minimal testing, but I briefly verified that all still seemed ok.