### PR TITLE
List of addresses needs a Line Feed

### DIFF
--- a/templates/editform.tpl
+++ b/templates/editform.tpl
@@ -44,7 +44,7 @@
                                     {elseif $field.type == 'pass' || $field.type == 'b64p'}
                                         <input class="form-control" type="password" name="value[{$key}]"/>
                                     {elseif $field.type == 'txtl'}
-                                        <textarea class="form-control" rows="10" cols="35" name="value[{$key}]">{foreach key=key2 item=field2 from=$value_{$key}}{$field2}{/foreach}</textarea>
+                                        <textarea class="form-control" rows="10" cols="35" name="value[{$key}]">{foreach key=key2 item=field2 from=$value_{$key}}{$field2}&#10;{/foreach}</textarea>
                                     {else}
                                         <input class="form-control" type="text" name="value[{$key}]"
                                                value="{$value_{$key}}"/>


### PR DESCRIPTION
Edit field does display a list of aliases in a single line in the edit form. Adding a Line Feed character fixes this problem.