### PR TITLE
Change Login changePassword, fixes #456

### DIFF
--- a/model/Login.php
+++ b/model/Login.php
@@ -110,7 +110,7 @@ class Login {
             'password' => pacrypt($new_password),
         );
 
-        $result = db_update($this->key_table, 'username', $username, $set);
+        $result = db_update($this->table, 'username', $username, $set);
 
         if ($result != 1) {
             db_log($domain, 'edit_password', "FAILURE: " . $username);


### PR DESCRIPTION
When the function `changePassword` is called, it passes the table name to `db_update()` which already was treated by the `table_by_key()` function. However, `db_update()` also calls the `table_by_key()` function for the table name argument. This results in double backticks and causes PHP errors for users that want to change their password.

Signed-off-by: Sven Seeberg <mail@sven-seeberg.de>