### PR TITLE
UTF8 is no real UTF8 in MySQL, one needs to use utf8mb4

### DIFF
--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -208,7 +208,7 @@ if (!$dbh) {
 
 my $db_true; # MySQL and PgSQL use different values for TRUE, and unicode support...
 if ($db_type eq 'mysql') {
-    $dbh->do('SET CHARACTER SET utf8;');
+    $dbh->do('SET CHARACTER SET utf8mb4;');
     $db_true = '1';
 } else { # Pg
     $dbh->do("SET CLIENT_ENCODING TO 'UTF8'");

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1626,9 +1626,9 @@ function db_connection_string()
         $database_name = Config::read_string('database_name');
 
         if ($socket) {
-            $dsn = "mysql:unix_socket={$socket};dbname={$database_name};charset=UTF8";
+            $dsn = "mysql:unix_socket={$socket};dbname={$database_name};charset=utf8mb4";
         } else {
-            $dsn = "mysql:host={$CONF['database_host']};dbname={$database_name};charset=UTF8";
+            $dsn = "mysql:host={$CONF['database_host']};dbname={$database_name};charset=utf8mb4";
         }
     } elseif (db_sqlite()) {
         $db = $CONF['database_name'];
@@ -1699,8 +1699,8 @@ function db_connect()
 
             $options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = (bool)$verify;
         }
-        $queries[] = 'SET CHARACTER SET utf8';
-        $queries[] = "SET COLLATION_CONNECTION='utf8_general_ci'";
+        $queries[] = 'SET CHARACTER SET utf8mb4';
+        $queries[] = "SET COLLATION_CONNECTION='utf8mb4_general_ci'";
     } elseif (db_sqlite()) {
         $db = $CONF['database_name'];
 

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1626,9 +1626,9 @@ function db_connection_string()
         $database_name = Config::read_string('database_name');
 
         if ($socket) {
-            $dsn = "mysql:unix_socket={$socket};dbname={$database_name};charset=utf8mb4";
+            $dsn = "mysql:unix_socket={$socket};dbname={$database_name}";
         } else {
-            $dsn = "mysql:host={$CONF['database_host']};dbname={$database_name};charset=utf8mb4";
+            $dsn = "mysql:host={$CONF['database_host']};dbname={$database_name}";
         }
     } elseif (db_sqlite()) {
         $db = $CONF['database_name'];
@@ -1699,7 +1699,7 @@ function db_connect()
 
             $options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = (bool)$verify;
         }
-        $queries[] = 'SET CHARACTER SET utf8mb4';
+        $queries[] = 'SET NAMES utf8mb4';
         $queries[] = "SET COLLATION_CONNECTION='utf8mb4_general_ci'";
     } elseif (db_sqlite()) {
         $db = $CONF['database_name'];


### PR DESCRIPTION
This allows to use emojis in vacation mails and allow characters in names.

The usage of UTF8mb4 should be the default or at least configurable. utf8mb4 was introuced in MySQL 5.5.3 IIRC.