### PR TITLE
Re-add configurable quota levels

### DIFF
--- a/templates/list.tpl
+++ b/templates/list.tpl
@@ -95,9 +95,9 @@
                     {elseif $field.type == 'quot'}
                         {assign "tmpkey" "_{$key}_percent"}
 
-                        {if $item[$tmpkey]>90}
+                        {if $item[$tmpkey] > $CONF.quota_level_high_pct}
                             {assign var="quota_level" value="high"}
-                        {elseif $item[$tmpkey]>55}
+                        {elseif $item[$tmpkey] > $CONF.quota_level_med_pct}
                             {assign var="quota_level" value="mid"}
                         {else}
                             {assign var="quota_level" value="low"}


### PR DESCRIPTION
The configurable setting seems to be accidentally removed in 68a8caac283f2249479708c5c419bc5b6bc68c2e.
