### PR TITLE
VIRTUAL_VACATION/vacation.pl :: smtp_ssl variable must be boolean not literal

### DIFF
--- a/VIRTUAL_VACATION/vacation.pl
+++ b/VIRTUAL_VACATION/vacation.pl
@@ -66,8 +66,8 @@ our $smtp_client = 'localhost';
 our $smtp_helo = 'localhost.localdomain';
 
 # send mail encrypted or plaintext
-# if 'starttls', use STARTTLS; if 'ssl' (or 1), connect securely; otherwise, no security
-our $smtp_ssl = 'starttls';
+# if 1, connect securely via ssl; otherwise, no security
+our $smtp_ssl = 0;
 
 # maximum time in secs to wait for server; default is 120
 our $smtp_timeout = '120';

--- a/model/AliasdomainHandler.php
+++ b/model/AliasdomainHandler.php
@@ -53,7 +53,7 @@ class AliasdomainHandler extends PFAHandler
         }
     }
 
-    public function init($id) : bool
+    public function init(string $id) : bool
     {
         $success = parent::init($id);
         if ($success) {

--- a/model/VacationHandler.php
+++ b/model/VacationHandler.php
@@ -19,7 +19,7 @@ class VacationHandler extends PFAHandler
      */
     protected $domain_field = 'domain';
 
-    public function init($id) : bool
+    public function init(string $id) : bool
     {
         throw new \Exception('VacationHandler is not yet ready to be used with *Handler methods');
     }


### PR DESCRIPTION
When smtp_ssl value is 'starttls' it throws an error:

Attribute (ssl) does not pass the type constraint because: Validation failed for 'Bool' with value "starttls" at constructor Email::Sender::Transport::SMTP::new (defined at /usr/share/perl5/vendor_perl/Email/Sender/Transport/SMTP.pm line 200) line 98, <STDIN> line 5
