### PR TITLE
model/AdminpasswordHandler.php :: eliminate php waring

### DIFF
--- a/model/AdminpasswordHandler.php
+++ b/model/AdminpasswordHandler.php
@@ -39,7 +39,7 @@ class AdminpasswordHandler extends PFAHandler
         );
     }
 
-    public function init($id) :bool
+    public function init(string $id) :bool
     {
         # hardcode to logged in admin
         if ($this->admin_username == '') {


### PR DESCRIPTION
PHP Warning:  Declaration of ****Handler::init($id): bool should be compatible with PFAHandler::init(string $id): bool
