### PR TITLE
model/MailboxHandler.php :: eliminate php warning

### DIFF
--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -66,7 +66,7 @@ class MailboxHandler extends PFAHandler
         }
     }
 
-    public function init($id) : bool
+    public function init(string $id) : bool
     {
         if (!parent::init($id)) {
             return false;


### PR DESCRIPTION
PHP Warning:  Declaration of ****Handler::init($id): bool should be compatible with PFAHandler::init(string $id): bool
