### PR TITLE
model/AliasdomainHandler.php :: eliminate php warning

### DIFF
--- a/model/AliasdomainHandler.php
+++ b/model/AliasdomainHandler.php
@@ -53,7 +53,7 @@ class AliasdomainHandler extends PFAHandler
         }
     }
 
-    public function init($id) : bool
+    public function init(string $id) : bool
     {
         $success = parent::init($id);
         if ($success) {


### PR DESCRIPTION
PHP Warning:  Declaration of ****Handler::init($id): bool should be compatible with PFAHandler::init(string $id): bool
