### PR TITLE
model/VacationHandler.php :: eliminate php warning

### DIFF
--- a/model/VacationHandler.php
+++ b/model/VacationHandler.php
@@ -19,7 +19,7 @@ class VacationHandler extends PFAHandler
      */
     protected $domain_field = 'domain';
 
-    public function init($id) : bool
+    public function init(string $id) : bool
     {
         throw new \Exception('VacationHandler is not yet ready to be used with *Handler methods');
     }


### PR DESCRIPTION
PHP Warning:  Declaration of ****Handler::init($id): bool should be compatible with PFAHandler::init(string $id): bool
