### PR TITLE
removed broken link to postfixadmin.org website

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -84,7 +84,6 @@ if ($CONF['configured']) {
         <p>For further help, or documentation please check out -
         <ul>
             <li><a href="https://github.com/postfixadmin/postfixadmin">GitHub - Postfix Admin</a> web site</li>
-            <li><a href="https://postfixadmin.org">Postfix Admin</a> web site<br /></li>
             <li><a href="https://sourceforge.net/forum/forum.php?forum_id=676076">Knowledge Base</a></li>
         </ul>
         </p>


### PR DESCRIPTION
removed reference to postfixadmin.org website from index.php - link has been broken an long time.
Minor clean up to index page for users.
