### PR TITLE
Improve dovecot mail-crypt postpassword script security

### DIFF
--- a/ADDITIONS/postfixadmin-mailbox-postpassword.sh
+++ b/ADDITIONS/postfixadmin-mailbox-postpassword.sh
@@ -3,11 +3,14 @@
 # Example script for dovecot mail-crypt-plugin
 # https://doc.dovecot.org/configuration_manual/mail_crypt_plugin/
 
+IFS= read -r -d $'\0' OLD_PASSWORD
+IFS= read -r -d $'\0' NEW_PASSWORD
+
 # New user
-if [ -z "$3" ]; then
-    doveadm -o plugin/mail_crypt_private_password="$4" mailbox cryptokey generate -u "$1" -U
-    exit 0
+if [ -z "$OLD_PASSWORD" ]; then
+    OLD_PASSWORD="$(openssl rand -hex 16)"
+    doveadm -o plugin/mail_crypt_private_password="$OLD_PASSWORD" mailbox cryptokey generate -u "$1" -U
 fi
 
 # Password change
-doveadm mailbox cryptokey password -u "$1" -o "$3" -n "$4"
+printf "%s\n%s\n" "$OLD_PASSWORD" "$NEW_PASSWORD" | doveadm mailbox cryptokey password -u "$1" -N -O ""

--- a/config.inc.php
+++ b/config.inc.php
@@ -600,9 +600,10 @@ $CONF['mailbox_postedit_script'] = '';
 $CONF['mailbox_postdeletion_script'] = '';
 
 // Optional: See NOTE above.
-// Script to run after setting a mailbox password. (New mailbox [$4 = empty] or change existing password)
+// Script to run after setting a mailbox password. (New mailbox [old password = empty] or change existing password)
 // Disables changing password without entering old password.
-// Parameters: (1) username (2) domain (3) old password (4) new password
+// Parameters: (1) username (2) domain
+// STDIN: old password + \0 + new password
 // $CONF['mailbox_postpassword_script']='sudo -u dovecot /usr/local/bin/postfixadmin-mailbox-postpassword.sh';
 $CONF['mailbox_postpassword_script'] = '';
 

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -650,17 +650,35 @@ class MailboxHandler extends PFAHandler
         }
 
         if (!empty($cmd_pw)) {
-            $cmdarg3='""';
-            $cmdarg4=escapeshellarg($this->values['password']);
-            $command= "$cmd_pw $cmdarg1 $cmdarg2 $cmdarg3 $cmdarg4";
-            $retval=0;
-            $output=array();
-            $firstline='';
-            $firstline=exec($command, $output, $retval);
-            if (0!=$retval) {
-                error_log("Running $command yielded return value=$retval, first line of output=$firstline");
+            // Use proc_open call to avoid safe_mode problems and to prevent showing plain password in process table
+            $spec = array(
+                0 => array("pipe", "r"), // stdin
+                1 => array("pipe", "w"), // stdout
+            );
+
+            $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
+
+            $proc = proc_open($command, $spec, $pipes);
+
+            if (!$proc) {
+                error_log("can't proc_open $cmd_pw");
                 $this->errormsg[] .= $warnmsg_pw;
                 $status = false;
+            } else {
+                // Write passwords through pipe to command stdin -- provide old password, then new password.
+                fwrite($pipes[0], "\0", 1);
+                fwrite($pipes[0], $this->values['password'] . "\0", 1+strlen($this->values['password']));
+                $output = stream_get_contents($pipes[1]);
+                fclose($pipes[0]);
+                fclose($pipes[1]);
+
+                $retval = proc_close($proc);
+
+                if (0!=$retval) {
+                    error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+                    $this->errormsg[] .= $warnmsg_pw;
+                    $status = false;
+                }
             }
         }
 


### PR DESCRIPTION
pipe password(s) through STDIN to postpassword script instead of passing it as arguments on cmdline.

Suggested from: https://github.com/postfixadmin/postfixadmin/issues/441#issuecomment-774736944

Also for those wanting to use this on the stable (3.3) branch, I've backported the feature here: https://github.com/BotoX/postfixadmin/tree/postfixadmin_3.3-crypt
