### PR TITLE
Remove unnecessary <br>'s

### DIFF
--- a/templates/flash_error.tpl
+++ b/templates/flash_error.tpl
@@ -1,5 +1,4 @@
 <!-- {$smarty.template} -->
-<br clear="all"/><br/>
 {strip}
     {if isset($smarty.session.flash)}
         {if isset($smarty.session.flash.info)}

--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -8,7 +8,7 @@
 {/strip}
 
 {strip}
-    <nav class="navbar navbar-default fixed-top">
+    <nav class="navbar navbar-default navbar-fixed-top">
         <div class="container-fluid">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar"

--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -8,7 +8,7 @@
 {/strip}
 
 {strip}
-    <nav class="navbar navbar-default navbar-fixed-top">
+    <nav class="navbar navbar-default fixed-top">
         <div class="container-fluid">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar"


### PR DESCRIPTION
This removes some unnecessary spacing added by `flash_error.tpl` in all pages.

Before:
![before](https://user-images.githubusercontent.com/787075/122274982-8fb1d500-ceb9-11eb-85a3-9a1cef9a53bb.png)

After:
![after](https://user-images.githubusercontent.com/787075/122274993-92142f00-ceb9-11eb-9e9b-26159111d4dc.png)

