### PR TITLE
Navbar is supposed to be fixed

### DIFF
--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -8,7 +8,7 @@
 {/strip}
 
 {strip}
-    <nav class="navbar navbar-default fixed-top">
+    <nav class="navbar navbar-default navbar-fixed-top">
         <div class="container-fluid">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar"


### PR DESCRIPTION
The navbar had the class `fixed-top`, but it doesn't exist. It used to be `navbar-fixed-top` which indeed makes the navbar fixed, but that class was replaced in 897e57d4036bffb9779d71494e710d847297ea6a. Why was it replaced? Was it unintentional?
Also because of this, a lot of extra space is added after the navbar.

Before:
![before](https://user-images.githubusercontent.com/787075/122275866-8ffea000-ceba-11eb-9807-370292e78b5c.png)

Now:
![after](https://user-images.githubusercontent.com/787075/122278836-bf62dc00-cebd-11eb-8e57-155e522d74bc.png)

Maybe some of that space was intentional, in which case it should be added back with CSS. Let me know if I should do that.