### PR TITLE
Disable password autocomplete

### DIFF
--- a/templates/editform.tpl
+++ b/templates/editform.tpl
@@ -42,7 +42,7 @@
                                             {html_options output=$struct.{$key}.options values=$struct.{$key}.options selected=$value_{$key}}
                                         </select>
                                     {elseif $field.type == 'pass' || $field.type == 'b64p'}
-                                        <input class="form-control" type="password" name="value[{$key}]"/>
+                                        <input class="form-control" type="password" name="value[{$key}]" {if $key == 'password' || $key == 'password2'}autocomplete="new-password"{/if}/>
                                     {elseif $field.type == 'txtl'}
                                         <textarea class="form-control" rows="10" cols="35" name="value[{$key}]">{foreach key=key2 item=field2 from=$value_{$key}}{$field2}&#10;{/foreach}</textarea>
                                     {else}

--- a/templates/password-change.tpl
+++ b/templates/password-change.tpl
@@ -29,14 +29,14 @@
         <label for="fPassword">
             {$PALANG.pPassword_password}
         </label>
-        <input class="form-control" type="password" name="fPassword"/>
+        <input class="form-control" type="password" name="fPassword" autocomplete="new-password"/>
     </div>
 
     <div class="form-group">
         <label for="fPassword2">
             {$PALANG.pPassword_password2}
         </label>
-        <input class="form-control" type="password" name="fPassword2"/>
+        <input class="form-control" type="password" name="fPassword2" autocomplete="new-password"/>
     </div>
 
     <button class="btn btn-primary" type="submit" name="submit"

--- a/templates/password.tpl
+++ b/templates/password.tpl
@@ -17,13 +17,13 @@
             <div class="form-group {if $pPassword_password_text}has-error{/if}">
                 <label class="col-md-4 col-sm-4 control-label" for="fPassword">{$PALANG.pPassword_password}:</label>
                 <div class="col-md-6 col-sm-8"><input class="form-control" type="password" name="fPassword"
-                                                      id="fPassword"/></div>
+                                                      id="fPassword" autocomplete="new-password"/></div>
                 <span class="help-block">{$pPassword_password_text}</span>
             </div>
             <div class="form-group">
                 <label class="col-md-4 col-sm-4 control-label" for="fPassword2">{$PALANG.pPassword_password2}:</label>
                 <div class="col-md-6 col-sm-8"><input class="form-control" type="password" name="fPassword2"
-                                                      id="fPassword2"/></div>
+                                                      id="fPassword2" autocomplete="new-password"/></div>
             </div>
         </div>
         <div class="panel-footer">


### PR DESCRIPTION
Passwords should not be autocompleted (by browser or password manager) in fields that ask for a new password.

I'm not sure about the change in `editform.tpl`, it seems a bit "hacky". Maybe the right way would probably be to add a new attribute to the model columns.