### PR TITLE
Redirect to listview after editing

### DIFF
--- a/public/edit.php
+++ b/public/edit.php
@@ -184,13 +184,8 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
                 }
             }
 
-            if ($new == 0) {
-                header("Location: " . $formconf['listview']);
-                exit;
-            } else {
-                header("Location: edit.php?table=$table");
-                exit;
-            }
+            header("Location: " . $formconf['listview']);
+            exit;
         }
     }
 }


### PR DESCRIPTION
This PR redirects the user to the list view after editing an item, which is the same behaviour than after creating an item.

Was there a specific reason for the previous behaviour?