### PR TITLE
Allow super admins to view all log entries

### DIFF
--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -200,6 +200,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Разглеждане на последните %s действия за ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Дата';
 $PALANG['pViewlog_action'] = 'Действие';
 $PALANG['pViewlog_data'] = 'Данни';

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -198,6 +198,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Veure les últimes %s accions per ';
+$PALANG['pViewlog_welcome_all'] = 'Veure les últimes %s accions ';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acció';
 $PALANG['pViewlog_data'] = 'Dades';

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -199,6 +199,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = '查看最新的%s项操作日志 域名: ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = '时间';
 $PALANG['pViewlog_action'] = '操作';
 $PALANG['pViewlog_data'] = '内容';

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -209,6 +209,7 @@ $PALANG['reply_once_per_day'] = 'Odpovědět jednou za den';
 $PALANG['reply_once_per_week'] = 'Odpovědět jednou za týden';
 
 $PALANG['pViewlog_welcome'] = 'Prohlížet %s posledních akcí pro ';
+$PALANG['pViewlog_welcome_all'] = 'Prohlížet %s posledních akcí ';
 $PALANG['pViewlog_timestamp'] = 'Časová značka';
 $PALANG['pViewlog_action'] = 'Akce';
 $PALANG['pViewlog_data'] = 'Poznámka';

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vis de sidste %s poster for ';
+$PALANG['pViewlog_welcome_all'] = 'Vis de sidste %s poster ';
 $PALANG['pViewlog_timestamp'] = 'Tidsstempel';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -203,6 +203,7 @@ $PALANG['reply_once_per_day'] = 'Einmal pro Tag antworten';
 $PALANG['reply_once_per_week'] = 'Einmal pro Woche antworten';
 
 $PALANG['pViewlog_welcome'] = 'Zeigt die letzten %s Aktionen für ';
+$PALANG['pViewlog_welcome_all'] = 'Zeigt die letzten %s Aktionen ';
 $PALANG['pViewlog_timestamp'] = 'Zeitpunkt';
 $PALANG['pViewlog_action'] = 'Aktion';
 $PALANG['pViewlog_data'] = 'Daten';

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -205,6 +205,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day';
 $PALANG['reply_once_per_week'] = 'Reply once a week';
 
 $PALANG['pViewlog_welcome'] = 'View the last %s actions for ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions ';
 $PALANG['pViewlog_timestamp'] = 'Timestamp';
 $PALANG['pViewlog_action'] = 'Action';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -200,6 +200,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Ver las últimas %s acciones para ';
+$PALANG['pViewlog_welcome_all'] = 'Ver las últimas %s acciones ';
 $PALANG['pViewlog_timestamp'] = 'Fecha/Hora';
 $PALANG['pViewlog_action'] = 'Acción';
 $PALANG['pViewlog_data'] = 'Datos';

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -199,6 +199,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vaata %s viimast muudatust domeeniga ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Ajatempel';
 $PALANG['pViewlog_action'] = 'Toiming';
 $PALANG['pViewlog_data'] = 'Andmed';

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -197,6 +197,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Honen azken %s ekintzak ikusi ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Data/ordua';
 $PALANG['pViewlog_action'] = 'Ekintza';
 $PALANG['pViewlog_data'] = 'Datuak';

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -199,6 +199,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Näytä viimeiset kymmenen tapahtumaa domainille ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Aikaleima';
 $PALANG['pViewlog_action'] = 'Tapahtuma';
 $PALANG['pViewlog_data'] = 'Tiedot';

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -199,6 +199,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vís seinastu %s hendingarnar fyri ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Tíðarstempul';
 $PALANG['pViewlog_action'] = 'Hending';
 $PALANG['pViewlog_data'] = 'Dáta';

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -203,6 +203,7 @@ $PALANG['reply_once_per_day'] = 'Répondre une fois par jour';
 $PALANG['reply_once_per_week'] = 'Répondre une fois par semaine';
 
 $PALANG['pViewlog_welcome'] = 'Visualiser les %s dernières actions pour ';
+$PALANG['pViewlog_welcome_all'] = 'Visualiser les %s dernières actions ';
 $PALANG['pViewlog_timestamp'] = 'Date/Heure';
 $PALANG['pViewlog_action'] = 'Action';
 $PALANG['pViewlog_data'] = 'Information';

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -198,6 +198,7 @@ $PALANG['reply_once_per_day'] = 'Respostar unha vez ao día'; # XXX
 $PALANG['reply_once_per_week'] = 'Respostar unha vez á semana'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Ver as últimas %s accións para ';
+$PALANG['pViewlog_welcome_all'] = 'Ver as últimas %s accións ';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acción';
 $PALANG['pViewlog_data'] = 'Datos';

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -198,6 +198,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Pogledaj zadnjih %s akcija za ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Vrijeme';
 $PALANG['pViewlog_action'] = 'Akcija';
 $PALANG['pViewlog_data'] = 'Podaci';

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -203,6 +203,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Az utolsó %s esemény megtekintése: ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Idõbélyeg';
 $PALANG['pViewlog_action'] = 'Akció';
 $PALANG['pViewlog_data'] = 'Adat';

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -199,6 +199,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Skoða síðustu %s aðgerðir fyrir ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Tími';
 $PALANG['pViewlog_action'] = 'aðgerð';
 $PALANG['pViewlog_data'] = 'gögn';

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -200,6 +200,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Elenca gli ultimi %s eventi per ';
+$PALANG['pViewlog_welcome_all'] = 'Elenca gli ultimi %s eventi ';
 $PALANG['pViewlog_timestamp'] = 'Orario';
 $PALANG['pViewlog_action'] = 'Azione';
 $PALANG['pViewlog_data'] = 'Dati';

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -203,6 +203,7 @@ $PALANG['reply_once_per_day'] = '毎日返信';
 $PALANG['reply_once_per_week'] = '週に一度返信';
 
 $PALANG['pViewlog_welcome'] = '過去 %s 個のアクション ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'タイムスタンプ';
 $PALANG['pViewlog_action'] = 'アクション';
 $PALANG['pViewlog_data'] = 'データ';

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -200,6 +200,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Peržiūrėti paskutinius %s vartotojo veiksmų ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Laikas';
 $PALANG['pViewlog_action'] = 'Veiksmas';
 $PALANG['pViewlog_data'] = 'Duomenys';

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -199,6 +199,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Преглед на последните %s операции за: ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Маркер (Timestamp)';
 $PALANG['pViewlog_action'] = 'Операција';
 $PALANG['pViewlog_data'] = 'Датум';

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -200,6 +200,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vis de %s siste handlingene for ';
+$PALANG['pViewlog_welcome_all'] = 'Vis de %s siste handlingene ';
 $PALANG['pViewlog_timestamp'] = 'Klokkeslett';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -202,6 +202,7 @@ $PALANG['reply_once_per_day'] = 'Beantwoord een keer per dag';
 $PALANG['reply_once_per_week'] = 'Beantwoord een keer per week';
 
 $PALANG['pViewlog_welcome'] = 'Laat de laatste %s actie\'s zien van ';
+$PALANG['pViewlog_welcome_all'] = 'Laat de laatste %s actie\'s zien ';
 $PALANG['pViewlog_timestamp'] = 'Tijd';
 $PALANG['pViewlog_action'] = 'Actie';
 $PALANG['pViewlog_data'] = 'Aanpassing';

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -198,6 +198,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vis de %s siste handlingene ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Klokkeslett';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -202,6 +202,7 @@ $PALANG['reply_once_per_day'] = 'Odpowiedz raz na dzień';
 $PALANG['reply_once_per_week'] = 'Odpowiedz raz na tydzień';
 
 $PALANG['pViewlog_welcome'] = 'Pokaż %s ostatnich działań dla ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Data';
 $PALANG['pViewlog_action'] = 'Działanie';
 $PALANG['pViewlog_data'] = 'Dane';

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -205,6 +205,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Últimas %s ações para ';
+$PALANG['pViewlog_welcome_all'] = 'Últimas %s ações ';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Ação';
 $PALANG['pViewlog_data'] = 'Descrição';

--- a/languages/pt-pt.lang
+++ b/languages/pt-pt.lang
@@ -205,6 +205,7 @@ $PALANG['reply_once_per_day'] = 'Reesponder uma vez por dia'; # XXX
 $PALANG['reply_once_per_week'] = 'Responder uma vez por semana'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Últimas %s acções para ';
+$PALANG['pViewlog_welcome_all'] = 'Últimas %s acções ';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acção';
 $PALANG['pViewlog_data'] = 'Descrição';

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -203,6 +203,7 @@ $PALANG['reply_once_per_day'] = 'Raspunde odata pe zi';
 $PALANG['reply_once_per_week'] = 'Raspunde odata pe saptamana';
 
 $PALANG['pViewlog_welcome'] = 'Vizualizati ultimele %s operatii pentru ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Data si ora';
 $PALANG['pViewlog_action'] = 'Operatie';
 $PALANG['pViewlog_data'] = 'Detalii';

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_day'] = 'Отвечать один раз в день';
 $PALANG['reply_once_per_week'] = 'Отвечать один раз в неделю';
 
 $PALANG['pViewlog_welcome'] = 'Просмотр %s последних действий для ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Время создания/модификации';
 $PALANG['pViewlog_action'] = 'Действие';
 $PALANG['pViewlog_data'] = 'Данные';

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -200,6 +200,7 @@ $PALANG['reply_once_per_day'] = 'Odpovedať raz za deň';
 $PALANG['reply_once_per_week'] = 'Odpovedať raz za týždeň';
 
 $PALANG['pViewlog_welcome'] = 'Prehľad %s posledných akcií pre ';
+$PALANG['pViewlog_welcome_all'] = 'Prehľad %s posledných akcií ';
 $PALANG['pViewlog_timestamp'] = 'Časová značka';
 $PALANG['pViewlog_action'] = 'Akcia';
 $PALANG['pViewlog_data'] = 'Podrobnosti';

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -199,6 +199,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Seznam zadnjih %s operacij za ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Čas';
 $PALANG['pViewlog_action'] = 'Operacija';
 $PALANG['pViewlog_data'] = 'Podatki';

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -204,6 +204,7 @@ $PALANG['reply_once_per_day'] = 'Svara en gång om dagen';
 $PALANG['reply_once_per_week'] = 'Svara en gång i veckan';
 
 $PALANG['pViewlog_welcome'] = 'Visa de senaste %s åtgärderna för ';
+$PALANG['pViewlog_welcome_all'] = 'Visa de senaste %s åtgärderna ';
 $PALANG['pViewlog_timestamp'] = 'Tidpunkt';
 $PALANG['pViewlog_action'] = 'Åtgärd';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -199,6 +199,7 @@ $PALANG['reply_once_per_day'] = 'Günde bir kez yanıtla';
 $PALANG['reply_once_per_week'] = 'Haftada bir kez yanıtla';
 
 $PALANG['pViewlog_welcome'] = 'Son %s hareketi:';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Timestamp'; # XXX
 $PALANG['pViewlog_action'] = 'Hareket';
 $PALANG['pViewlog_data'] = 'Veri';

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -201,6 +201,7 @@ $PALANG['reply_once_per_day'] = 'Reply once a day'; # XXX
 $PALANG['reply_once_per_week'] = '每星期回覆一次';
 
 $PALANG['pViewlog_welcome'] = '查看最新的%s項操作日誌 網域: ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = '時間';
 $PALANG['pViewlog_action'] = '操作';
 $PALANG['pViewlog_data'] = '內容';

--- a/languages/ua.lang
+++ b/languages/ua.lang
@@ -205,6 +205,7 @@ $PALANG['reply_once_per_day'] = 'Відповідати один раз на д�
 $PALANG['reply_once_per_week'] = 'Відповідати один раз на тиждень';
 
 $PALANG['pViewlog_welcome'] = 'Перегляд %s останніх дій для ';
+$PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_timestamp'] = 'Час створення/модифікації';
 $PALANG['pViewlog_action'] = 'Дія';
 $PALANG['pViewlog_data'] = 'Данні';

--- a/public/viewlog.php
+++ b/public/viewlog.php
@@ -45,7 +45,7 @@ $fDomain = '';
 $error = 0;
 
 if ($_SERVER['REQUEST_METHOD'] == "GET") {
-    if ((is_array($list_domains) and sizeof($list_domains) > 0)) {
+    if ((is_array($list_domains) and sizeof($list_domains) > 0) and !authentication_has_role('global-admin')) {
         $fDomain = $list_domains[0];
     }
 } elseif ($_SERVER['REQUEST_METHOD'] == "POST") {
@@ -67,10 +67,12 @@ if ($error != 1) {
     $table_log = table_by_key('log');
     $page_size = isset($CONF['page_size']) ? intval($CONF['page_size']) : 35;
 
-    $query = "SELECT timestamp,username,domain,action,data FROM $table_log WHERE domain= :domain ORDER BY timestamp DESC LIMIT $page_size";
+    $where_domain = $fDomain ? 'WHERE domain= :domain' : '';
+
+    $query = "SELECT timestamp,username,domain,action,data FROM $table_log $where_domain ORDER BY timestamp DESC LIMIT $page_size";
 
     if (db_pgsql()) {
-        $query = "SELECT extract(epoch from timestamp) as timestamp,username,domain,action,data FROM $table_log WHERE domain= :domain ORDER BY timestamp DESC LIMIT $page_size";
+        $query = "SELECT extract(epoch from timestamp) as timestamp,username,domain,action,data FROM $table_log $where_domain ORDER BY timestamp DESC LIMIT $page_size";
     }
     $result = db_query_all($query, array('domain' => $fDomain));
     foreach ($result as $row) {
@@ -88,7 +90,13 @@ foreach ($tLog as $k => $v) {
     }
 }
 
-$smarty->assign('domain_list', $list_domains);
+$domain_options = array();
+if (authentication_has_role('global-admin')) {
+    $domain_options = array('' => '');
+}
+$domain_options = array_merge($domain_options, array_combine($list_domains, $list_domains));
+
+$smarty->assign('domain_options', $domain_options);
 $smarty->assign('domain_selected', $fDomain);
 $smarty->assign('tLog', $tLog, false);
 $smarty->assign('fDomain', $fDomain);

--- a/templates/viewlog.tpl
+++ b/templates/viewlog.tpl
@@ -1,13 +1,17 @@
 <div class="panel panel-default">
     <div class="panel-heading">
         <form name="frmOverview" method="post" action="">
-            {html_options name='fDomain' output=$domain_list values=$domain_list selected=$domain_selected onchange="this.form.submit();"}
+            {html_options name='fDomain' options=$domain_options selected=$domain_selected onchange="this.form.submit();"}
             <noscript><input class="button" type="submit" name="go" value="{$PALANG.go}"/></noscript>
         </form>
     </div>
     {if $tLog}
         <div class="panel-body">
-            <h4>{$PALANG.pViewlog_welcome|replace:"%s":$CONF.page_size} {$fDomain} </h4>
+            {if $domain_selected}
+                <h4>{$PALANG.pViewlog_welcome|replace:"%s":$CONF.page_size} {$fDomain} </h4>
+            {else}
+                <h4>{$PALANG.pViewlog_welcome_all|replace:"%s":$CONF.page_size}</h4>
+            {/if}
         </div>
         <table id="log_table" class="table">
             {#tr_header#}


### PR DESCRIPTION
This PR adds an empty option (and it's also the default) to the list of domains available in the domain dropdown in viewlogs, only for super admins. This allows the admin to see all log entries even if they're not associated to a domain.

This is useful not only to see logs of all domains, but also to be able to see log entries regarding modification of admin users, and deletion of domains, which were previously not possible.

I added translations to some languages, and left an english default for the rest.

Please let me know if any changes are required.