### PR TITLE
Fix debian builds: ADDITIONS/README.TXT was renamed

### DIFF
--- a/debian/postfixadmin.examples
+++ b/debian/postfixadmin.examples
@@ -13,4 +13,4 @@ ADDITIONS/delete-mailq-by-domain.pl
 ADDITIONS/pfa_maildir_cleanup.pl
 ADDITIONS/quota_usage.pl
 ADDITIONS/fetchmail.pl
-ADDITIONS/README.TXT
+ADDITIONS/README.md


### PR DESCRIPTION
While trying to build a recent deb package, I got the following error:

```
dh_installexamples: Cannot find (any matches for) "ADDITIONS/README.TXT" (tried in .)

make: *** [debian/rules:45: binary-indep] Error 2
dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2
```

I realized that this was because the file ADDITIONS/README.TXT no longer exists - it was renamed to README.md.