### PR TITLE
default $transport_maps: exclude results where transport='virtual'

### DIFF
--- a/DOCUMENTS/POSTFIX_CONF.txt
+++ b/DOCUMENTS/POSTFIX_CONF.txt
@@ -125,7 +125,7 @@ user = postfix
 password = password
 hosts = localhost
 dbname = postfix
-query = SELECT transport FROM domain WHERE domain='%s' AND active = '1'
+query = SELECT transport FROM domain WHERE domain='%s' AND active = '1' AND transport != 'virtual'
 
 
 (See above note re Concat + PostgreSQL)


### PR DESCRIPTION
Modify the default query for $transport_maps to exclude all entries
which have the transport set to 'virtual'.

Postfixadmin sets the transport for domains to 'virtual' by default,
which is a rather unfortunate choice when enabling transport_maps, as
it will direct postfix to use the 'virtual' transport as defined in
master.cf, which most likely is not what the user intended.
The user most likely still wants emails being delivered to virtual
mailboxes, via the transport defined per $virtual_transport.

$virtual_transport however is only a fallback, which applies if
$transport_maps is either undefined or the table lookup it refers to
fails.

Hence excluding domains where transport is set to 'virtual', which
by default and therewith in most cases probably means all domains
ever created by postfixadmin.

This results in the query returning no results, leading to postfix
falling back to the transport defined in $virtual_transport.