### PR TITLE
Add support for implicit TLS, replace "smtp_sendmail_tls" with "smtp_type"

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -167,13 +167,17 @@ $CONF['admin_name'] = 'Postmaster';
 $CONF['smtp_server'] = 'localhost';
 $CONF['smtp_port'] = '25';
 
+// The communication layer used.
+//
+// 'plain'    Everything in plain text (standard port: 25).
+// 'tls'      TLS/SSL from the very beginning (standard port: 465).
+// 'starttls' "STARTTLS" in plain text and then TLS/SSL (standard port: 587).
+$CONF['smtp_type'] = 'plain';
+
 // SMTP Client
 // Hostname (FQDN) of the server hosting Postfix Admin
 // Used in the HELO when sending emails from Postfix Admin
 $CONF['smtp_client'] = '';
-
-// Set 'YES' to use TLS when sending emails.
-$CONF['smtp_sendmail_tls'] = 'NO';
 
 // Encrypt - how passwords are stored/hashed in the database.
 //


### PR DESCRIPTION
For reference: https://datatracker.ietf.org/doc/html/rfc8314

Please note that this only applies to the "send email" feature.

In the future we should implement it for the "fetch email" one too.

---

Fixes #563.