### PR TITLE
Update PFACrypt.php

### DIFF
--- a/model/PFACrypt.php
+++ b/model/PFACrypt.php
@@ -60,6 +60,17 @@ class PFACrypt
                 $algorithm = $method_in_hash;
             }
         }
+ 
+        if (!empty($pw_db) && preg_match('/^\$[0-9]\$/i', $pw_db, $matches)) {
+            $method_in_hash = $matches[0];
+            switch ($method_in_hash){
+                case '$1$':
+                case '$6$':
+                        $algorithm='SYSTEM';                       
+                }
+        }
+
+        
         if ($algorithm == 'SHA512CRYPT.B64') {
             $algorithm = 'SHA512-CRYPT.B64';
         }


### PR DESCRIPTION

If you have hashes like $nr$salt$hash in the admin table. I think you will not be able to migrate to {hash}algorithm (for example to {SHA512-CRYPT.B64}...).

I have added the following lines of code that check if the hash is like $1$ (md5) or $6$. If yes, the algorithm will be changed to 'SYSTEM'.
