### PR TITLE
update mysql_transport_maps.cf - translate 'virtual' to ':'

### DIFF
--- a/DOCUMENTS/POSTFIX_CONF.txt
+++ b/DOCUMENTS/POSTFIX_CONF.txt
@@ -125,8 +125,9 @@ user = postfix
 password = password
 hosts = localhost
 dbname = postfix
-query = SELECT transport FROM domain WHERE domain='%s' AND active = '1' AND transport != 'virtual'
-
+#query = SELECT transport FROM domain WHERE domain='%s' AND active = '1' AND transport != 'virtual'
+# Enforce virtual transport (catches internal virtual domains and avoid mails being lost in other transport maps)
+query = SELECT REPLACE(transport, 'virtual', ':') AS transport FROM domain WHERE domain='%s' AND active = '1'
 
 (See above note re Concat + PostgreSQL)
 


### PR DESCRIPTION
This makes sure our internal/virtual domains aren't caught in other transport map/nexthop

I needed this to safely implement transport rules like .fr => relay:[smtp.relay.com] without smashing our internal domains

So found out that transparent transport was ':' but took me a wile, so thought I could share.