### PR TITLE
Sendonly

### DIFF
--- a/DOCUMENTS/DOVECOT.txt
+++ b/DOCUMENTS/DOVECOT.txt
@@ -3,6 +3,7 @@
 # Originally written by: Massimo <AndyCapp> Danieli
 # Revised by: Sampsa Hario <shario> for Dovecot v1.0
 # Revised by: David Goodwin <david@palepurple.co.uk> for Dovecot 2.1.x  (2014/01/02)
+# Small adjustment by: Jan Kruis < jan@crossreference.nl> in the sql question regarding sendonly (2022/10/28)
 #
 
 More complete Dovecot documentation:
@@ -128,13 +129,13 @@ password_query = SELECT username AS user,password FROM mailbox WHERE username = 
 
 # Query to retrieve user information, note uid matches dovecot.conf AND Postfix virtual_uid_maps parameter.
 # MYSQL:
-user_query = SELECT CONCAT('/var/mail/vmail/', maildir) AS home, 1001 AS uid, 1001 AS gid, CONCAT('*:bytes=', quota) AS quota_rule FROM mailbox WHERE username = '%u' AND active='1'
+user_query = SELECT CONCAT('/var/mail/vmail/', maildir) AS home, 1001 AS uid, 1001 AS gid, CONCAT('*:bytes=', quota) AS quota_rule FROM mailbox WHERE username = '%u' AND active='1' AND sendonly='0'
 # PostgreSQL:
 # user_query =   SELECT '/var/mail/vmail/' || maildir AS home, 1001 AS uid, 1001 AS gid,
-#   '*:bytes=' || quota AS quota_rule FROM mailbox WHERE username = '%u' AND active = '1'
+#   '*:bytes=' || quota AS quota_rule FROM mailbox WHERE username = '%u' AND active = '1' AND sendonly = '0'
 
 # see: https://doc.dovecot.org/configuration_manual/authentication/sql/#id6
-iterate_query = SELECT username as user FROM mailbox WHERE active = '1'
+iterate_query = SELECT username as user FROM mailbox WHERE active = '1'  AND sendonly='0'
 
 #END /etc/dovecot/dovecot-sql.conf
 

--- a/DOCUMENTS/POSTFIX_CONF.txt
+++ b/DOCUMENTS/POSTFIX_CONF.txt
@@ -32,6 +32,11 @@ transport_maps = proxy:mysql:/etc/postfix/sql/mysql_transport_maps.cf
 virtual_mailbox_base = /var/mail/vmail
 # or whereever you want to store the mails
 
+### Conditions in which Postfix accepts e-mails as recipient (additional to relay conditions)
+### check_recipient_access checks if an account is "sendonly"
+smtpd_recipient_restrictions = check_recipient_access mysql:/etc/postfix/sql/recipient-access.cf
+
+
 Where you chose to store the .cf files doesn't really matter, but they will
 have database passwords stored in plain text so they should be readable only
 by user postfix, or in a directory only accessible to user postfix.
@@ -51,14 +56,15 @@ use values of domain_path=YES and domain_in_mailbox=NO
 
 You can create these files (with your values for user, password, hosts and
 dbname) automatically by executing this file (sh POSTFIX_CONF.txt).
-Please note that the generated files are for use with MySQL. 
+Please note that the generated files are for use with MySQL.
 
 If you are using PostgreSQL, you'll need to do some changes to the queries:
-- PostgreSQL uses a different implementation for boolean values, which means 
-  you'll need to change  active='1'  to  active='t'  in all queries
-- PostgreSQL does not have a concat() function, instead use e.g. 
+- PostgreSQL uses a different implementation for boolean values, which means
+  you'll need to change  active='1'  to  active='t'  in all queries and
+  you'll need to change  sendonly='0'  to  sendonly='f'  in all queries
+- PostgreSQL does not have a concat() function, instead use e.g.
   .... alias.address = '%u' || '@' || alias_domain.target_domain AND ....
- 
+
 
 mysql_virtual_alias_maps.cf:
 user = postfix
@@ -90,12 +96,12 @@ user = postfix
 password = password
 hosts = localhost
 dbname = postfix
-query          = SELECT domain FROM domain WHERE domain='%s' AND active = '1'
-#query          = SELECT domain FROM domain WHERE domain='%s'
+query  = SELECT domain FROM domain WHERE domain='%s' AND active = '1'
+#query = SELECT domain FROM domain WHERE domain='%s'
 #optional query to use when relaying for backup MX
-#query           = SELECT domain FROM domain WHERE domain='%s' AND backupmx = '0' AND active = '1'
+#query = SELECT domain FROM domain WHERE domain='%s' AND backupmx = '0' AND active = '1'
 #optional query to use for transport map support
-#query           = SELECT domain FROM domain WHERE domain='%s' AND active = '1' AND NOT (transport LIKE 'smtp%%' OR transport LIKE 'relay%%')
+#query = SELECT domain FROM domain WHERE domain='%s' AND active = '1' AND NOT (transport LIKE 'smtp%%' OR transport LIKE 'relay%%')
 #expansion_limit = 100
 
 mysql_virtual_mailbox_maps.cf:
@@ -103,7 +109,7 @@ user = postfix
 password = password
 hosts = localhost
 dbname = postfix
-query           = SELECT maildir FROM mailbox WHERE username='%s' AND active = '1'
+query  = SELECT maildir FROM mailbox WHERE username='%s' AND active = '1'
 #expansion_limit = 100
 
 mysql_virtual_alias_domain_mailbox_maps.cf:
@@ -111,7 +117,7 @@ user = postfix
 password = password
 hosts = localhost
 dbname = postfix
-query = SELECT maildir FROM mailbox,alias_domain WHERE alias_domain.alias_domain = '%d' and mailbox.username = CONCAT('%u', '@', alias_domain.target_domain) AND mailbox.active='1' AND alias_domain.active='1'
+query = SELECT maildir FROM mailbox,alias_domain WHERE alias_domain.alias_domain = '%d' and mailbox.username = CONCAT('%u', '@', alias_domain.target_domain) AND mailbox.active='1' AND alias_domain.active='1' AND mailbox.sendonly='0'
 
 mysql_relay_domains.cf:
 user = postfix
@@ -139,6 +145,14 @@ password = password
 hosts = localhost
 dbname = postfix
 query = SELECT quota FROM mailbox WHERE username='%s' AND active = '1'
+
+
+recipient-access.cf
+user = postfix
+password = password
+hosts = localhost
+dbname = postfix
+query = select if(sendonly = true, 'REJECT', 'OK') AS acces from mailbox where username = '%s' and domain = '%d' and active='1' LIMIT 1;
 
 -------------------------
 

--- a/DOCUMENTS/Postfix-Dovecot-Postgresql-Example.md
+++ b/DOCUMENTS/Postfix-Dovecot-Postgresql-Example.md
@@ -113,7 +113,7 @@ user = postfix
 password = whatever
 hosts = localhost
 dbname = postfix
-query = SELECT username FROM mailbox WHERE username='%s' AND active = true
+query = SELECT username FROM mailbox WHERE username='%s' AND active = true AND sendonly = false
 ```
 
 
@@ -234,5 +234,5 @@ default_pass_scheme = MD5-CRYPT
 password_query = SELECT username AS user,password FROM mailbox WHERE username = '%u' AND active='1'
 
 # Query to retrieve user information, note uid matches dovecot.conf AND Postfix virtual_uid_maps parameter.
-user_query = SELECT '/var/mail/vmail/' || maildir AS home, 8 as uid, 8 as gid FROM mailbox WHERE username = '%u' AND active = '1'
+user_query = SELECT '/var/mail/vmail/' || maildir AS home, 8 as uid, 8 as gid FROM mailbox WHERE username = '%u' AND active = '1' AND sendonly ='0'
 ```

--- a/config.inc.php
+++ b/config.inc.php
@@ -185,16 +185,16 @@ $CONF['smtp_client'] = '';
 //
 // See: https://github.com/postfixadmin/postfixadmin/blob/master/DOCUMENTS/HASHING.md
 //
-// - PLAIN, CLEAR or CLEARTEXT - plain text variants, may be useful for testing. 
+// - PLAIN, CLEAR or CLEARTEXT - plain text variants, may be useful for testing.
 //
 // - ARGON2ID, ARGON2I, SHA512-CRYPT, SHA256-CRYPT or BLF-CRYPT might be good options.
 //
-// - other, older variants are : 
-//   - md5crypt, 
-//   - md5, 
-//   - system, 
+// - other, older variants are :
+//   - md5crypt,
+//   - md5,
+//   - system,
 //   - mysql_encrypt - mysql's password()
-//   - dovecot:CRYPT-METHOD = use dovecotpw -s 'CRYPT-METHOD'. 
+//   - dovecot:CRYPT-METHOD = use dovecotpw -s 'CRYPT-METHOD'.
 //     - Note: dovecot relies on doveadm binary, and suitable permissions on config files - see https://github.com/postfixadmin/postfixadmin/issues/398
 //
 // - authlib = support for courier-authlib style passwords - also set $CONF['authlib_default_flavor']
@@ -397,6 +397,15 @@ $CONF['transport_options'] = array (
 // You should define default transport. It must be in array above.
 $CONF['transport_default'] = 'virtual';
 
+// Sendonly Controle
+// If you want to define additional funktion sendonly for a mailbox set sendonly_control to 'YES'.
+// The sendonly_contole will enable you to set and change the value of the sendonly record in de mailbox table.
+// to use this function you need to add sendonly  to the sql query SEE
+//       <POSTFIXADMIN_ROOT_DIR>/DOCUMENTS/POSTFIX_CONF.txt and/or
+//       <POSTFIXADMIN_ROOT_DIR>/DOCUMENTS/Postfix-Dovecot-Postgresql-Example.md section "/etc/postfix/pgsql/virtual_sender_maps.cf"
+// By default the value of sendonly  will be set to '0', or 'false' so if you don't have postfixadmin setup with   $CONF['sendonly_control'] = 'YES'
+// on your mailserver for this funktion but use the query's as described above on harm is done.
+$CONF['sendonly_control'] = 'NO';
 
 //
 //
@@ -425,8 +434,8 @@ $CONF['vacation_control_admin'] = 'YES';
 // ReplyType options
 // If you want to define additional reply options put them in array below.
 // The array has the format   seconds between replies => $PALANG text
-// Special values for seconds are: 
-// 0 => only reply to the first mail while on vacation 
+// Special values for seconds are:
+// 0 => only reply to the first mail while on vacation
 // 1 => reply on every mail
 $CONF['vacation_choice_of_reply'] = array (
    0 => 'reply_once',        // Sends only Once the message during Out of Office

--- a/configs/menu.conf
+++ b/configs/menu.conf
@@ -1,5 +1,6 @@
 url_main = main.php
 url_editactive = editactive.php?table=
+url_editsendonly = editsendonly.php?table=
 # list_admin
 url_list_admin = list.php?table=admin
 url_create_admin = edit.php?table=admin

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Overview for ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains';
 $PALANG['pOverview_alias_address'] = 'From';
 $PALANG['active'] = 'Active';
+$PALANG['sendonly'] = 'Send Only'; # XXX
 $PALANG['and_x_more'] = '[and %s more...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Name';

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Overzicht voor ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias domeinen';
 $PALANG['pOverview_alias_address'] = 'Van';
 $PALANG['active'] = 'Actief';
+$PALANG['sendonly'] = 'Alleen Zenden';
 $PALANG['and_x_more'] = '[en %s meer...]';
 $PALANG['pOverview_mailbox_username'] = 'e-mail';
 $PALANG['name'] = 'Naam';
@@ -288,7 +289,6 @@ $PALANG['description'] = 'Omschrijving';
 $PALANG['aliases'] = 'Aliassen';
 $PALANG['pAdminList_domain_quota'] = 'Domein quota (MB)';
 $PALANG['pAdminList_domain_backupmx'] = 'Back-up MX';
-$PALANG['pAdminList-tls_policy'] = 'TLS Policy';
 $PALANG['last_modified'] = 'Laatst bewerkt';
 
 $PALANG['pAdminCreate_domain_welcome'] = 'Voeg een nieuw domein toe';
@@ -319,7 +319,7 @@ $PALANG['pAdminEdit_domain_quota'] = 'Domein Quota';
 $PALANG['transport'] = 'Transport';
 $PALANG['backupmx'] = 'Backup-MX';
 $PALANG['pAdminEdit_domain_transport_text'] = 'Definieer transport';
-$PALANG['pAdminEdit_domain_backupmx'] = 'Definieer of deze Mailserver een Backup MX is voor het domain';
+$PALANG['pAdminEdit_domain_backupmx'] = 'MX Backup Server';
 $PALANG['pAdminEdit_domain_result_error'] = 'Het bewerken van domein %s is mislukt!';
 
 $PALANG['pAdminCreate_admin_welcome'] = 'Voeg een nieuw domein beheerder toe';

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -48,6 +48,7 @@ class MailboxHandler extends PFAHandler
             # read_from_db_postprocess() also sets 'quotabytes' for use in init()
             # TODO: read used quota from quota/quota2 table
             'active'           => pacol(1,          1,      1,      'bool', 'active'                        , ''                                 , 1 ),
+            'sendonly'         => pacol(1,          1,      1,      'bool', 'sendonly'                      , ''                                 , 0 ),
             'welcome_mail'     => pacol($this->new, $this->new, 0,  'bool', 'pCreate_mailbox_mail'          , ''                                 , 1,
                 /*options*/ array(),
                 /*not_in_db*/ 1             ),

--- a/public/editsendonly.php
+++ b/public/editsendonly.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Postfix Admin
+ *
+ * LICENSE
+ * This source file is subject to the GPL license that is bundled with
+ * this package in the file LICENSE.TXT
+ *
+ * Further details on the project are available at http://postfixadmin.sf.net
+ *
+ * @version $Id$
+ * @license GNU GPL v2 or later.
+ *
+ * File: editsendonly.php
+ * Used to switch sendonly status in mailboxes.
+ *
+ * Template File: list-virtual_mailbox.tpl
+ */
+
+require_once('common.php');
+
+if (safeget('token') != $_SESSION['PFA_token']) {
+    die('Invalid token!');
+}
+
+$username = authentication_get_username(); # enforce login
+
+$id = safeget('id');
+$table = safeget('table');
+$sendonly = safeget('sendonly');
+
+if (empty($table)) {
+    die("Invalid table name given");
+}
+
+$handlerclass = ucfirst($table) . 'Handler';
+
+if (!preg_match('/^[a-z]+$/', $table) || !file_exists(dirname(__FILE__) . "/../model/$handlerclass.php")) { # validate $table
+    die("Invalid table name given!");
+}
+
+$handler = new $handlerclass(0, $username);
+
+$formconf = $handler->webformConfig();
+
+authentication_require_role($formconf['required_role']);
+
+if ($handler->init($id)) { # errors will be displayed as last step anyway, no need for duplicated code ;-)
+    if ($sendonly != '0' && $sendonly != '1') {
+        die(Config::Lang('invalid_parameter'));
+    }
+
+    if ($handler->set(array('sendonly' => $sendonly))) {
+        $handler->save();
+    }
+}
+
+flash_error($handler->errormsg);
+flash_info($handler->infomsg);
+
+header("Location: " . $formconf['listview']);
+exit;
+
+/* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2153,7 +2153,7 @@ function upgrade_1847_mysql()
         `created` {DATETIME},
         `modified` {DATETIME},
         INDEX(domain_name, description),
-        FOREIGN KEY (`domain_name`) 
+        FOREIGN KEY (`domain_name`)
             REFERENCES $domain_table(`domain`)
             ON DELETE CASCADE) {COLLATE} COMMENT='Postfix Admin - OpenDKIM Key Table';
     ");
@@ -2166,7 +2166,7 @@ function upgrade_1847_mysql()
         `created` {DATETIME},
         `modified` {DATETIME},
         INDEX(author),
-        FOREIGN KEY (`dkim_id`) 
+        FOREIGN KEY (`dkim_id`)
             REFERENCES $dkim_key_table(`id`)
             ON DELETE CASCADE) {COLLATE} COMMENT='Postfix Admin - OpenDKIM Signing Table';
     ");
@@ -2206,7 +2206,7 @@ function upgrade_1847_pgsql()
         dkim_id integer NOT NULL,
         created {DATETIME},
         modified  {DATETIME},
-        FOREIGN KEY (dkim_id) 
+        FOREIGN KEY (dkim_id)
             REFERENCES $dkim_key_table(id)
             ON DELETE CASCADE) {COLLATE} ;
     ");
@@ -2234,7 +2234,7 @@ function upgrade_1847_sqlite()
         `public_key` text,
         `created` {DATETIME},
         `modified` {DATETIME},
-        FOREIGN KEY (`domain_name`) 
+        FOREIGN KEY (`domain_name`)
             REFERENCES $domain_table(`domain`)
             ON DELETE CASCADE) {COLLATE};
     ");
@@ -2246,8 +2246,41 @@ function upgrade_1847_sqlite()
         `dkim_id` integer NOT NULL,
         `created` {DATETIME},
         `modified` {DATETIME},
-        FOREIGN KEY (`dkim_id`) 
+        FOREIGN KEY (`dkim_id`)
             REFERENCES $dkim_key_table(`id`)
             ON DELETE CASCADE) {COLLATE};
     ");
+}
+
+#
+# add record for sendony to mailbox
+# Recoord is a boolean and MUST be set ddefault to 0 ( false)
+# otherwise all mailboxes are set to sendonly and we don't want that
+#
+
+function upgrade_1848() {
+    global $CONF;
+
+    if ($CONF['database_type'] == 'sqlite') {
+        return;
+    }
+    # alternative contact means to reset a forgotten password
+    _db_add_field(,mailbox', 'sendonly',  '{BOOLEAN}', 'active');
+}
+
+/**
+ * @return void
+ */
+
+
+##
+## Need to add record for SQlite database as well
+##
+
+function upgrade_1848_sqlite() {
+    # Add columns for the  sendonly
+            db_query_parsed("ALTER TABLE `$table` ADD COLUMN `sendonly` BOOLEAN ''");
+        _db_add_field('mailbox', 'sendonly', 'BOOLEAN', 'active');
+        }
+    }
 }

--- a/templates/list-virtual_mailbox.tpl
+++ b/templates/list-virtual_mailbox.tpl
@@ -15,6 +15,7 @@
 		{if $CONF.quota===YES}<th>{$PALANG.pOverview_mailbox_quota}</th>{/if}
 		<th>{$PALANG.last_modified}</th>
 		<th>{$PALANG.active}</th>
+		{if $CONF.sendonly_control===YES}<th>{$PALANG.sendonly}</th>{/if}
 		{assign var="colspan" value="`$colspan-6`"}
 		<th colspan="{$colspan}">&nbsp;</th>
 	</tr>
@@ -76,6 +77,10 @@
 			<td>{$item.modified}</td>
 			<td><a class="btn btn-warning" href="{#url_editactive#}mailbox&amp;id={$item.username|escape:"url"}&amp;active={if ($item.active==0)}1{else}0{/if}&amp;token={$smarty.session.PFA_token|escape:"url"}"
 				>{if $item.active==1}<span class="glyphicon glyphicon-check" aria-hidden="true"></span> {$PALANG.YES}{else}<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span> {$PALANG.NO}{/if}</a></td>
+                        {if $CONF.sendonly_control===YES}
+			<td><a class="btn btn-warning" href="{#url_editsendonly#}mailbox&amp;id={$item.username|escape:"url"}&amp;sendonly={if ($item.sendonly==0)}1{else}0{/if}&amp;token={$smarty.session.PFA_token|escape:"url"}"
+				>{if $item.sendonly==1}<span class="glyphicon glyphicon-check" aria-hidden="true"></span> {$PALANG.YES}{else}<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span> {$PALANG.NO}{/if}</a></td>
+			{/if}
 			{if $CONF.vacation_control_admin===YES && $CONF.vacation===YES}
 				{if $item.v_active!==-1}
 					{if $item.v_active==1}


### PR DESCRIPTION
send only

allows the administrator to make a mailbox sendonly or not, for example a noreply mailbox

the following file have been changed

DOCUMENTS/DOVECOT.txt
DOCUMENTS/POSTFIX_CONF.txt
DOCUMENTS/Postfix-Dovecot-Postgresql-Example.md

config.inc.php
configs/menu.conf

languages/en.lang
languages/nl.lang

model/MailboxHandler.php
public/upgrade.php
templates/list-virtual_mailbox.tpl

public/editsendonly.php

also the sql query for dovecot and if desired also postfix must be adjusted

for dovecot see DOCUMENTS/DOVECOT.txt
for postfix see DOCUMENTS/Postfix-Dovecot-Postgresql-Example.md

for a quick adjustment of the sendonly status a file has been added to <POSTFIXADMIN_ROOT_DIR>/public/

editsendonly.php this is derived from editactive.php

in config.inc.php or config.local.php you can indicate at $CONF[sendonly] whether you want to use the function sendonly or not

the variable sendonly is placed in the table 'mailbox' after the variable active