### PR TITLE
Translatable Mailbox and Forward only text

### DIFF
--- a/languages/en.lang
+++ b/languages/en.lang
@@ -454,6 +454,10 @@ $PALANG['dateformat_mysql'] = '%Y-%m-%d';   # translators: rearrange to your loc
 $PALANG['password_expiration'] = 'Pass expires';
 $PALANG['password_expiration_desc'] = 'Date when password will expire';
 
+$PALANG['To_Mailbox']                       = 'Mailbox'; # XXX
+$PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX
+
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -288,7 +288,6 @@ $PALANG['description'] = 'Omschrijving';
 $PALANG['aliases'] = 'Aliassen';
 $PALANG['pAdminList_domain_quota'] = 'Domein quota (MB)';
 $PALANG['pAdminList_domain_backupmx'] = 'Back-up MX';
-$PALANG['pAdminList-tls_policy'] = 'TLS Policy';
 $PALANG['last_modified'] = 'Laatst bewerkt';
 
 $PALANG['pAdminCreate_domain_welcome'] = 'Voeg een nieuw domein toe';
@@ -319,7 +318,7 @@ $PALANG['pAdminEdit_domain_quota'] = 'Domein Quota';
 $PALANG['transport'] = 'Transport';
 $PALANG['backupmx'] = 'Backup-MX';
 $PALANG['pAdminEdit_domain_transport_text'] = 'Definieer transport';
-$PALANG['pAdminEdit_domain_backupmx'] = 'Definieer of deze Mailserver een Backup MX is voor het domain';
+$PALANG['pAdminEdit_domain_backupmx'] = 'Mailserver is Backup MX';
 $PALANG['pAdminEdit_domain_result_error'] = 'Het bewerken van domein %s is mislukt!';
 
 $PALANG['pAdminCreate_admin_welcome'] = 'Voeg een nieuw domein beheerder toe';

--- a/templates/list-virtual_mailbox.tpl
+++ b/templates/list-virtual_mailbox.tpl
@@ -35,9 +35,9 @@
 			{if $display_mailbox_aliases==true}
 				<td>
 				{if $item.goto_mailbox == 1}
-					Mailbox<br/>
+					{PALANG.To_Mailbox}<br/>
 				{else}
-					Forward only<br/>
+					{PALANG.To_Forward_Only}<br/>
 				{/if}
 				{foreach from=$item.goto_other item=item2 key=j}
 					{if $search eq ""}


### PR DESCRIPTION
Added two text variables
$PALANG['To_Mailbox'] and $PALANG['To_Forward_Only']
to be able to translate Mailbox and Forward Only in templates/list-virtual_mailbox.tpl and replace the fixed text with the above mentioned variables
