### PR TITLE
Forward admin users merge

### DIFF
--- a/configs/menu.conf
+++ b/configs/menu.conf
@@ -33,7 +33,7 @@ url_logout = login.php
 
 # user-menu
 url_user_main = main.php
-url_user_edit_alias = edit-alias.php
+url_user_edit_forward = edit-forward.php
 url_user_vacation = vacation.php
 url_user_password = password.php
 url_user_logout = login.php

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -288,7 +288,6 @@ $PALANG['description'] = 'Omschrijving';
 $PALANG['aliases'] = 'Aliassen';
 $PALANG['pAdminList_domain_quota'] = 'Domein quota (MB)';
 $PALANG['pAdminList_domain_backupmx'] = 'Back-up MX';
-$PALANG['pAdminList-tls_policy'] = 'TLS Policy';
 $PALANG['last_modified'] = 'Laatst bewerkt';
 
 $PALANG['pAdminCreate_domain_welcome'] = 'Voeg een nieuw domein toe';
@@ -319,7 +318,7 @@ $PALANG['pAdminEdit_domain_quota'] = 'Domein Quota';
 $PALANG['transport'] = 'Transport';
 $PALANG['backupmx'] = 'Backup-MX';
 $PALANG['pAdminEdit_domain_transport_text'] = 'Definieer transport';
-$PALANG['pAdminEdit_domain_backupmx'] = 'Definieer of deze Mailserver een Backup MX is voor het domain';
+$PALANG['pAdminEdit_domain_backupmx'] = 'Mailserver is Backup MX';
 $PALANG['pAdminEdit_domain_result_error'] = 'Het bewerken van domein %s is mislukt!';
 
 $PALANG['pAdminCreate_admin_welcome'] = 'Voeg een nieuw domein beheerder toe';

--- a/public/edit-forward.php
+++ b/public/edit-forward.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Postfix Admin
+ *
+ * LICENSE
+ * This source file is subject to the GPL license that is bundled with
+ * this package in the file LICENSE.TXT.
+ *
+ * Further details on the project are available at http://postfixadmin.sf.net
+ *
+ * @version $Id$
+ * @license GNU GPL v2 or later.
+ *
+ * File: edit-forward.php
+ * Users can use this to set forwards etc for their mailbox.
+ * Admin can set forwards for there users
+ *
+ * Template File: edit_forward.tpl
+ *
+ */
+
+require_once('../common.php');
+
+$CONF= Config::getInstance()->getAll();
+$smarty = PFASmarty::getInstance();
+$smarty->configureTheme('../');
+
+$smarty->assign('smarty_template', 'edit_forward');
+
+// authentication_require_role('user');
+// $USERID_USERNAME = authentication_get_username();
+
+// only allow admins to change someone else's 'stuff'
+if (authentication_has_role('admin')) {
+    $Admin_role = 1;
+    $USERID_USERNAME = safeget('username');
+    list(/*NULL*/, $fDomain) = explode('@', $USERID_USERNAME);
+    $Return_url = "list-virtual.php?domain=" . urlencode($fDomain);
+
+//echo "<pre>" . json_encode($USERID_USERNAME, JSON_PRETTY_PRINT); 
+//die('check ^');
+
+    # TODO: better check for valid username (check if mailbox exists)
+    # TODO: (should be done in VacationHandler)
+    if ($fDomain == '' || !check_owner(authentication_get_username(), $fDomain)) {
+        die("Invalid username!"); # TODO: better error message
+    }
+} else {
+    $Admin_role = 0;
+    $Return_url = "main.php";
+    authentication_require_role('user');
+    $USERID_USERNAME = authentication_get_username();
+}
+
+$smarty->assign('return_url', $Return_url);
+
+
+// is edit-alias support enabled in $CONF ?
+if (! Config::bool('edit_alias')) {
+    header("Location: main.php");
+    exit(0);
+}
+
+$ah = new AliasHandler();
+$ah->init($USERID_USERNAME);
+
+$smarty->assign('USERID_USERNAME', $USERID_USERNAME);
+
+
+if (! $ah->view()) {
+    die("Can't get alias details. Invalid alias?");
+} # this can only happen if a admin deleted the user since the user logged in
+$result = $ah->result();
+$tGotoArray = $result['goto'];
+$tStoreAndForward = $result['goto_mailbox'];
+
+if ($_SERVER['REQUEST_METHOD'] == "GET") {
+    if ($tStoreAndForward) {
+        $smarty->assign('forward_and_store', ' checked="checked"');
+        $smarty->assign('forward_only', '');
+    } else {
+        $smarty->assign('forward_and_store', '');
+        $smarty->assign('forward_only', ' checked="checked"');
+    }
+
+    $smarty->assign('tGotoArray', $tGotoArray);
+    $smarty->display('index.tpl');
+}
+
+if ($_SERVER['REQUEST_METHOD'] == "POST") {
+    if (safepost('token') != $_SESSION['PFA_token']) {
+        die('Invalid token!');
+    }
+
+    // user clicked on cancel button
+    if (isset($_POST['fCancel'])) {
+        header("Location: main.php");
+        exit(0);
+    }
+
+    $fGoto = trim(safepost('fGoto'));
+    $fForward_and_store = safepost('fForward_and_store');
+
+    # TODO: use edit.php (or create a edit_user.php)
+    # TODO: this will obsolete lots of the code below (parsing $goto and the error checks)
+
+    $goto = strtolower($fGoto);
+    $goto = preg_replace('/\\\r\\\n/', ',', $goto);
+    $goto = preg_replace('/\r\n/', ',', $goto);
+    $goto = preg_replace('/,[\s]+/i', ',', $goto);
+    $goto = preg_replace('/[\s]+,/i', ',', $goto);
+    $goto = preg_replace('/\,*$/', '', $goto);
+
+    $goto = explode(",", $goto);
+
+    $error = 0;
+    $goto = array_merge(array_unique($goto));
+    $good_goto = array();
+
+    if ($fForward_and_store != 1 && sizeof($goto) == 1 && $goto[0] == '') {
+        flash_error($PALANG['pEdit_alias_goto_text_error1']);
+        $error += 1;
+    }
+    if ($error === 0) {
+        foreach ($goto as $address) {
+            if ($address != "") { # $goto[] may contain a "" element
+                # TODO - from https://sourceforge.net/tracker/?func=detail&aid=3027375&group_id=191583&atid=937964
+                # The not-so-good news is that some internals of edit-alias aren't too nice
+                # - for example, $goto[] can contain an element with empty string. I added a
+                # check for that in the 2.3 branch, but we should use a better solution
+                # (avoid empty elements in $goto) in trunk ;-)
+                $email_check = check_email($address);
+                if ($email_check != '') {
+                    $error += 1;
+                    flash_error("$address: $email_check");
+                } else {
+                    $good_goto[] = $address;
+                }
+            }
+        }
+    }
+
+    if ($error == 0) {
+        $values = array(
+            'goto'          => $good_goto,
+            'goto_mailbox'  => $fForward_and_store,
+        );
+
+        if (!$ah->set($values)) {
+            $errormsg = $ah->errormsg;
+            flash_error($errormsg[0]);
+        }
+
+        $updated = $ah->save();
+
+        if ($updated) {
+            header("Location: main.php");
+            exit;
+        }
+        flash_error($PALANG['pEdit_alias_result_error']);
+    } else {
+        $tGotoArray = $goto;
+    }
+    $smarty->assign('tGotoArray', $tGotoArray);
+    if ($fForward_and_store == 1) {
+        $smarty->assign('forward_and_store', ' checked="checked"');
+        $smarty->assign('forward_only', '');
+    } else {
+        $smarty->assign('forward_and_store', '');
+        $smarty->assign('forward_only', ' checked="checked"');
+    }
+    $smarty->display('index.tpl');
+}
+
+/* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/public/users/edit-forward.php
+++ b/public/users/edit-forward.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Postfix Admin
+ *
+ * LICENSE
+ * This source file is subject to the GPL license that is bundled with
+ * this package in the file LICENSE.TXT.
+ *
+ * Further details on the project are available at http://postfixadmin.sf.net
+ *
+ * @version $Id$
+ * @license GNU GPL v2 or later.
+ *
+ * File: edit-forward.php
+ * Responsible for allowing users to update their forwarding status.
+ *
+ */
+
+require_once('../common.php');
+
+$smarty = PFASmarty::getInstance();
+$smarty->configureTheme('../');
+require_once('../edit-forward.php');
+
+/* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/templates/edit_forward.tpl
+++ b/templates/edit_forward.tpl
@@ -1,0 +1,50 @@
+<form name="alias" method="post" action="" class="form-horizontal">
+    <div id="edit_form" class="panel panel-default">
+        <div class="panel-heading"><h4>{$PALANG.pEdit_alias_welcome}</h4></div>
+        <div class="panel-body enable-asterisk">
+            <input class="flat" type="hidden" name="token" value="{$smarty.session.PFA_token|escape:"url"}"/>
+            <p class="text-center"><em>{$PALANG.pEdit_alias_help}</em></p>
+            <div class="form-group">
+                <label class="col-md-4 col-sm-4 control-label">{$PALANG.alias}:</label>
+                <div class="col-md-6 col-sm-8"><p class="form-control-static"><em>{$USERID_USERNAME}</em></p></div>
+            </div>
+            <div class="form-group">
+                <label class="col-md-4 col-sm-4 control-label" for="fGoto">{$PALANG.to}:</label>
+                <div class="col-md-6 col-sm-8">
+                    <textarea class="form-control" rows="8" cols="50" name="fGoto"
+                              id="fGoto">{foreach key=key2 item=field2 from=$tGotoArray}{$field2}&#10;{/foreach}</textarea>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-md-4 col-sm-4 control-label"></label>
+                <div class="col-md-6 col-sm-8">
+                    <div class="radio">
+                        <label>
+                            <input type="radio" name="fForward_and_store" id="fForward_and_store1"
+                                   value="1"{$forward_and_store}/>
+                            {$PALANG.pEdit_alias_forward_and_store}
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <input type="radio" name="fForward_and_store" id="fForward_and_store0"
+                                   value="0" {$forward_only}/>
+                            {$PALANG.pEdit_alias_forward_only}
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="panel-footer">
+
+            <div class="btn-toolbar">
+                <div class="pull-right">
+                    <a href="main.php" class="mr btn btn-secondary">{$PALANG.exit}</a>
+
+                    <button class="ml btn btn-lg btn-primary" type="submit" name="submit" value="{$PALANG.save}">{$PALANG.save}</butt>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</form>

--- a/templates/list-virtual_mailbox.tpl
+++ b/templates/list-virtual_mailbox.tpl
@@ -92,7 +92,7 @@
 			{if $authentication_has_role.global_admin!==true && $CONF.alias_control_admin===YES}{assign var="edit_aliases" value=1}{/if}
 			{if $authentication_has_role.global_admin==true && $CONF.alias_control===YES}{assign var="edit_aliases" value=1}{/if}
 			{if $edit_aliases==1}
-				<td><a class="btn btn-primary" href="edit.php?table=alias&amp;edit={$item.username|escape:"url"}"><span class="glyphicon glyphicon-envelope" aria-hidden="true"></span> {$PALANG.alias}</a></td>
+				<td><a class="btn btn-primary" href="edit-forward.php?username={$item.username|escape:"url"}"><span class="glyphicon glyphicon-envelope" aria-hidden="true"></span> {$PALANG.alias}</a></td>
 			{/if}
 			<td><a class="btn btn-primary" href="edit.php?table=mailbox&amp;edit={$item.username|escape:"url"}"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span> {$PALANG.edit}</a></td>
 			<td>

--- a/templates/users_menu.tpl
+++ b/templates/users_menu.tpl
@@ -20,7 +20,7 @@
                     <li><a target="_top" href="{#url_user_vacation#}">{$PALANG.pUsersMenu_vacation}</a></li>
                 {/if}
                 {if $CONF.edit_alias===YES}
-                    <li><a target="_top" href="{#url_user_edit_alias#}">{$PALANG.pUsersMenu_edit_alias}</a></li>
+                    <li><a target="_top" href="{#url_user_edit_forward#}">{$PALANG.pUsersMenu_edit_forward}</a></li>
                 {/if}
                 <li><a target="_top" href="{#url_user_password#}">{$PALANG.change_password}</a></li>
                 <li class="logout"><a target="_top" href="{#url_user_logout#}">{$PALANG.pMenu_logout}</a></li>


### PR DESCRIPTION
.../public/users/edit-alias.php renamed to .../public/edit-forward.php and modified so admins can use it too.
As was done at .../public/user/vacation.php and .../public/vacation.php
 
.../public/users/edit-forward.php added.
This provides a reference to .../public/edit-forward.php.
.../public/edit-forward.php uses .../templates/edit-forward.tpl as template this was .../templates/edit-alias.tpl

This allows .../public/user/edit-alias.php and .../templates/edit-alias.tpl to be dropped

Made changes in .../templates/list-virtual_mailbos.tpl , .../templates/user_menu.tpl and .../config/menu.conf so that they now cause .../public/edit-forward .php is called for both users and admins.


TODO
        .../public/edit-forward.php to use templates/editform.tpl at David Goodwin's request to reduce the number of templates.