### PR TITLE
Fix CSV alias export

### DIFF
--- a/public/list.php
+++ b/public/list.php
@@ -120,7 +120,7 @@ if (safeget('output') == 'csv') {
     $columns = array();
     foreach ($handler->getStruct() as $key => $field) {
         $label = trim($field['label']);
-        if ($field['display_in_list'] && $label != '') { # don't show fields without a label
+        if ($field['display_in_list'] && $label != '' && $label != ' ') { # don't show fields without a label and those with a whitespace
             $header[] = html_entity_decode($label, ENT_COMPAT | ENT_HTML401, 'UTF-8');
             $columns[] = $key;
         }


### PR DESCRIPTION
Currently, exporting the alias list to CSV, the first column label is only a whitespace. For some reason the contents of this column consists of a long concatenation of "nbsp;"s.
This fix ignores the whitespace column label and gets rid of the "nbsp;nbsp;......" contents of this column.
This was successfully tested on a running installation of postfixadmin 3.2 on a Debian 11 system.

The current CSV export looks like this:
`" ";Alias;To;"Deliver to the local mailbox.";"Auto Response";"Last modified";Active
"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";some_alias@anonymized_mailbox;Array;0;0;2018-07-02;1
"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";another_alias@anonymized_mailbox;Array;0;0;2022-02-19;1`

With the fix the CSV looks like this:
`Alias;To;"Deliver to the local mailbox.";"Auto Response";"Last modified";Active
some_alias@anonymized_mailbox;Array;0;0;2018-07-02;1
another_alias@anonymized_mailbox;Array;0;0;2022-02-19;1`
