### PR TITLE
Javascript validation of username to prevent illegal characters

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -251,6 +251,13 @@ $CONF['password_validation'] = array(
     // 'length_check'          => function($password) { if (strlen(trim($password)) < 3) { return 'password_too_short'; } },
 );
 
+// Username legal characters
+// New/changed usernames will be checked against this regular expression with javascript
+// during entry, offending characters not displaying.
+// For example:
+// $CONF['username_legal_chars'] = '^[a-zA-Z0-9-_.]+$';
+$CONF['username_legal_chars'] = '';
+
 // Generate Password
 // Generate a random password for a mailbox or admin and display it.
 // If you want to automagically generate passwords set this to 'YES'.

--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -441,6 +441,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -440,6 +440,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Caràcter il·legal';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -440,6 +440,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = '非法性质';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -454,6 +454,8 @@ $PALANG['password_expiration_desc'] = 'Datum expirace hesla';
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Nelegální charakter';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -454,6 +454,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
   
+$PALANG['pLegal_char_warning'] = 'Ulovlig figur';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -452,6 +452,8 @@ $PALANG['password_expiration_desc'] = 'Datum, an dem das Passwort abläuft';
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegaler Charakter';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -457,7 +457,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire';
 
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX
-
+$PALANG['pLegal_char_warning']              = 'Illegal character';
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -442,6 +442,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Carácter ilegal';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -444,6 +444,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -439,6 +439,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -440,6 +440,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Laitonta luonnetta';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -445,6 +445,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -445,6 +445,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Caractère illégal';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -440,6 +440,8 @@ $PALANG['password_expiration_desc'] = 'Data na que expirará o contrasinal'; # X
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -439,6 +439,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -453,6 +453,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegális karakter';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -440,6 +440,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -441,6 +441,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Carattere illegale';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -451,6 +451,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = '違法な性格';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -446,6 +446,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -441,6 +441,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -441,6 +441,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -444,6 +444,8 @@ $PALANG['password_expiration_desc']         = 'Aantal dagen waarnaar het wachtwo
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX
 $PALANG['To_Forward_Only']                  = 'Alleen Doorsturen'; # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegaal karakter';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -440,6 +440,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -446,6 +446,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Nielegalny charakter';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -453,6 +453,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Característica ilegítima';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/pt-pt.lang
+++ b/languages/pt-pt.lang
@@ -453,6 +453,8 @@ $PALANG['password_expiration_desc'] = 'Data de quando a password irá expirar'; 
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Característica ilegítima';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -452,6 +452,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -454,6 +454,8 @@ $PALANG['password_expiration_desc'] = 'Дата истечения срока д
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Незаконный характер';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -441,6 +441,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Nelegálne charakter';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -440,6 +440,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Illegal character';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -453,6 +453,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Olaglig karaktär';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -440,6 +440,8 @@ $PALANG['password_expiration_desc'] = 'Şifrenin geçerlilik süresinin doluş t
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Yasadışı karakter';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -442,6 +442,8 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = '非法性质';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/ua.lang
+++ b/languages/ua.lang
@@ -455,6 +455,8 @@ $PALANG['password_expiration_desc'] = 'Кількість днів дії пар
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
+$PALANG['pLegal_char_warning'] = 'Нелегальний характер';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -31,7 +31,7 @@ class MailboxHandler extends PFAHandler
             #                           editing?    form    list
             'username'         => pacol($this->new, 1,      1,      'mail', 'pEdit_mailbox_username'        , ''                                , '' ),
             'local_part'       => pacol($this->new, 0,      0,      'text', 'pEdit_mailbox_username'        , ''                                , '',
-                /*options*/ array('legal_chars' => Config::read('username_legal_chars'))
+                /*options*/ array('legal_chars' => Config::read('username_legal_chars'), 'legal_char_warning' => Config::lang('pLegal_char_warning'))
             ),
             'domain'           => pacol($this->new, 0,      1,      'enum', ''                              , ''                                , '',
                 /*options*/ $this->allowed_domains      ),

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -30,7 +30,9 @@ class MailboxHandler extends PFAHandler
             # field name                allow       display in...   type    $PALANG label                     $PALANG description                 default / options / ...
             #                           editing?    form    list
             'username'         => pacol($this->new, 1,      1,      'mail', 'pEdit_mailbox_username'        , ''                                , '' ),
-            'local_part'       => pacol($this->new, 0,      0,      'text', 'pEdit_mailbox_username'        , ''                                , '' ),
+            'local_part'       => pacol($this->new, 0,      0,      'text', 'pEdit_mailbox_username'        , ''                                , '',
+                /*options*/ array('legal_chars' => Config::read('username_legal_chars'))
+            ),
             'domain'           => pacol($this->new, 0,      1,      'enum', ''                              , ''                                , '',
                 /*options*/ $this->allowed_domains      ),
             # TODO: maildir: display in list is needed to include maildir in SQL result (for post_edit hook)

--- a/templates/editform.tpl
+++ b/templates/editform.tpl
@@ -120,12 +120,19 @@
         }
         {if $struct.local_part.options.legal_chars }
                 // If set: Check for illegal characters in local part of username
+
+                // decode htmlentities
+                var div = document.createElement('div');
+                div.innerHTML = "{$struct.local_part.options.legal_char_warning}";
+                var decoded = div.firstChild.nodeValue;
+
                 const local_part = document.getElementsByName("value[local_part]");
                 local_part[0].tabIndex = -1
                 local_part[0].addEventListener("keydown", function(event){
                         var regex = new RegExp("{$struct.local_part.options.legal_chars}");
                         if (!regex.test(event.key)) {
                                 event.preventDefault();
+                                alert(decoded + ": " + event.key);
                                 return false;
                         }
                 });

--- a/templates/editform.tpl
+++ b/templates/editform.tpl
@@ -118,5 +118,16 @@
 
                 }
         }
-
+        {if $struct.local_part.options.legal_chars }
+                // If set: Check for illegal characters in local part of username
+                const local_part = document.getElementsByName("value[local_part]");
+                local_part[0].tabIndex = -1
+                local_part[0].addEventListener("keydown", function(event){
+                        var regex = new RegExp("{$struct.local_part.options.legal_chars}");
+                        if (!regex.test(event.key)) {
+                                event.preventDefault();
+                                return false;
+                        }
+                });
+        {/if}
 </script>


### PR DESCRIPTION
We've had problems with users entering a local_part containing characters later disliked by postfix or dovecot. This PR adds a javascript check on keystroke against a configurable regex and refuses to accept forbidden characters (now with helpful/annoying js-alert...).

There is no check at save as this is not a security-relevant issue, more of a service for the user.