### PR TITLE
Add missing "# XXX" to failed translations

### DIFF
--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -441,7 +441,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -444,7 +444,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -439,7 +439,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -445,7 +445,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -440,7 +440,7 @@ $PALANG['password_expiration_desc'] = 'Data na que expirará o contrasinal'; # X
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -439,7 +439,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -440,7 +440,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -446,7 +446,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -441,7 +441,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -441,7 +441,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -440,7 +440,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -452,7 +452,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -440,7 +440,7 @@ $PALANG['password_expiration_desc'] = 'Date when password will expire'; # XXX
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX # XXX
 
-$PALANG['pLegal_char_warning'] = 'Illegal character';
+$PALANG['pLegal_char_warning'] = 'Illegal character'; # XXX
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */


### PR DESCRIPTION
As @cboltz pointed out I had missed adding the "XXX" to failed translations defaulting to english in https://github.com/postfixadmin/postfixadmin/pull/765