### PR TITLE
try removing support for php7.2/7.3 and add 8.3 to github build

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -9,6 +9,7 @@
 MASTER (should have all changes from 3.3.10 plus)
 ------
 
+   - Update composer's PHP requirement to PHP 7.4+ (which matches Wordpress etc, PHP project is supporting 8.1<->8.3)
    - Make fetchmail.pl respect src_port (thanks @tempixx - see #784)
    - Improve github action (php 8.2)
    - Add Javascript username validation to prevent illegal characters (see #765; thanks @verdinago)


### PR DESCRIPTION
remove official support for PHP < 7.4 (i.e. postfixadmin would require PHP 7.4 or above)

add github build support for php 8.3

