### PR TITLE
Add a flag to mailbox table for enable/disable smtp protocol

### DIFF
--- a/DOCUMENTS/DOVECOT.txt
+++ b/DOCUMENTS/DOVECOT.txt
@@ -147,7 +147,12 @@ iterate_query = SELECT username as user FROM mailbox WHERE active = '1'
 
 #END /etc/dovecot/dovecot-sql.conf
 
+If you make use of the separate smtp_active flag in the mailbox table of postfixadmin by 
+enabling the configuration parameter $CONF['smtp_active_flag'] = YES in postfixadmin configuration
+and you're using dovecot sasl with postfix, the dovecot queries can be updated to use the different flag for smtp:
 
+password_query = SELECT username AS user,password FROM mailbox WHERE username = '%u' AND (('%s' = 'smtp' AND smtp_active = '1') OR ('%s' <> 'smtp' AND active = '1'))
+user_query = SELECT CONCAT('/var/mail/vmail/', maildir) AS home, 1001 AS uid, 1001 AS gid, CONCAT('*:bytes=', quota) AS quota_rule FROM mailbox WHERE username = '%u' AND (('%s' = 'smtp' AND smtp_active = '1') OR ('%s' <> 'smtp' AND active = '1'))
 
 3. Permissions
 --------------

--- a/DOCUMENTS/POSTFIX_CONF.txt
+++ b/DOCUMENTS/POSTFIX_CONF.txt
@@ -32,6 +32,36 @@ transport_maps = proxy:mysql:/etc/postfix/sql/mysql_transport_maps.cf
 virtual_mailbox_base = /var/mail/vmail
 # or whereever you want to store the mails
 
+If you are using dovecot sasl for authentication you can configure Postfix main.cf:
+
+smtpd_sasl_path = private/auth
+smtpd_sasl_type = dovecot
+smtpd_sasl_authenticated_header = yes
+
+If using the Postfix submission service you could configure as follows in master.cf
+
+submission inet n      -       n       -       -       smtpd
+        -o syslog_name=postfix/submission
+        -o stress=
+        -o smtpd_sasl_auth_enable=yes
+        -o smtpd_delay_reject=no
+        -o smtpd_etrn_restrictions=reject
+        -o smtpd_helo_restrictions=
+        -o smtpd_client_restrictions=submission_client_checks
+        -o smtpd_sender_restrictions=submission_sender_checks
+        -o smtpd_recipient_restrictions=submission_recipient_checks
+        -o smtpd_tls_security_level=encrypt
+
+and in main.cf:
+
+smtpd_sender_login_maps = proxy:mysql:/etc/postfix/mysql-login_maps_dovecot.cf
+smtpd_sasl_auth_enable = no
+smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated reject_unauth_destination
+smtpd_restriction_classes = submission_recipient_checks, submission_sender_checks
+submission_recipient_checks = reject_unknown_recipient_domain,permit_sasl_authenticated,reject_unauth_destination
+submission_sender_checks = reject_sender_login_mismatch
+submission_client_checks = permit_sasl_authenticated,reject_unauth_destination
+
 Where you chose to store the .cf files doesn't really matter, but they will
 have database passwords stored in plain text so they should be readable only
 by user postfix, or in a directory only accessible to user postfix.

--- a/config.inc.php
+++ b/config.inc.php
@@ -802,6 +802,17 @@ $CONF['site_url'] = null;
 
 $CONF['version'] = '3.4-dev';
 
+// The smtp_active_flag when set to YES enables editing of the smtp_active 
+// field of the mailbox table. The smtp_active field can be used to enable
+// or disable smtp sending for a mailbox separately to other mailbox functions.  
+// This can be useful if you want the ability to stop a user sending email 
+// while still allowing receipt of new mail and reading existing email. 
+// Please refer to DOCUMENTS/DOVECOT.txt for an example of how to configure this.
+// The default is NO for backwards compatibility. Only enable this if you
+// have also set up the SQL queries that make use of the smtp_active field
+// in your Dovecot SQL configuration.
+$CONF['smtp_active_flag'] = 'NO';
+
 // If you want to keep most settings at default values and/or want to ensure
 // that future updates work without problems, you can use a separate config 
 // file (config.local.php) instead of editing this file and override some

--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -83,6 +83,7 @@ $PALANG['pOverview_welcome'] = 'Преглед на ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'От';
 $PALANG['active'] = 'Активен';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'Е-мейл';
 $PALANG['name'] = 'Име';

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -81,6 +81,7 @@ $PALANG['pOverview_welcome'] = 'Resum de ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'De';
 $PALANG['active'] = 'Actiu';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'E-mail'; # XXX
 $PALANG['name'] = 'Nom';

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = '浏览 ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = '前往';
 $PALANG['active'] = '活动';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = '邮件地址';
 $PALANG['name'] = '姓名';

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -90,6 +90,7 @@ $PALANG['pOverview_welcome'] = 'Přehled domény ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Přesměrované domény';
 $PALANG['pOverview_alias_address'] = 'Od';
 $PALANG['active'] = 'Aktivní';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[a %s dalších...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Jméno';

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -86,6 +86,7 @@ $PALANG['pOverview_welcome'] = 'Oversigt for ';
 $PALANG['pOverview_alias_domain_aliases']  = 'Alias domæner';
 $PALANG['pOverview_alias_address'] = 'Alias';
 $PALANG['active'] = 'Aktiv';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[og %s til...]';
 $PALANG['pOverview_mailbox_username'] = 'Emailadresse';
 $PALANG['name'] = 'Navn';

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Überblick über ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias-Domains';
 $PALANG['pOverview_alias_address'] = 'Von';
 $PALANG['active'] = 'Aktiv';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[und %s weitere...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Name';

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -90,6 +90,7 @@ $PALANG['pOverview_welcome'] = 'Overview for ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains';
 $PALANG['pOverview_alias_address'] = 'From';
 $PALANG['active'] = 'Active';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Name';

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Resumen de ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias de Dominios'; 
 $PALANG['pOverview_alias_address'] = 'De';
 $PALANG['active'] = 'Activo'; 
+$PALANG['smtp_active'] = 'Smtp'; 
 $PALANG['and_x_more'] = '[y %s más...]'; 
 $PALANG['pOverview_mailbox_username'] = 'E-mail';
 $PALANG['name'] = 'Nombre';

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Ülevaade domeenist: ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Kellelt';
 $PALANG['active'] = 'Aktiivne';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'E-posti aadress';
 $PALANG['name'] = 'Nimi';

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -81,6 +81,7 @@ $PALANG['pOverview_welcome'] = 'Laburpena ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Igorlea';
 $PALANG['active'] = 'Aktibatua';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'E-mail';
 $PALANG['name'] = 'Izena';

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -83,6 +83,7 @@ $PALANG['pOverview_welcome'] = 'Yleisnäkymä ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domainit';
 $PALANG['pOverview_alias_address'] = 'Keneltä';
 $PALANG['active'] = 'Aktiivinen';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[ja %s lisää...]';
 $PALANG['pOverview_mailbox_username'] = 'Sähköposti';
 $PALANG['name'] = 'Nimi';

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Yvirlit yvir ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Frá';
 $PALANG['active'] = 'Virkin';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'E-post';
 $PALANG['name'] = 'Navn';

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -86,6 +86,7 @@ $PALANG['pOverview_welcome'] = 'Vue d\'ensemble pour ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias de domaines';
 $PALANG['pOverview_alias_address'] = 'De';
 $PALANG['active'] = 'Actif';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[et %s en plus...]';
 $PALANG['pOverview_mailbox_username'] = 'courriel';
 $PALANG['name'] = 'Nom';

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -80,6 +80,7 @@ $PALANG['pOverview_welcome'] = 'Resumo de ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias de Dominios'; 
 $PALANG['pOverview_alias_address'] = 'De';
 $PALANG['active'] = 'Activo'; 
+$PALANG['smtp_active'] = 'Smtp'; 
 $PALANG['and_x_more'] = '[e %s máis...]'; 
 $PALANG['pOverview_mailbox_username'] = 'E-mail';
 $PALANG['name'] = 'Nome';

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -81,6 +81,7 @@ $PALANG['pOverview_welcome'] = 'Pregled za ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Od';
 $PALANG['active'] = 'Aktivan';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'E-pota';
 $PALANG['name'] = 'Ime';

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -83,6 +83,7 @@ $PALANG['pOverview_welcome'] = 'Áttekintés: ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Honnan';
 $PALANG['active'] = 'Aktív';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Név';

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Yfirlit fyrir ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Póstur fyrir';
 $PALANG['active'] = 'Virkt';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'Póstfang';
 $PALANG['name'] = 'Nafn notanda'; # XXX check text - should be 'Name'

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Resoconto per ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias di Dominio';
 $PALANG['pOverview_alias_address'] = 'Da';
 $PALANG['active'] = 'Attivo';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[più %s altri...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Nome';

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = '概要 ';
 $PALANG['pOverview_alias_domain_aliases'] = 'エイリアスドメイン';
 $PALANG['pOverview_alias_address'] = '転送元';
 $PALANG['active'] = 'アクティブ';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[その他 %s 個]';
 $PALANG['pOverview_mailbox_username'] = 'メールアドレス';
 $PALANG['name'] = '名前';

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Peržiūra ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Srities sinonimai';
 $PALANG['pOverview_alias_address'] = 'Iš';
 $PALANG['active'] = 'Įjungtas'; # XXX check text - should be 'Active'
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[ir %s daugiau...]';
 $PALANG['pOverview_mailbox_username'] = 'El.paštas';
 $PALANG['name'] = 'Vardas';

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Преглед за ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Од';
 $PALANG['active'] = 'Активен';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'Адреса';
 $PALANG['name'] = 'Име';

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Oversikt for ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Aliasdomener';
 $PALANG['pOverview_alias_address'] = 'Fra';
 $PALANG['active'] = 'Aktiv';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[og %s flere...]';
 $PALANG['pOverview_mailbox_username'] = 'E-post';
 $PALANG['name'] = 'Navn';

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Overzicht voor ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias domeinen';
 $PALANG['pOverview_alias_address'] = 'Van';
 $PALANG['active'] = 'Actief';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[en %s meer...]';
 $PALANG['pOverview_mailbox_username'] = 'e-mail';
 $PALANG['name'] = 'Naam';

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Oversikt for ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Fra';
 $PALANG['active'] = 'Aktiv'; # XXX check text - should be 'Active'
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'E-post';
 $PALANG['name'] = 'Nann'; # XXX check text - should be 'Name'

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -85,6 +85,7 @@ $PALANG['pOverview_welcome'] = 'Dane zbiorcze dla domeny ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Domeny aliasowe';
 $PALANG['pOverview_alias_address'] = 'Od';
 $PALANG['active'] = 'Aktywny';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[i %s wiecej...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Nazwa';

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Visão geral de ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Aliases de Domínio';
 $PALANG['pOverview_alias_address'] = 'De';
 $PALANG['active'] = 'Habilitado';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[e %s mais...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Nome';

--- a/languages/pt-pt.lang
+++ b/languages/pt-pt.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Visão geral de ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Aliases de Domínio';
 $PALANG['pOverview_alias_address'] = 'De';
 $PALANG['active'] = 'Activado';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[e %s mais...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Nome';

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -83,6 +83,7 @@ $PALANG['pOverview_welcome'] = 'Vizualizare pentru ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Domenii alias';
 $PALANG['pOverview_alias_address'] = 'De la';
 $PALANG['active'] = 'Activ';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[inca %s ...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Nume';

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -86,6 +86,7 @@ $PALANG['pOverview_welcome'] = 'Обзор для ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Алиасы доменов';
 $PALANG['pOverview_alias_address'] = 'От';
 $PALANG['active'] = 'Активен';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[и еще %s...]';
 $PALANG['pOverview_mailbox_username'] = 'Ящик';
 $PALANG['name'] = 'Имя';

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -83,6 +83,7 @@ $PALANG['pOverview_welcome'] = 'Prehľad pre doménu ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Aliasy domén';
 $PALANG['pOverview_alias_address'] = 'Od';
 $PALANG['active'] = 'Aktívny';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[a %s ďalších...]';
 $PALANG['pOverview_mailbox_username'] = 'Email';
 $PALANG['name'] = 'Meno';

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Pregled za ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domains'; # XXX
 $PALANG['pOverview_alias_address'] = 'Od';
 $PALANG['active'] = 'Aktiven';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = 'E-pošta';
 $PALANG['name'] = 'Ime';

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -85,6 +85,7 @@ $PALANG['pOverview_welcome'] = 'Sammanfattning för ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Domänalias';
 $PALANG['pOverview_alias_address'] = 'Från';
 $PALANG['active'] = 'Aktiv';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[och %s mer...]';
 $PALANG['pOverview_mailbox_username'] = 'E-post';
 $PALANG['name'] = 'Namn';

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -82,6 +82,7 @@ $PALANG['pOverview_welcome'] = 'Genel Bilgiler: ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Alias Domainleri';
 $PALANG['pOverview_alias_address'] = 'Kimden';
 $PALANG['active'] = 'Aktif';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[ve %s daha fazla...]';
 $PALANG['pOverview_mailbox_username'] = 'E-posta';
 $PALANG['name'] = 'İsim';

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -83,6 +83,7 @@ $PALANG['pOverview_welcome'] = '瀏覽 ';
 $PALANG['pOverview_alias_domain_aliases'] = '網域名';
 $PALANG['pOverview_alias_address'] = '前往';
 $PALANG['active'] = '生效';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[and %s more...]'; # XXX
 $PALANG['pOverview_mailbox_username'] = '郵件地址';
 $PALANG['name'] = '姓名';

--- a/languages/ua.lang
+++ b/languages/ua.lang
@@ -84,6 +84,7 @@ $PALANG['pOverview_welcome'] = 'Огляд для ';
 $PALANG['pOverview_alias_domain_aliases'] = 'Псевдоними (аліаси) доменів';
 $PALANG['pOverview_alias_address'] = 'Від кого';
 $PALANG['active'] = 'Активний';
+$PALANG['smtp_active'] = 'Smtp';
 $PALANG['and_x_more'] = '[та ще %s...]';
 $PALANG['pOverview_mailbox_username'] = 'Поштова адреса (Email)';
 $PALANG['name'] = 'Ім&#0039;я';

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -16,6 +16,7 @@ class MailboxHandler extends PFAHandler
     protected function initStruct()
     {
         $passwordReset = (int) ( Config::bool('forgotten_user_password_reset') && !Config::read('mailbox_postpassword_script') );
+        $smtpActiveFlag = (int) ( Config::bool('smtp_active_flag') );
         $reset_by_sms = 0;
         if ($passwordReset && Config::read_string('sms_send_function')) {
             $reset_by_sms = 1;
@@ -50,6 +51,7 @@ class MailboxHandler extends PFAHandler
             # read_from_db_postprocess() also sets 'quotabytes' for use in init()
             # TODO: read used quota from quota/quota2 table
             'active'           => pacol(1,          1,      1,      'bool', 'active'                        , ''                                 , 1 ),
+            'smtp_active'      => pacol($smtpActiveFlag, $smtpActiveFlag,0,      'bool', 'smtp_active'                   , ''                                 , 1 ),
             'welcome_mail'     => pacol($this->new, $this->new, 0,  'bool', 'pCreate_mailbox_mail'          , ''                                 , 1,
                 /*options*/ array(),
                 /*not_in_db*/ 1             ),

--- a/public/editactive.php
+++ b/public/editactive.php
@@ -28,7 +28,9 @@ $username = authentication_get_username(); # enforce login
 
 $id = safeget('id');
 $table = safeget('table');
+$field = safeget('field');
 $active = safeget('active');
+if ($field === '') $field = 'active';
 
 if (empty($table)) {
     die("Invalid table name given");
@@ -47,11 +49,21 @@ $formconf = $handler->webformConfig();
 authentication_require_role($formconf['required_role']);
 
 if ($handler->init($id)) { # errors will be displayed as last step anyway, no need for duplicated code ;-)
+    if ($table == 'mailbox') {
+        if ($field != 'active' && $field != 'smtp_active') {
+            die(Config::Lang('invalid_parameter'));
+        }
+    } else {
+        if ($field != 'active') {
+            die(Config::Lang('invalid_parameter'));
+        }
+    }
+
     if ($active != '0' && $active != '1') {
         die(Config::Lang('invalid_parameter'));
     }
 
-    if ($handler->set(array('active' => $active))) {
+    if ($handler->set(array($field => $active))) {
         $handler->save();
     }
 }

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2349,3 +2349,7 @@ function upgrade_1849_sqlite()
             )
         ");
 }
+
+function upgrade_1850() {
+    _db_add_field('mailbox',  'smtp_active', 'int DEFAULT 1');
+}

--- a/templates/list-virtual_mailbox.tpl
+++ b/templates/list-virtual_mailbox.tpl
@@ -15,6 +15,7 @@
 		{if $CONF.quota===YES}<th>{$PALANG.pOverview_mailbox_quota}</th>{/if}
 		<th>{$PALANG.last_modified}</th>
 		<th>{$PALANG.active}</th>
+		{if $CONF.smtp_active_flag===YES}<th>{$PALANG.smtp_active}</th>{/if}
 		{assign var="colspan" value="`$colspan-6`"}
 		<th colspan="{$colspan}">&nbsp;</th>
 	</tr>
@@ -76,6 +77,10 @@
 			<td>{$item.modified}</td>
 			<td><a class="btn btn-{if ($item.active==0)}info{else}warning{/if}" href="{#url_editactive#}mailbox&amp;id={$item.username|escape:"url"}&amp;active={if ($item.active==0)}1{else}0{/if}&amp;token={$smarty.session.PFA_token|escape:"url"}"
 				>{if $item.active==1}<span class="glyphicon glyphicon-check" aria-hidden="true"></span> {$PALANG.YES}{else}<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span> {$PALANG.NO}{/if}</a></td>
+                        {if $CONF.smtp_active_flag===YES}
+				<td><a class="btn btn-{if ($item.smtp_active==0)}info{else}warning{/if}" href="{#url_editactive#}mailbox&amp;id={$item.username|escape:"url"}&amp;active={if ($item.smtp_active==0)}1{else}0{/if}&amp;field=smtp_active&amp;token={$smarty.session.PFA_token|escape:"url"}"
+				>{if $item.smtp_active==1}<span class="glyphicon glyphicon-check" aria-hidden="true"></span> {$PALANG.YES}{else}<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span> {$PALANG.NO}{/if}</a></td>
+			{/if}
 			{if $CONF.vacation_control_admin===YES && $CONF.vacation===YES}
 				{if $item.v_active!==-1}
 					{if $item.v_active==1}


### PR DESCRIPTION
Add a flag to mailbox table for enable/disbale of smtp protocol. the name of the flag is "smtp_active". This enables use of this flag instead of active flag for postfix mysql queries. There is a new configuration parameter $CONF['smtp_active_flag'] = YES or NO, which defaults to NO, providing the existing behaviour. When set to YES the active_smtp field is displayed in the edit mode and can be modified. For simplicity the flag is not shown in the table view, but this could be added. The commit includes update to the language files and documentation. The commit does not include the code to add the field to existing installs, which I presume can be added during the release
 cycle in upgrade.php along the lines of:

_db_add_field('mailbox',  'smtp_active', 'int DEFAULT 1');