### PR TITLE
docs(install): fix a typo for unarchived dir

### DIFF
--- a/INSTALL.TXT
+++ b/INSTALL.TXT
@@ -44,7 +44,7 @@ Assuming we are installing Postfixadmin into /srv/postfixadmin, then something l
   $ cd /srv/
   $ wget -O postfixadmin.tgz https://github.com/postfixadmin/postfixadmin/archive/postfixadmin-3.3.10.tar.gz
   $ tar -zxvf postfixadmin.tgz
-  $ mv postfixadmin-postfixadmin-3.3 postfixadmin
+  $ mv postfixadmin-postfixadmin-3.3.10 postfixadmin
 
 Alternatively :
 


### PR DESCRIPTION
`tar -zxvf postfixadmin.tgz` will create `postfixadmin-postfixadmin-3.3.10` instead of postfixadmin-postfixadmin-3.3`

so, current install.txt is a bit outdated