### PR TITLE
Fix deprecated config parameter error

### DIFF
--- a/model/Config.php
+++ b/model/Config.php
@@ -16,6 +16,7 @@ final class Config
     # do not error_log() 'undefined config option' for deprecated options
     private static $deprecated_options = array(
         'min_password_length',
+	'create_mailbox_subdirs',
     );
 
     /**


### PR DESCRIPTION
The error appears when creating a mailbox. If the parameter is not specified in the config:
“PHP message: Config::read(): attempt to read undefined config option “create_mailbox_subdirs”, returning null”
If specified:
“PHP message: /opt/www/postfixadmin/model/MailboxHandler.php WARNING : PostfixAdmin no longer supports the imap folder population via config parameters, see https://github.com/postfixadmin/postfixadmin/issues/812”