### PR TITLE
avoid php deprecation message

### DIFF
--- a/scripts/postfixadmin-cli.php
+++ b/scripts/postfixadmin-cli.php
@@ -411,6 +411,6 @@ try {
     $dispatcher->stderr("Execution Exception: " . $e->getMessage());
     $retval = 1;
 }
-exit($retval);
+exit($retval || 0);
 
 /* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */


### PR DESCRIPTION
On Debian testing, postfixadmin-cli reports the following message:

Deprecated: exit(): Passing null to parameter #1 ($status) of type string|int is deprecated in /usr/share/postfixadmin/scripts/postfixadmin-cli.php on line 403

postfixadmin: 3.3.15
PHP: 8.4.6

This is maybe just a workaround, but it removed at least the deprecation warning.