### PR TITLE
Re-implementation of the multiple server feature

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -138,6 +138,7 @@ $CONF['database_tables'] = array (
     'fetchmail' => 'fetchmail',
     'log' => 'log',
     'mailbox' => 'mailbox',
+    'server' => 'server',
     'vacation' => 'vacation',
     'vacation_notification' => 'vacation_notification',
     'quota' => 'quota',
@@ -364,6 +365,7 @@ function maildir_name_hook($domain, $user) {
     $CONF['admin_struct_hook'] = 'x_struct_admin_modify';
 */
 $CONF['admin_struct_hook']          = '';
+$CONF['server_struct_hook']         = '';
 $CONF['domain_struct_hook']         = '';
 $CONF['alias_struct_hook']          = '';
 $CONF['mailbox_struct_hook']        = '';
@@ -421,6 +423,9 @@ $CONF['transport_options'] = array (
 // You should define default transport. It must be in array above.
 $CONF['transport_default'] = 'virtual';
 
+// Support for multiple servers
+// If you want to enable support for multiple servers, set this to 'YES'
+$CONF['multiple_servers'] = 'NO';
 
 //
 //

--- a/configs/menu.conf
+++ b/configs/menu.conf
@@ -3,6 +3,9 @@ url_editactive = editactive.php?table=
 # list_admin
 url_list_admin = list.php?table=admin
 url_create_admin = edit.php?table=admin
+# list-server
+url_list_server = list.php?table=server
+url_create_server = edit.php?table=server
 # list-domain
 url_list_domain = list.php?table=domain
 url_edit_domain = edit.php?table=domain

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -269,6 +269,9 @@ $PALANG['pViewlog_action_delete_totp_exception'] = 'Delete TOTP exception';
 $PALANG['pViewlog_action_create_domain'] = 'create domain';
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain';
 $PALANG['pViewlog_action_edit_domain'] = 'edit domain';
+$PALANG['pViewlog_action_create_server'] = 'create server';
+$PALANG['pViewlog_action_delete_server'] = 'delete server';
+$PALANG['pViewlog_action_edit_server'] = 'edit server';
 $PALANG['pViewlog_action_create_mailbox'] = 'create mailbox';
 $PALANG['pViewlog_action_delete_mailbox'] = 'delete mailbox';
 $PALANG['pViewlog_action_edit_mailbox'] = 'edit mailbox';
@@ -332,10 +335,12 @@ $PALANG['pViewlog_action_delete_dkim_signing_entry'] = 'delete domain signing en
 $PALANG['pMain_dkim'] = 'Add a Domain Key for use with OpenDKIM.';
 
 $PALANG['pAdminMenu_list_admin'] = 'Admin List';
+$PALANG['pAdminMenu_list_server'] = 'Server List';
 $PALANG['pAdminMenu_list_domain'] = 'Domain List';
 $PALANG['pAdminMenu_list_virtual'] = 'Virtual List';
 $PALANG['pAdminMenu_backup'] = 'Backup';
 $PALANG['pAdminMenu_create_domain_admins'] = 'Domain Admins';
+$PALANG['pAdminMenu_create_server'] = 'New Server';
 $PALANG['pAdminMenu_create_admin'] = 'New Admin';
 $PALANG['pAdminMenu_create_domain'] = 'New Domain';
 
@@ -380,6 +385,7 @@ $PALANG['pAdminEdit_domain_maxquota'] = 'Max Mailbox Quota'; # TODO: add change 
 $PALANG['pAdminEdit_domain_maxquota_text'] = 'MB | -1 = disable | 0 = unlimited';
 $PALANG['pAdminEdit_domain_quota'] = 'Domain Quota';
 $PALANG['transport'] = 'Transport';
+$PALANG['pAdminEdit_domain_primarymx_text'] = 'Define the primary MX';
 $PALANG['pAdminEdit_domain_transport_text'] = 'Define transport';
 $PALANG['pAdminEdit_domain_backupmx'] = 'Mail server is backup MX';
 $PALANG['pAdminEdit_domain_result_error'] = 'Modifying the domain %s failed!';
@@ -517,6 +523,25 @@ $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX
 $PALANG['pLegal_char_warning']              = 'Illegal character';
 $PALANG['TOTP_already_configured']          = 'TOTP is already configured for this account, do you want to change your secret?';
 $PALANG['pApp_passwords_add']               = 'Add application-specific password';
+
+$PALANG['server'] = 'Server';
+$PALANG['smtpaddress'] = 'SMTP-Address';
+$PALANG['server_address_description'] = 'smtp address of the remote server for relaying (e.g. smtp:[10.0.0.5]:25 )';
+$PALANG['server_creation'] = 'Add a server';
+$PALANG['server_edit'] = 'Edit a server';
+$PALANG['server_button'] = 'Add server';
+$PALANG['server_create_error'] = 'Creating server %s failed';
+$PALANG['server_edit_error'] = 'Modifying server %s failed';
+$PALANG['server_store_success'] = 'The Server %s has successfully been added.';
+$PALANG['server_already_exists'] = 'The server already exists';
+$PALANG['server_does_not_exist'] = 'The server %s does not exist.';
+$PALANG['confirm_delete_server'] = 'Do you really want to delete the server %s?';
+$PALANG['delete_server_domain_target'] = 'There are still domains, where this server is the primary one. Change them first';
+$PALANG['server_updated'] = 'The Server %s was updated';
+$PALANG['primarymx'] = 'Primary MX';
+$PALANG['server_postcreate_failed'] = 'The server postcreate script failed, check the error log for details!';
+$PALANG['server_postdel_failed'] = 'The server postdeletion script failed, check the error log for details!';
+$PALANG['server_must_not_be_empty'] = 'The server name must not be empty.';
 
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */

--- a/model/ServerHandler.php
+++ b/model/ServerHandler.php
@@ -1,0 +1,90 @@
+<?php
+
+# $Id$
+
+class ServerHandler extends PFAHandler
+{
+    protected $db_table = 'server';
+    protected $id_field = 'server';
+
+    protected function validate_new_id() {
+        if ($this->id == null || $this->id == "") {
+            $this->errormsg[$this->id_field] = Config::lang('server_must_not_be_empty');
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    protected function no_domain_field() {
+    }
+
+    protected function initStruct()
+    {
+        $super = $this->is_superadmin;
+        $this->struct = array(
+            'server'      => self::pacol( $this->new, 1, 1, 'text', 'server',        ''),
+            'description' => self::pacol(   1,        1, 1, 'text', 'description',   ''),
+            'address'     => self::pacol(   1,        1, 1, 'text', 'smtpaddress',   'server_address_description'),
+            'created'     => self::pacol(   0,        0, 0, 'ts',   'created',       ''),
+            'modified'    => self::pacol(   0,        0, 0, 'ts',   'last_modified', ''),
+            '_can_edit'   => self::pacol(   0,        0, 1, 'int',  '',              '', 0, array(), 0, 1, (Config::bool('multiple_servers') && $this->is_superadmin) . ' as _can_edit' ),
+            '_can_delete' => self::pacol(   0,        0, 1, 'int',  '',              '', 0, array(), 0, 1, (Config::bool('multiple_servers') && $this->is_superadmin) . ' as _can_delete' ),
+        );
+    }
+
+    protected function initMsg() {
+        $this->msg['error_already_exists'] = 'server_already_exists';
+        $this->msg['error_does_not_exist'] = 'server_does_not_exist';
+        $this->msg['confim_delete'] = 'confirm_delete_server';
+        if ($this->new) {
+            $this->msg['logname'] = 'create_server';
+            $this->msg['store_error'] = 'server_create_error';
+            $this->msg['successmessage'] = 'server_store_success';
+        } else {
+            $this->msg['logname'] = 'edit_server';
+            $this->msg['store_error'] = 'server_edit_error';
+            $this->msg['successmessage'] = 'server_updated';
+        }
+        $this->msg['can_create'] = Config::bool('multiple_servers') && $this->is_superadmin;
+    }
+
+    public function webformConfig() {
+        return array(
+            'formtitle_create' => 'server_creation',
+            'formtitle_edit' => 'server_edit',
+            'create_button' => 'server_button',
+
+            'required_role' => 'global-admin',
+            'listview' => 'list.php?table=server',
+            'early_init' => 0,
+        );
+    }
+
+    public function delete() {
+        if (!(Config::bool('multiple_servers') && $this->is_superadmin)) {
+            $this->errormsg[] = Config::Lang_f('no_delete_permission', $this->id);
+            return false;
+        }
+
+        if ( !$this->view() ) {
+            $this->errormsg[] = Config::lang('server_does_not_exist');
+            return false;
+        }
+
+        $handler = new DomainHandler(0, $this->admin_username);
+        $handler->getList(array("primarymx" => $this->id));
+        $domains = $handler->result();
+        if (count($domains) > 0) {
+            $this->errormsg[] = Config::Lang_f('delete_server_domain_target', $this->id);
+            return false;
+        }
+
+        db_delete($this->db_table, $this->id_field, $this->id);
+
+        db_log($this->id, 'delete_server', $this->id);
+
+        $this->infomsg[] = Config::Lang_f('pDelete_delete_success', $this->id);
+        return true;
+    }
+}	

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2412,3 +2412,39 @@ function upgrade_1851_mysql()
         )
     ");
 }
+
+function upgrade_1852_mysql_pgsql()
+{
+    # Add support for multiple servers
+    $server = table_by_key('server');
+    db_query_parsed("
+        CREATE TABLE {IF_NOT_EXISTS} $server (
+            `server` varchar(100) NOT NULL,
+            `description` varchar(255) NOT NULL,
+            `address` varchar(100) NOT NULL,
+            `created` {DATE},
+            `modified` {DATECURRENT},
+            {PRIMARY} (server)
+        );
+    ");
+}
+
+function upgrade_1852_sqlite()
+{
+    $server = table_by_key('server');
+    db_query_parsed("
+        CREATE TABLE $server (
+            `server` varchar(100) NOT NULL,
+            `description` varchar(255) NOT NULL,
+            `address` varchar(255) NOT NULL,
+            `created` {DATE},
+            `modified` {DATECURRENT},
+            {PRIMARY} (`server`)
+        );
+    ");
+}
+
+function upgrade_1853()
+{
+    _db_add_field('domain', 'primarymx', "varchar(100) NOT NULL DEFAULT ''", 'transport');
+}

--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -56,6 +56,31 @@
                             </a>
                         </li>
                     {/if}
+                    {* list-server *}
+                    {if $authentication_has_role.global_admin && Config::bool('multiple_servers')}
+                        {strip}
+                            <li class="dropdown">
+                                <a class="btn navbar-btn dropdown-toggle" data-toggle="dropdown" role="button"
+                                   aria-haspopup="true"
+                                   aria-expanded="false" href="{#url_list_server#}"><span
+                                            class="glyphicon glyphicon-tasks"
+                                            aria-hidden="true"></span> List servers <span
+                                            class="caret"></span></a>
+                                <ul class="dropdown-menu">
+                                    <li>
+                                        <a href="{#url_list_server#}"><span class="glyphicon glyphicon-tasks"
+                                                          aria-hidden="true"></span> List servers
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a href="{#url_create_server#}"><span class="glyphicon glyphicon-plus"
+                                                          aria-hidden="true"></span> Add server
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                        {/strip}
+                    {/if}
                     {* list-domain *}
                     {strip}
                         <li>


### PR DESCRIPTION
This is a re-implementation of the multiple server feature ( #12 ) based on postfixadmin v4.

Useful for hot standby or backup systems with replicated databases.

The main problem is that, if you want to have a backup mx, you need to copy all mailbox setting changes you make on the first system to the second one.

With this new feature you can just replicate your database and use it for both, the primary and the secondary mailserver.

You can also do load balancing by sending one domain to the first and an other domain to the second mailserver as primary.


Most notable change from the last #12 version: Removed the post-create/post-delete scripts, as they may not be that useful after all.

TODO-List before merge:
* [ ] Add hint in `DOCUMENTS/BACKUP_MX.txt`
* [ ] Add a new document in `DOCUMENTS/` to describe this feature
* [ ] Modify example postfix scripts in `DOCUMENTS/POSTFIX_CONF.txt`

I will get to the TODO list if there is a response that this is a useful feature and will be merged.