### PR TITLE
Fix of #484 was incompletely applied to 3.3 branch

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1598,7 +1598,7 @@ function db_connection_string() {
             $dsn .= ";port={$CONF['database_port']}";
         }
 
-        $dsn .= ";dbname={$database_name};charset=UTF8";
+        $dsn .= ";dbname={$database_name}";
     } elseif (db_sqlite()) {
         $db = $CONF['database_name'];
 
@@ -1667,8 +1667,8 @@ function db_connect() {
 
             $options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = (bool)$verify;
         }
-        $queries[] = 'SET CHARACTER SET utf8';
-        $queries[] = "SET COLLATION_CONNECTION='utf8_general_ci'";
+        $queries[] = 'SET NAMES utf8mb4';
+        $queries[] = "SET COLLATION_CONNECTION='utf8mb4_general_ci'";
     } elseif (db_sqlite()) {
         $db = $CONF['database_name'];
 


### PR DESCRIPTION
Four-byte-UTF8 characters (such as 𒀆) cannot be used in vacation subject/text