### PR TITLE
No need to specify charset in connection string and then set it explicitly using "SET NAMES" again

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1505,7 +1505,7 @@ function db_connection_string()
             $dsn .= ";port={$CONF['database_port']}";
         }
 
-        $dsn .= ";dbname={$database_name};charset=UTF8";
+        $dsn .= ";dbname={$database_name}";
     } elseif (db_sqlite()) {
         $db = $CONF['database_name'];
 


### PR DESCRIPTION
Also, both settings were inconsistent