### PR TITLE
Pfa4 actions set output (backport for 4.0)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Get composer cache directory
       if: ${{ !env.ACT }}
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
       if: ${{ !env.ACT }}
@@ -74,7 +74,7 @@ jobs:
     - name: Get composer cache directory
       if: ${{ !env.ACT }}
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
       if: ${{ !env.ACT }}


### PR DESCRIPTION
cf. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/