### PR TITLE
Disable totp and app password pages based on config value

### DIFF
--- a/public/users/app-passwords.php
+++ b/public/users/app-passwords.php
@@ -36,6 +36,12 @@ $pPassword_text = "";
 $pUser_text = '';
 $pUser = '';
 
+// check if app-passwords are enabled
+if (Config::bool('app_passwords') === false) {
+    header("Location: main.php");
+    exit(0);
+}
+
 if (authentication_has_role('global-admin')) {
     $login = new Login('admin');
     $admin = 2;

--- a/public/users/totp-exceptions.php
+++ b/public/users/totp-exceptions.php
@@ -40,6 +40,12 @@ $pUser = '';
 
 $username = authentication_get_username();
 
+// check if totp is enabled
+if (Config::bool('totp') === false) {
+    header("Location: main.php");
+    exit(0);
+}
+
 if (authentication_has_role('global-admin')) {
     $login = new Login('admin');
     $totppf = new TotpPf('admin', $login);

--- a/public/users/totp.php
+++ b/public/users/totp.php
@@ -39,6 +39,12 @@ $pPassword_password_text = "";
 $pTOTP_secret_text = '';
 $pTOTP_code_text = '';
 
+// check if totp is enabled
+if (Config::bool('totp') === false) {
+    header("Location: main.php");
+    exit(0);
+}
+
 if (authentication_has_role('admin')) {
     $login = new Login('admin');
     $totppf = new TotpPf('admin', $login);


### PR DESCRIPTION
This PR redirects to main.php if totp or app_passwords page is accessed when either is disabled in config files.