### PR TITLE
Add in-app update check and upgrade for global admins

### DIFF
--- a/configs/menu.conf
+++ b/configs/menu.conf
@@ -27,6 +27,8 @@ url_password = edit.php?table=adminpassword
 url_totp = totp.php
 url_totp_exceptions = totp-exceptions.php
 url_app_passwords = app-passwords.php
+# update-check
+url_update_check = update-check.php
 # backup
 url_backup = backup.php
 # viewlog

--- a/public/update-check.php
+++ b/public/update-check.php
@@ -1,0 +1,417 @@
+<?php
+
+/**
+ * Postfix Admin
+ *
+ * LICENSE
+ * This source file is subject to the GPL license that is bundled with
+ * this package in the file LICENSE.TXT.
+ *
+ * Further details on the project are available at https://github.com/postfixadmin/postfixadmin
+ *
+ * @license GNU GPL v2 or later.
+ *
+ * File: update-check.php
+ * Checks for available updates via the GitHub Releases API and allows
+ * global admins to download and apply updates from the web UI.
+ *
+ * Template File: update-check.tpl
+ */
+
+require_once('common.php');
+
+authentication_require_role('global-admin');
+
+$smarty = PFASmarty::getInstance();
+
+$current_version = Config::read_string('version');
+
+/**
+ * Fetch content from a URL using cURL (preferred) or file_get_contents as fallback.
+ * Returns the response body as a string, or false on failure.
+ *
+ * @param string $url
+ * @param int $timeout
+ * @param array<string> $headers
+ * @return string|false
+ */
+function http_fetch(string $url, int $timeout = 10, array $headers = [])
+{
+    if (function_exists('curl_init')) {
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return false;
+        }
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'PostfixAdmin-UpdateCheck');
+        if (!empty($headers)) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        }
+        $response = curl_exec($ch);
+        $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        if (!is_string($response) || $http_code >= 400) {
+            return false;
+        }
+        return $response;
+    }
+
+    // Fallback to file_get_contents (requires allow_url_fopen)
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'GET',
+            'header' => array_merge(['User-Agent: PostfixAdmin-UpdateCheck'], $headers),
+            'timeout' => $timeout,
+            'follow_location' => true,
+        ],
+    ]);
+
+    /** @psalm-suppress InvalidArgument */
+    return @file_get_contents($url, false, $context);
+}
+
+/**
+ * Fetch release information from the GitHub Releases API.
+ * Returns an array of releases or an empty array on failure.
+ */
+function fetch_github_releases(): array
+{
+    $response = http_fetch(
+        'https://api.github.com/repos/postfixadmin/postfixadmin/releases',
+        10,
+        ['Accept: application/vnd.github.v3+json']
+    );
+
+    if ($response === false) {
+        return [];
+    }
+
+    $releases = json_decode($response, true);
+    if (!is_array($releases)) {
+        return [];
+    }
+
+    return $releases;
+}
+
+/**
+ * Normalize a version tag to a comparable version string.
+ * Handles formats like "v4.0.1", "postfixadmin-3.3.16", "3.3.8".
+ */
+function normalize_version(string $tag): string
+{
+    // Strip common prefixes
+    $result = preg_replace('/^(postfixadmin-|postfxadmin-|v)/i', '', $tag);
+    return $result ?? $tag;
+}
+
+/**
+ * Find the tarball asset URL from a release's assets array.
+ * Returns the download URL or null if no suitable asset is found.
+ */
+function find_tarball_asset(array $release): ?string
+{
+    if (empty($release['assets'])) {
+        return null;
+    }
+
+    foreach ($release['assets'] as $asset) {
+        if (preg_match('/\.tar\.gz$/', $asset['name'])) {
+            return $asset['browser_download_url'];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Download a file from a URL to a local path.
+ * Uses cURL if available, falls back to file_get_contents.
+ * Returns true on success, false on failure.
+ */
+function download_file(string $url, string $dest): bool
+{
+    if (function_exists('curl_init')) {
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return false;
+        }
+        $fp = fopen($dest, 'w');
+        if ($fp === false) {
+            return false;
+        }
+        curl_setopt($ch, CURLOPT_FILE, $fp);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 120);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'PostfixAdmin-UpdateCheck');
+        $success = curl_exec($ch);
+        $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        fclose($fp);
+        if (!$success || $http_code >= 400) {
+            @unlink($dest);
+            return false;
+        }
+        return filesize($dest) > 0;
+    }
+
+    // Fallback to file_get_contents
+    $response = http_fetch($url, 120);
+    if ($response === false) {
+        return false;
+    }
+    return (bool)file_put_contents($dest, $response);
+}
+
+/**
+ * Apply an update from a downloaded tarball.
+ * Extracts the archive over the current installation directory.
+ * Returns true on success, false on failure.
+ */
+function apply_update(string $tarball_path): bool
+{
+    $install_dir = dirname(__DIR__);
+    $tmp_dir = sys_get_temp_dir() . '/postfixadmin-update-' . uniqid();
+
+    if (!mkdir($tmp_dir, 0700, true)) {
+        flash_error('Failed to create temporary directory for extraction.');
+        return false;
+    }
+
+    // Extract the tarball (.tar.gz)
+    try {
+        $phar = new PharData($tarball_path);
+        // For .tar.gz, PharData needs to decompress first, then extract
+        if (preg_match('/\.tar\.gz$|\.tgz$/i', $tarball_path)) {
+            $phar->decompress(); // creates .tar file alongside the .tar.gz
+            $tar_path = preg_replace('/\.gz$/i', '', $tarball_path);
+            if ($tar_path && file_exists($tar_path)) {
+                $phar = new PharData($tar_path);
+                $phar->extractTo($tmp_dir);
+                @unlink($tar_path);
+            } else {
+                // Fallback: try direct extraction (some PHP versions handle .tar.gz directly)
+                $phar->extractTo($tmp_dir);
+            }
+        } else {
+            $phar->extractTo($tmp_dir);
+        }
+    } catch (Exception $e) {
+        flash_error('Failed to extract update archive: ' . $e->getMessage());
+        cleanup_dir($tmp_dir);
+        return false;
+    }
+
+    // Find the extracted directory (tarball usually contains a single top-level dir)
+    $extracted_dirs = glob($tmp_dir . '/*', GLOB_ONLYDIR);
+    if (count($extracted_dirs) === 1) {
+        $source_dir = $extracted_dirs[0];
+    } else {
+        $source_dir = $tmp_dir;
+    }
+
+    // Check we're not about to overwrite config.local.php
+    if (file_exists($source_dir . '/config.local.php')) {
+        flash_error('Update archive unexpectedly contains config.local.php — aborting for safety.');
+        cleanup_dir($tmp_dir);
+        return false;
+    }
+
+    // Copy files from extracted archive to installation directory
+    if (!recursive_copy($source_dir, $install_dir)) {
+        flash_error('Failed to copy updated files to installation directory.');
+        cleanup_dir($tmp_dir);
+        return false;
+    }
+
+    cleanup_dir($tmp_dir);
+    return true;
+}
+
+/**
+ * Recursively copy files from source to destination, skipping config.local.php.
+ */
+function recursive_copy(string $src, string $dst): bool
+{
+    $dir = opendir($src);
+    if ($dir === false) {
+        return false;
+    }
+
+    if (!is_dir($dst) && !mkdir($dst, 0755, true)) {
+        return false;
+    }
+
+    while (($file = readdir($dir)) !== false) {
+        if ($file === '.' || $file === '..') {
+            continue;
+        }
+
+        // Never overwrite the local config
+        if ($file === 'config.local.php') {
+            continue;
+        }
+
+        $src_path = $src . '/' . $file;
+        $dst_path = $dst . '/' . $file;
+
+        if (is_dir($src_path)) {
+            if (!recursive_copy($src_path, $dst_path)) {
+                closedir($dir);
+                return false;
+            }
+        } else {
+            if (!copy($src_path, $dst_path)) {
+                closedir($dir);
+                return false;
+            }
+        }
+    }
+
+    closedir($dir);
+    return true;
+}
+
+/**
+ * Recursively remove a directory and its contents.
+ */
+function cleanup_dir(string $dir): void
+{
+    if (!is_dir($dir)) {
+        return;
+    }
+
+    $items = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($items as $item) {
+        if ($item->isDir()) {
+            rmdir($item->getRealPath());
+        } else {
+            unlink($item->getRealPath());
+        }
+    }
+
+    rmdir($dir);
+}
+
+// --- Main logic ---
+
+$error = '';
+$latest_release = null;
+$newer_releases = [];
+$update_available = false;
+$tarball_url = null;
+
+// Handle POST: apply update
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    CsrfToken::assertValid(safepost('CSRF_Token'));
+
+    $action = safepost('action');
+
+    if ($action === 'apply_update') {
+        $download_url = safepost('download_url');
+        $update_version = safepost('update_version');
+
+        if (empty($download_url) || empty($update_version)) {
+            flash_error('Missing update information.');
+        } elseif (!preg_match('#^https://github\.com/postfixadmin/postfixadmin/releases/download/#', $download_url)) {
+            flash_error('Invalid download URL — only official GitHub release assets are allowed.');
+        } else {
+            // Check the install directory is writable
+            $install_dir = dirname(__DIR__);
+            if (!is_writable($install_dir)) {
+                flash_error('Installation directory is not writable by the web server. Cannot apply update.');
+            } else {
+                // Download to temp file (PharData needs .tar.gz extension to detect format)
+                $tmp_base = tempnam(sys_get_temp_dir(), 'postfixadmin-update-');
+                $tmp_file = $tmp_base ? $tmp_base . '.tar.gz' : false;
+                if ($tmp_base === false || $tmp_file === false) {
+                    flash_error('Failed to create temporary file.');
+                } elseif (!rename($tmp_base, $tmp_file)) {
+                    flash_error('Failed to prepare temporary file.');
+                    @unlink($tmp_base);
+                } elseif (!download_file($download_url, $tmp_file)) {
+                    flash_error('Failed to download update from: ' . htmlspecialchars($download_url));
+                    @unlink($tmp_file);
+                } elseif (apply_update($tmp_file)) {
+                    @unlink($tmp_file);
+                    // Clear OPcache so PHP serves the new files
+                    if (function_exists('opcache_reset')) {
+                        opcache_reset();
+                    }
+                    flash_info("Successfully updated to version " . htmlspecialchars($update_version) . ". Please run <a href='upgrade.php'>upgrade.php</a> to apply any database changes.");
+                    header('Location: update-check.php');
+                    exit;
+                } else {
+                    @unlink($tmp_file);
+                    // flash_error was already called inside apply_update()
+                }
+            }
+        }
+    }
+}
+
+// Check we have a way to make HTTP requests before trying
+$has_curl = function_exists('curl_init');
+$allow_url_fopen = (bool)ini_get('allow_url_fopen');
+$can_download = $has_curl || $allow_url_fopen;
+
+if (!$can_download) {
+    $error = 'Neither cURL nor allow_url_fopen is available. Install php-curl or enable allow_url_fopen in php.ini.';
+    $releases = [];
+} else {
+    $releases = fetch_github_releases();
+}
+
+if (!$error && empty($releases)) {
+    $error = 'Could not fetch release information from GitHub. Check that your server can reach api.github.com.';
+} else {
+    // Filter to non-draft, non-prerelease, and find newer versions
+    foreach ($releases as $release) {
+        if (!empty($release['draft']) || !empty($release['prerelease'])) {
+            continue;
+        }
+
+        $release_version = normalize_version($release['tag_name']);
+
+        if (version_compare($release_version, $current_version, '>')) {
+            $release['normalized_version'] = $release_version;
+            $release['tarball_asset'] = find_tarball_asset($release);
+            $newer_releases[] = $release;
+        }
+    }
+
+    // Sort newest first
+    usort($newer_releases, function ($a, $b) {
+        return version_compare($b['normalized_version'], $a['normalized_version']);
+    });
+
+    if (!empty($newer_releases)) {
+        $update_available = true;
+        $latest_release = $newer_releases[0];
+        $tarball_url = $latest_release['tarball_asset'];
+    }
+}
+
+// Check prerequisites for applying updates
+$install_dir = dirname(__DIR__);
+$is_writable = is_writable($install_dir);
+$has_phar = class_exists('PharData');
+
+$smarty->assign('current_version', $current_version);
+$smarty->assign('error', $error);
+$smarty->assign('update_available', $update_available);
+$smarty->assign('latest_release', $latest_release);
+$smarty->assign('newer_releases', $newer_releases);
+$smarty->assign('tarball_url', $tarball_url);
+$smarty->assign('is_writable', $is_writable);
+$smarty->assign('has_phar', $has_phar);
+$smarty->assign('can_download', $can_download);
+$smarty->assign('install_dir', $install_dir);
+$smarty->assign('smarty_template', 'update-check');
+$smarty->display('index.tpl');

--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -60,10 +60,16 @@
         {else}
             <a target="_blank" rel="noopener" href="https://github.com/postfixadmin/postfixadmin/">Postfix
                 Admin {$version}</a>
+            {if $authentication_has_role.global_admin}
+            <span id="update-check">&nbsp;|&nbsp;
+                <a href="update-check.php">{$PALANG.check_update}</a>
+            </span>
+            {else}
             <span id="update-check">&nbsp;|&nbsp;
                 <a target="_blank" rel="noopener"
                    href="https://github.com/postfixadmin/postfixadmin/releases">{$PALANG.check_update}</a>
             </span>
+            {/if}
             {if isset($smarty.session.sessid)}
                 {if $smarty.session.sessid.username}
                     &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;

--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -210,6 +210,13 @@
                             <span class="bi bi-lock" aria-hidden="true"></span>
                             {$PALANG.pMenu_password}</a></li>
                 {/if}
+                {* update check *}
+                {if $authentication_has_role.global_admin}
+                    <li><a class="nav-link" type="button"
+                           href="{#url_update_check#}">
+                            <span class="bi bi-arrow-repeat" aria-hidden="true"></span>
+                            {$PALANG.pUpdate_check_title|default:'Update Check'}</a></li>
+                {/if}
                 {* backup *}
                 {if $authentication_has_role.global_admin && $CONF.database_type!=='pgsql' && $CONF.backup === 'YES'}
                     <li><a class="nav-link" type="button"

--- a/templates/update-check.tpl
+++ b/templates/update-check.tpl
@@ -1,0 +1,102 @@
+<div class="card mb-4">
+    <div class="card-header">
+        <h4><span class="bi bi-arrow-repeat" aria-hidden="true"></span> {$PALANG.pUpdate_check_title|default:'Update Check'}</h4>
+    </div>
+    <div class="card-body">
+        <p><strong>{$PALANG.pUpdate_current_version|default:'Current version'}:</strong> {$current_version}</p>
+
+        {if $error}
+            <div class="alert alert-warning">{$error}</div>
+        {elseif !$update_available}
+            <div class="alert alert-success">
+                <span class="bi bi-check-circle" aria-hidden="true"></span>
+                {$PALANG.pUpdate_up_to_date|default:'You are running the latest version.'}
+            </div>
+        {else}
+            <div class="alert alert-info">
+                <span class="bi bi-info-circle" aria-hidden="true"></span>
+                {$PALANG.pUpdate_available|default:'A newer version is available'}:
+                <strong>{$latest_release.normalized_version}</strong>
+            </div>
+
+            {if !$has_phar}
+                <div class="alert alert-danger">
+                    <span class="bi bi-exclamation-triangle" aria-hidden="true"></span>
+                    {$PALANG.pUpdate_no_phar|default:'The PHP PharData extension is not available. Cannot extract update archives.'}
+                </div>
+            {/if}
+
+            {if !$is_writable}
+                <div class="alert alert-danger">
+                    <span class="bi bi-exclamation-triangle" aria-hidden="true"></span>
+                    {$PALANG.pUpdate_not_writable|default:'The installation directory is not writable by the web server. Cannot apply updates automatically.'}
+                    <br><code>{$install_dir}</code>
+                </div>
+            {/if}
+
+            {if !$can_download}
+                <div class="alert alert-danger">
+                    <span class="bi bi-exclamation-triangle" aria-hidden="true"></span>
+                    {$PALANG.pUpdate_no_download|default:'Neither cURL nor allow_url_fopen is available. Cannot download updates. Install php-curl or enable allow_url_fopen in php.ini.'}
+                </div>
+            {/if}
+
+            {if $tarball_url && $is_writable && $has_phar && $can_download}
+                <form method="post" action="">
+                    {CSRF_Token}
+                    <input type="hidden" name="action" value="apply_update">
+                    <input type="hidden" name="download_url" value="{$tarball_url}">
+                    <input type="hidden" name="update_version" value="{$latest_release.normalized_version}">
+
+                    <div class="alert alert-warning">
+                        <span class="bi bi-exclamation-triangle" aria-hidden="true"></span>
+                        {$PALANG.pUpdate_backup_warning|default:'Make sure you have a backup of your database before proceeding. Your config.local.php will not be overwritten.'}
+                    </div>
+
+                    <button type="submit" class="btn btn-primary" onclick="return confirm('{$PALANG.pUpdate_confirm|default:'Are you sure you want to apply this update?'}');">
+                        <span class="bi bi-download" aria-hidden="true"></span>
+                        {$PALANG.pUpdate_apply|default:'Download & Apply Update'}
+                    </button>
+                </form>
+            {elseif !$tarball_url}
+                <div class="alert alert-warning">
+                    <span class="bi bi-exclamation-triangle" aria-hidden="true"></span>
+                    {$PALANG.pUpdate_no_tarball|default:'No self-contained release archive is available for this version. You may need to update manually.'}
+                    <br>
+                    <a href="{$latest_release.html_url}" target="_blank" rel="noopener" class="btn btn-secondary mt-2">
+                        <span class="bi bi-box-arrow-up-right" aria-hidden="true"></span>
+                        {$PALANG.pUpdate_view_release|default:'View release on GitHub'}
+                    </a>
+                </div>
+            {/if}
+        {/if}
+    </div>
+</div>
+
+{if $update_available && $newer_releases|@count > 0}
+    <div class="card">
+        <div class="card-header">
+            <h4><span class="bi bi-journal-text" aria-hidden="true"></span> {$PALANG.pUpdate_changelog|default:'Changelog'}</h4>
+        </div>
+        <div class="card-body">
+            {foreach from=$newer_releases item=release}
+                <div class="mb-4">
+                    <h5>
+                        <a href="{$release.html_url}" target="_blank" rel="noopener">
+                            {$release.normalized_version}
+                        </a>
+                        <small class="text-muted">
+                            &mdash; {$release.published_at|truncate:10:''}
+                        </small>
+                    </h5>
+                    {if $release.body}
+                        <div class="ps-3 border-start">
+                            <pre class="mb-0" style="white-space: pre-wrap;">{$release.body}</pre>
+                        </div>
+                    {/if}
+                </div>
+                {if !$release@last}<hr>{/if}
+            {/foreach}
+        </div>
+    </div>
+{/if}


### PR DESCRIPTION
## Summary

Closes #998
Depends on #999

Adds a web-based update check and upgrade page accessible to global admins. The page queries the GitHub Releases API to show available updates with full changelogs from the running version, and allows one-click download and installation of updates.

## Features

- **Version check** — compares `$CONF['version']` against GitHub Releases API
- **Changelog** — shows release notes for all versions between current and latest
- **One-click upgrade** — downloads the self-contained release tarball and extracts it over the current installation
- **Safety checks** before applying:
  - Verifies PHP `PharData` extension is available
  - Checks the installation directory is writable
  - Never overwrites `config.local.php`
  - Clears OPcache after update so PHP serves the new files
  - Prompts admin to confirm before applying
  - Reminds to run `upgrade.php` for database migrations
- **Graceful fallback** — if no tarball asset exists (pre-#999 releases), links to the GitHub release page instead
- **Menu integration** — added to admin navbar, and footer "check update" link now points to this page for global admins

## How it works

1. Admin visits Update Check page (or clicks "check update" in footer)
2. Page fetches releases from `api.github.com/repos/postfixadmin/postfixadmin/releases`
3. Shows all newer versions with changelogs
4. If a self-contained `.tar.gz` asset is available (from #999), shows "Download & Apply" button
5. On click: downloads tarball to `sys_get_temp_dir()`, extracts via PharData, copies files over installation, resets OPcache
6. Redirects back with success message and link to `upgrade.php`

## Files changed

- `public/update-check.php` — new page with all update logic
- `templates/update-check.tpl` — Smarty template with Bootstrap 5 UI
- `configs/menu.conf` — added URL mapping
- `templates/menu.tpl` — added menu item for global admins
- `templates/index.tpl` — footer "check update" link points to new page for global admins

## Test plan

- [ ] Verify page loads and shows current version
- [ ] Verify GitHub API returns release list with changelogs
- [ ] Verify "up to date" message when running latest
- [ ] Verify writable/PharData checks display appropriate warnings
- [ ] Test upgrade flow with a self-contained release tarball (requires #999)
- [ ] Verify `config.local.php` is preserved during upgrade
- [ ] Verify OPcache is cleared after upgrade