### PR TITLE
Migrate TOTP exceptions to TotpexceptionHandler class

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -381,6 +381,7 @@ $CONF['alias_domain_struct_hook']   = '';
 $CONF['fetchmail_struct_hook']      = '';
 $CONF['dkim_struct_hook']           = '';
 $CONF['dkim_signing_struct_hook']   = '';
+$CONF['totp_exception_address_struct_hook'] = '';
 
 /*
     mailbox_postcreation_hook example function

--- a/configs/menu.conf
+++ b/configs/menu.conf
@@ -25,7 +25,7 @@ url_dkim_newsign = edit.php?table=dkimsigning
 # password
 url_password = edit.php?table=adminpassword
 url_totp = totp.php
-url_totp_exceptions = totp-exceptions.php
+url_totp_exceptions = list.php?table=totpexception
 url_app_passwords = app-passwords.php
 # update-check
 url_update_check = update-check.php
@@ -42,6 +42,7 @@ url_user_edit_alias = edit-alias.php
 url_user_vacation = vacation.php
 url_user_password = password.php
 url_user_totp = totp.php
+url_user_totp_exceptions = ../list.php?table=totpexception
 url_user_logout = login.php
 
 

--- a/model/TotpexceptionHandler.php
+++ b/model/TotpexceptionHandler.php
@@ -9,6 +9,13 @@ class TotpexceptionHandler extends PFAHandler
     protected string $order_by = 'username, ip';
     protected ?string $user_field = 'username';
 
+    protected function no_domain_field()
+    {
+        // TOTP exceptions are not domain-scoped in the traditional sense.
+        // Visibility is handled in read_from_db_postprocess().
+        $this->allowed_domains = [];
+    }
+
     protected function initStruct()
     {
         $this->struct = array(
@@ -45,15 +52,15 @@ class TotpexceptionHandler extends PFAHandler
             'formtitle_edit' => 'pTotp_exceptions_welcome',
             'create_button' => 'pTotp_exceptions_add',
 
-            'required_role' => 'user',
+            'required_role' => 'admin',
             'listview' => 'list.php?table=totpexception',
             'early_init' => 0,
+            'user_hardcoded_field' => 'username',
         );
     }
 
     protected function validate_new_id()
     {
-        # auto_increment - any non-empty ID is an error
         if ($this->id != '') {
             $this->errormsg[$this->id_field] = 'auto_increment value, you must pass an empty string!';
             return false;
@@ -62,103 +69,181 @@ class TotpexceptionHandler extends PFAHandler
     }
 
     /**
-     * Restrict visibility based on user role:
-     * - Global admins see all exceptions
-     * - Admins see exceptions for domains they manage
-     * - Users see exceptions for their username, domain, and global (NULL) exceptions
+     * Validate IP address field.
      */
-    protected function read_from_db($condition, $searchmode = array(), $limit = -1, $offset = -1): array
+    protected function _validate_ip(string $field, string $value): bool
     {
-        if (authentication_has_role('global-admin')) {
-            return parent::read_from_db($condition, $searchmode, $limit, $offset);
+        if (trim($value) === '') {
+            $this->errormsg[$field] = Config::Lang('pException_ip_empty_error');
+            return false;
         }
-
-        $table = table_by_key($this->db_table);
-        $username = $this->admin_username;
-
-        if (authentication_has_role('admin')) {
-            $domains = list_domains_for_admin($username);
-            $params = ['username' => $username];
-            $domain_conditions = [];
-            foreach ($domains as $i => $domain) {
-                $key = '_domain_' . $i;
-                $domain_conditions[] = "username = :$key";
-                $params[$key] = $domain;
-            }
-            $domain_sql = implode(' OR ', $domain_conditions);
-            $query = "SELECT * FROM $table WHERE username = :username OR $domain_sql ORDER BY $this->order_by";
-        } else {
-            list($_, $domain) = explode('@', $username);
-            $params = ['username' => $username, 'domain' => $domain];
-            $query = "SELECT * FROM $table WHERE username = :username OR username = :domain OR username IS NULL ORDER BY $this->order_by";
+        if (!filter_var($value, FILTER_VALIDATE_IP)) {
+            $this->errormsg[$field] = Config::Lang('pException_ip_error');
+            return false;
         }
-
-        if ($limit > -1 && $offset > -1) {
-            $query .= " LIMIT $limit OFFSET $offset";
-        }
-
-        $db_result = array();
-        $result = db_query_all($query, $params);
-        foreach ($result as $row) {
-            $db_result[$row[$this->id_field]] = $row;
-        }
-        return $db_result;
+        return true;
     }
 
-    protected function preSave(): bool
+    /**
+     * Validate username field — enforce permissions based on role.
+     */
+    protected function _validate_username(string $field, string $value): bool
     {
-        // Validate IP address
-        if (isset($this->values['ip']) && !filter_var($this->values['ip'], FILTER_VALIDATE_IP)) {
-            $this->errormsg['ip'] = Config::Lang('pException_ip_empty_error');
+        // Normalize empty string to NULL for global exceptions
+        if ($value === '') {
+            if ($this->is_superadmin) {
+                $this->values['username'] = null;
+                return true;
+            }
+            $this->errormsg[$field] = Config::Lang('pException_user_global_error');
             return false;
         }
 
-        // Regular users can only add exceptions for their own username
-        if (!authentication_has_role('admin') && !authentication_has_role('global-admin')) {
-            $this->values['username'] = $this->admin_username;
+        // Users can only set exceptions for themselves
+        if (!$this->is_admin) {
+            $this->values['username'] = $this->username;
+            return true;
         }
 
-        // Admins can only add exceptions for domains they manage
-        if (authentication_has_role('admin') && !authentication_has_role('global-admin')) {
-            $exception_username = $this->values['username'] ?? '';
-            if ($exception_username !== $this->admin_username) {
-                if (strpos($exception_username, '@')) {
-                    list($_, $exception_domain) = explode('@', $exception_username);
-                } else {
-                    $exception_domain = $exception_username;
-                }
-                $domains = list_domains_for_admin($this->admin_username);
-                if (!in_array($exception_domain, $domains)) {
-                    $this->errormsg['username'] = Config::Lang('pException_user_entire_domain_error');
-                    return false;
-                }
-            }
+        // Superadmins can set for anyone
+        if ($this->is_superadmin) {
+            return true;
+        }
+
+        // Admins can set for users/domains they manage
+        if (strpos($value, '@')) {
+            list($_, $exception_domain) = explode('@', $value);
+        } else {
+            $exception_domain = $value;
+        }
+
+        if (!in_array($exception_domain, $this->allowed_domains)) {
+            $this->errormsg[$field] = Config::Lang('pException_user_entire_domain_error');
+            return false;
         }
 
         return true;
     }
 
+    /**
+     * Filter results based on user role after reading from DB.
+     * - Superadmins see all
+     * - Admins see exceptions for their managed domains + own username
+     * - Users see exceptions for their username, domain, and global (NULL)
+     */
+    protected function read_from_db_postprocess($db_result)
+    {
+        if ($this->is_superadmin) {
+            return $db_result;
+        }
+
+        $filtered = [];
+
+        if ($this->is_admin) {
+            foreach ($db_result as $key => $row) {
+                $ex_username = $row['username'] ?? '';
+                if ($ex_username === $this->admin_username) {
+                    $filtered[$key] = $row;
+                    continue;
+                }
+                if (strpos($ex_username, '@')) {
+                    list($_, $ex_domain) = explode('@', $ex_username);
+                } else {
+                    $ex_domain = $ex_username;
+                }
+                if (in_array($ex_domain, $this->allowed_domains)) {
+                    $filtered[$key] = $row;
+                }
+            }
+        } else {
+            // User mode
+            list($_, $domain) = explode('@', $this->username);
+            foreach ($db_result as $key => $row) {
+                $ex_username = $row['username'] ?? null;
+                if ($ex_username === $this->username || $ex_username === $domain || $ex_username === null) {
+                    $filtered[$key] = $row;
+                }
+            }
+        }
+
+        return $filtered;
+    }
+
     protected function postSave(): bool
     {
-        if ($this->new) {
-            $cmd = Config::read('mailbox_post_totp_exception_add_script');
-            $warnmsg = Config::Lang('mailbox_post_totp_exception_add_failed');
-        } else {
+        if (!$this->new) {
             return true;
         }
 
+        $cmd = Config::read('mailbox_post_totp_exception_add_script');
         if (empty($cmd)) {
             return true;
         }
 
-        $cmdarg1 = escapeshellarg($this->admin_username);
+        $cmdarg1 = escapeshellarg($this->values['username'] ?? '');
         $cmdarg2 = escapeshellarg($this->values['ip'] ?? '');
         $command = "$cmd $cmdarg1 $cmdarg2 2>&1";
 
+        return $this->run_post_script($command, Config::Lang('mailbox_post_totp_exception_add_failed'));
+    }
+
+    public function delete()
+    {
+        if (!$this->view()) {
+            $this->errormsg[] = Config::Lang($this->msg['error_does_not_exist']);
+            return false;
+        }
+
+        $exception = $this->result;
+        $ex_username = $exception['username'] ?? '';
+
+        // Check permissions
+        if ($this->is_superadmin) {
+            // can delete anything
+        } elseif ($this->is_admin) {
+            if ($ex_username !== $this->admin_username) {
+                if (strpos($ex_username, '@')) {
+                    list($_, $ex_domain) = explode('@', $ex_username);
+                } else {
+                    $ex_domain = $ex_username;
+                }
+                if (!in_array($ex_domain, $this->allowed_domains)) {
+                    $this->errormsg[] = Config::Lang('pException_user_entire_domain_error');
+                    return false;
+                }
+            }
+        } else {
+            if ($ex_username !== $this->username) {
+                $this->errormsg[] = Config::lang('pEdit_totp_exception_result_error');
+                return false;
+            }
+        }
+
+        db_delete($this->db_table, $this->id_field, $this->id);
+
+        // Run post-delete script
+        $cmd = Config::read('mailbox_post_totp_exception_delete_script');
+        if (!empty($cmd)) {
+            $cmdarg1 = escapeshellarg($ex_username);
+            $cmdarg2 = escapeshellarg($exception['ip'] ?? '');
+            $command = "$cmd $cmdarg1 $cmdarg2 2>&1";
+            $this->run_post_script($command, Config::Lang('mailbox_post_totp_exception_delete_failed'));
+        }
+
+        db_log($this->admin_username ?: $this->username, 'delete_totp_exception', $exception['ip'] ?? '');
+        $this->infomsg[] = Config::Lang_f('pDelete_delete_success', $exception['ip'] ?? $this->id);
+        return true;
+    }
+
+    /**
+     * Run a post-save/delete script via proc_open.
+     */
+    private function run_post_script(string $command, string $warnmsg): bool
+    {
         $spec = [0 => ["pipe", "r"], 1 => ["pipe", "w"]];
         $proc = proc_open($command, $spec, $pipes);
         if (!$proc) {
-            error_log("can't proc_open $cmd");
+            error_log("can't proc_open: $command");
             $this->errormsg[] = $warnmsg;
             return false;
         }
@@ -174,68 +259,6 @@ class TotpexceptionHandler extends PFAHandler
             return false;
         }
 
-        return true;
-    }
-
-    public function delete()
-    {
-        if (!$this->view()) {
-            $this->errormsg[] = Config::Lang($this->msg['error_does_not_exist']);
-            return false;
-        }
-
-        // Check permissions
-        $exception = $this->result;
-        $username = $this->admin_username;
-
-        if (!authentication_has_role('global-admin')) {
-            if (authentication_has_role('admin')) {
-                $domains = list_domains_for_admin($username);
-                $exception_username = $exception['username'] ?? '';
-                if ($exception_username !== $username) {
-                    if (strpos($exception_username, '@')) {
-                        list($_, $exception_domain) = explode('@', $exception_username);
-                    } else {
-                        $exception_domain = $exception_username;
-                    }
-                    if (!in_array($exception_domain, $domains)) {
-                        $this->errormsg[] = Config::Lang('pException_user_entire_domain_error');
-                        return false;
-                    }
-                }
-            } else {
-                if ($exception['username'] !== $username) {
-                    $this->errormsg[] = Config::lang('pEdit_totp_exception_result_error');
-                    return false;
-                }
-            }
-        }
-
-        db_delete($this->db_table, $this->id_field, $this->id);
-
-        // Run post-delete script
-        $cmd = Config::read('mailbox_post_totp_exception_delete_script');
-        if (!empty($cmd)) {
-            $cmdarg1 = escapeshellarg($username);
-            $cmdarg2 = escapeshellarg($exception['ip'] ?? '');
-            $command = "$cmd $cmdarg1 $cmdarg2 2>&1";
-
-            $spec = [0 => ["pipe", "r"], 1 => ["pipe", "w"]];
-            $proc = proc_open($command, $spec, $pipes);
-            if ($proc) {
-                fclose($pipes[0]);
-                $output = stream_get_contents($pipes[1]);
-                fclose($pipes[1]);
-                $retval = proc_close($proc);
-                if (0 != $retval) {
-                    error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
-                    $this->errormsg[] = Config::Lang('mailbox_post_totp_exception_delete_failed');
-                }
-            }
-        }
-
-        db_log($this->admin_username, 'delete_totp_exception', $exception['ip'] ?? '');
-        $this->infomsg[] = Config::Lang_f('pDelete_delete_success', $exception['ip'] ?? $this->id);
         return true;
     }
 

--- a/model/TotpexceptionHandler.php
+++ b/model/TotpexceptionHandler.php
@@ -1,0 +1,246 @@
+<?php
+
+class TotpexceptionHandler extends PFAHandler
+{
+    protected string $db_table = 'totp_exception_address';
+    protected string $id_field = 'id';
+    protected string $label_field = 'ip';
+    protected ?string $domain_field = '';
+    protected string $order_by = 'username, ip';
+    protected ?string $user_field = 'username';
+
+    protected function initStruct()
+    {
+        $this->struct = array(
+            # field name              allow       display in...   type    $PALANG label                     $PALANG description  default / options / ...
+            #                         editing?    form    list
+            'id'          => self::pacol(0,       0,      1,      'num',  'pFetchmail_field_id',            '', '', array(), array('dont_write_to_db' => 1)),
+            'username'    => self::pacol(1,       1,      1,      'text', 'pTotp_exceptions_user',          ''),
+            'ip'          => self::pacol(1,       1,      1,      'text', 'pTotp_exceptions_address',       ''),
+            'description' => self::pacol(1,       1,      1,      'text', 'pTotp_exceptions_description',   ''),
+        );
+    }
+
+    protected function initMsg()
+    {
+        $this->msg['error_already_exists'] = 'pTotp_exception_result_error';
+        $this->msg['error_does_not_exist'] = 'pTotp_exception_result_error';
+        $this->msg['confirm_delete'] = 'confirm';
+
+        if ($this->new) {
+            $this->msg['logname'] = 'add_totp_exception';
+            $this->msg['store_error'] = 'pTotp_exception_result_error';
+            $this->msg['successmessage'] = 'pTotp_exception_result_success';
+        } else {
+            $this->msg['logname'] = 'edit_totp_exception';
+            $this->msg['store_error'] = 'pEdit_totp_exception_result_error';
+            $this->msg['successmessage'] = 'pTotp_exception_result_success';
+        }
+    }
+
+    public function webformConfig()
+    {
+        return array(
+            'formtitle_create' => 'pTotp_exceptions_welcome',
+            'formtitle_edit' => 'pTotp_exceptions_welcome',
+            'create_button' => 'pTotp_exceptions_add',
+
+            'required_role' => 'user',
+            'listview' => 'list.php?table=totpexception',
+            'early_init' => 0,
+        );
+    }
+
+    protected function validate_new_id()
+    {
+        # auto_increment - any non-empty ID is an error
+        if ($this->id != '') {
+            $this->errormsg[$this->id_field] = 'auto_increment value, you must pass an empty string!';
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Restrict visibility based on user role:
+     * - Global admins see all exceptions
+     * - Admins see exceptions for domains they manage
+     * - Users see exceptions for their username, domain, and global (NULL) exceptions
+     */
+    protected function read_from_db($condition, $searchmode = array(), $limit = -1, $offset = -1): array
+    {
+        if (authentication_has_role('global-admin')) {
+            return parent::read_from_db($condition, $searchmode, $limit, $offset);
+        }
+
+        $table = table_by_key($this->db_table);
+        $username = $this->admin_username;
+
+        if (authentication_has_role('admin')) {
+            $domains = list_domains_for_admin($username);
+            $params = ['username' => $username];
+            $domain_conditions = [];
+            foreach ($domains as $i => $domain) {
+                $key = '_domain_' . $i;
+                $domain_conditions[] = "username = :$key";
+                $params[$key] = $domain;
+            }
+            $domain_sql = implode(' OR ', $domain_conditions);
+            $query = "SELECT * FROM $table WHERE username = :username OR $domain_sql ORDER BY $this->order_by";
+        } else {
+            list($_, $domain) = explode('@', $username);
+            $params = ['username' => $username, 'domain' => $domain];
+            $query = "SELECT * FROM $table WHERE username = :username OR username = :domain OR username IS NULL ORDER BY $this->order_by";
+        }
+
+        if ($limit > -1 && $offset > -1) {
+            $query .= " LIMIT $limit OFFSET $offset";
+        }
+
+        $db_result = array();
+        $result = db_query_all($query, $params);
+        foreach ($result as $row) {
+            $db_result[$row[$this->id_field]] = $row;
+        }
+        return $db_result;
+    }
+
+    protected function preSave(): bool
+    {
+        // Validate IP address
+        if (isset($this->values['ip']) && !filter_var($this->values['ip'], FILTER_VALIDATE_IP)) {
+            $this->errormsg['ip'] = Config::Lang('pException_ip_empty_error');
+            return false;
+        }
+
+        // Regular users can only add exceptions for their own username
+        if (!authentication_has_role('admin') && !authentication_has_role('global-admin')) {
+            $this->values['username'] = $this->admin_username;
+        }
+
+        // Admins can only add exceptions for domains they manage
+        if (authentication_has_role('admin') && !authentication_has_role('global-admin')) {
+            $exception_username = $this->values['username'] ?? '';
+            if ($exception_username !== $this->admin_username) {
+                if (strpos($exception_username, '@')) {
+                    list($_, $exception_domain) = explode('@', $exception_username);
+                } else {
+                    $exception_domain = $exception_username;
+                }
+                $domains = list_domains_for_admin($this->admin_username);
+                if (!in_array($exception_domain, $domains)) {
+                    $this->errormsg['username'] = Config::Lang('pException_user_entire_domain_error');
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    protected function postSave(): bool
+    {
+        if ($this->new) {
+            $cmd = Config::read('mailbox_post_totp_exception_add_script');
+            $warnmsg = Config::Lang('mailbox_post_totp_exception_add_failed');
+        } else {
+            return true;
+        }
+
+        if (empty($cmd)) {
+            return true;
+        }
+
+        $cmdarg1 = escapeshellarg($this->admin_username);
+        $cmdarg2 = escapeshellarg($this->values['ip'] ?? '');
+        $command = "$cmd $cmdarg1 $cmdarg2 2>&1";
+
+        $spec = [0 => ["pipe", "r"], 1 => ["pipe", "w"]];
+        $proc = proc_open($command, $spec, $pipes);
+        if (!$proc) {
+            error_log("can't proc_open $cmd");
+            $this->errormsg[] = $warnmsg;
+            return false;
+        }
+
+        fclose($pipes[0]);
+        $output = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        $retval = proc_close($proc);
+
+        if (0 != $retval) {
+            error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+            $this->errormsg[] = $warnmsg;
+            return false;
+        }
+
+        return true;
+    }
+
+    public function delete()
+    {
+        if (!$this->view()) {
+            $this->errormsg[] = Config::Lang($this->msg['error_does_not_exist']);
+            return false;
+        }
+
+        // Check permissions
+        $exception = $this->result;
+        $username = $this->admin_username;
+
+        if (!authentication_has_role('global-admin')) {
+            if (authentication_has_role('admin')) {
+                $domains = list_domains_for_admin($username);
+                $exception_username = $exception['username'] ?? '';
+                if ($exception_username !== $username) {
+                    if (strpos($exception_username, '@')) {
+                        list($_, $exception_domain) = explode('@', $exception_username);
+                    } else {
+                        $exception_domain = $exception_username;
+                    }
+                    if (!in_array($exception_domain, $domains)) {
+                        $this->errormsg[] = Config::Lang('pException_user_entire_domain_error');
+                        return false;
+                    }
+                }
+            } else {
+                if ($exception['username'] !== $username) {
+                    $this->errormsg[] = Config::lang('pEdit_totp_exception_result_error');
+                    return false;
+                }
+            }
+        }
+
+        db_delete($this->db_table, $this->id_field, $this->id);
+
+        // Run post-delete script
+        $cmd = Config::read('mailbox_post_totp_exception_delete_script');
+        if (!empty($cmd)) {
+            $cmdarg1 = escapeshellarg($username);
+            $cmdarg2 = escapeshellarg($exception['ip'] ?? '');
+            $command = "$cmd $cmdarg1 $cmdarg2 2>&1";
+
+            $spec = [0 => ["pipe", "r"], 1 => ["pipe", "w"]];
+            $proc = proc_open($command, $spec, $pipes);
+            if ($proc) {
+                fclose($pipes[0]);
+                $output = stream_get_contents($pipes[1]);
+                fclose($pipes[1]);
+                $retval = proc_close($proc);
+                if (0 != $retval) {
+                    error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+                    $this->errormsg[] = Config::Lang('mailbox_post_totp_exception_delete_failed');
+                }
+            }
+        }
+
+        db_log($this->admin_username, 'delete_totp_exception', $exception['ip'] ?? '');
+        $this->infomsg[] = Config::Lang_f('pDelete_delete_success', $exception['ip'] ?? $this->id);
+        return true;
+    }
+
+    public function domain_from_id()
+    {
+        return '';
+    }
+}

--- a/model/TotpexceptionHandler.php
+++ b/model/TotpexceptionHandler.php
@@ -35,7 +35,7 @@ class TotpexceptionHandler extends PFAHandler
         $this->struct = array(
             # field name              allow       display in...   type    $PALANG label                     $PALANG description  default / options / ...
             #                         editing?    form    list
-            'id'          => self::pacol(0,       0,      1,      'num',  'pFetchmail_field_id',            '', '', array(), array('dont_write_to_db' => 1)),
+            'id'          => self::pacol(0,       0,      1,      'num',  'pFetchmail_field_id',            '', '', array(), 1),
             'username'    => self::pacol(1,       1,      1,      'text', 'pTotp_exceptions_user',          ''),
             'ip'          => self::pacol(1,       1,      1,      'text', 'pTotp_exceptions_address',       ''),
             'description' => self::pacol(1,       1,      1,      'text', 'pTotp_exceptions_description',   ''),

--- a/model/TotpexceptionHandler.php
+++ b/model/TotpexceptionHandler.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * Handler for TOTP exception addresses.
+ *
+ * Manages IP addresses that are exempt from TOTP requirements.
+ * Exceptions can be scoped to a specific user, a domain, or global (NULL username).
+ *
+ * Visibility rules:
+ * - Superadmins see all exceptions
+ * - Admins see exceptions for users/domains they manage
+ * - Users see exceptions for their username, domain, and global (NULL)
+ */
 class TotpexceptionHandler extends PFAHandler
 {
     protected string $db_table = 'totp_exception_address';
@@ -9,13 +20,16 @@ class TotpexceptionHandler extends PFAHandler
     protected string $order_by = 'username, ip';
     protected ?string $user_field = 'username';
 
+    /**
+     * TOTP exceptions are not domain-scoped in the traditional sense.
+     * Visibility is handled in read_from_db_postprocess().
+     */
     protected function no_domain_field()
     {
-        // TOTP exceptions are not domain-scoped in the traditional sense.
-        // Visibility is handled in read_from_db_postprocess().
         $this->allowed_domains = [];
     }
 
+    /** @return void */
     protected function initStruct()
     {
         $this->struct = array(
@@ -45,6 +59,7 @@ class TotpexceptionHandler extends PFAHandler
         }
     }
 
+    /** @return array<string, mixed> */
     public function webformConfig()
     {
         return array(
@@ -59,6 +74,7 @@ class TotpexceptionHandler extends PFAHandler
         );
     }
 
+    /** @return bool */
     protected function validate_new_id()
     {
         if ($this->id != '') {
@@ -70,6 +86,10 @@ class TotpexceptionHandler extends PFAHandler
 
     /**
      * Validate IP address field.
+     *
+     * @param string $field field name
+     * @param string $value submitted value
+     * @return bool true if valid
      */
     protected function _validate_ip(string $field, string $value): bool
     {
@@ -85,7 +105,12 @@ class TotpexceptionHandler extends PFAHandler
     }
 
     /**
-     * Validate username field — enforce permissions based on role.
+     * Validate username field and enforce permissions based on role.
+     * Empty username is normalised to NULL (global exception, superadmin only).
+     *
+     * @param string $field field name
+     * @param string $value submitted value
+     * @return bool true if valid
      */
     protected function _validate_username(string $field, string $value): bool
     {
@@ -130,6 +155,9 @@ class TotpexceptionHandler extends PFAHandler
      * - Superadmins see all
      * - Admins see exceptions for their managed domains + own username
      * - Users see exceptions for their username, domain, and global (NULL)
+     *
+     * @param array $db_result rows keyed by ID
+     * @return array filtered rows
      */
     protected function read_from_db_postprocess($db_result)
     {
@@ -169,6 +197,11 @@ class TotpexceptionHandler extends PFAHandler
         return $filtered;
     }
 
+    /**
+     * Run post-creation script if configured.
+     *
+     * @return bool true on success
+     */
     protected function postSave(): bool
     {
         if (!$this->new) {
@@ -187,6 +220,11 @@ class TotpexceptionHandler extends PFAHandler
         return $this->run_post_script($command, Config::Lang('mailbox_post_totp_exception_add_failed'));
     }
 
+    /**
+     * Delete a TOTP exception with role-based permission checks.
+     *
+     * @return bool true on success
+     */
     public function delete()
     {
         if (!$this->view()) {
@@ -237,6 +275,10 @@ class TotpexceptionHandler extends PFAHandler
 
     /**
      * Run a post-save/delete script via proc_open.
+     *
+     * @param string $command full shell command to execute
+     * @param string $warnmsg error message to display on failure
+     * @return bool true on success
      */
     private function run_post_script(string $command, string $warnmsg): bool
     {
@@ -262,6 +304,9 @@ class TotpexceptionHandler extends PFAHandler
         return true;
     }
 
+    /**
+     * @return string empty string, TOTP exceptions are not domain-scoped
+     */
     public function domain_from_id()
     {
         return '';

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2183,3 +2183,40 @@ function upgrade_1851_mysql()
         )
     ");
 }
+
+/**
+ * Add created/modified columns to totp_exception_address table.
+ * Required for TotpexceptionHandler to work with PFAHandler's save() method.
+ */
+function upgrade_1852_mysql()
+{
+    $table = table_by_key('totp_exception_address');
+    if (!_mysql_field_exists($table, 'created')) {
+        db_query("ALTER TABLE $table ADD COLUMN created datetime DEFAULT NULL");
+    }
+    if (!_mysql_field_exists($table, 'modified')) {
+        db_query("ALTER TABLE $table ADD COLUMN modified datetime DEFAULT NULL");
+    }
+}
+
+function upgrade_1852_pgsql()
+{
+    $table = table_by_key('totp_exception_address');
+    if (!_pgsql_field_exists($table, 'created')) {
+        db_query("ALTER TABLE $table ADD COLUMN created timestamp DEFAULT NULL");
+    }
+    if (!_pgsql_field_exists($table, 'modified')) {
+        db_query("ALTER TABLE $table ADD COLUMN modified timestamp DEFAULT NULL");
+    }
+}
+
+function upgrade_1852_sqlite()
+{
+    $table = table_by_key('totp_exception_address');
+    if (!_sqlite_field_exists($table, 'created')) {
+        db_query("ALTER TABLE $table ADD COLUMN created datetime DEFAULT NULL");
+    }
+    if (!_sqlite_field_exists($table, 'modified')) {
+        db_query("ALTER TABLE $table ADD COLUMN modified datetime DEFAULT NULL");
+    }
+}

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2188,35 +2188,8 @@ function upgrade_1851_mysql()
  * Add created/modified columns to totp_exception_address table.
  * Required for TotpexceptionHandler to work with PFAHandler's save() method.
  */
-function upgrade_1852_mysql()
+function upgrade_1852()
 {
-    $table = table_by_key('totp_exception_address');
-    if (!_mysql_field_exists($table, 'created')) {
-        db_query("ALTER TABLE $table ADD COLUMN created datetime DEFAULT NULL");
-    }
-    if (!_mysql_field_exists($table, 'modified')) {
-        db_query("ALTER TABLE $table ADD COLUMN modified datetime DEFAULT NULL");
-    }
-}
-
-function upgrade_1852_pgsql()
-{
-    $table = table_by_key('totp_exception_address');
-    if (!_pgsql_field_exists($table, 'created')) {
-        db_query("ALTER TABLE $table ADD COLUMN created timestamp DEFAULT NULL");
-    }
-    if (!_pgsql_field_exists($table, 'modified')) {
-        db_query("ALTER TABLE $table ADD COLUMN modified timestamp DEFAULT NULL");
-    }
-}
-
-function upgrade_1852_sqlite()
-{
-    $table = table_by_key('totp_exception_address');
-    if (!_sqlite_field_exists($table, 'created')) {
-        db_query("ALTER TABLE $table ADD COLUMN created datetime DEFAULT NULL");
-    }
-    if (!_sqlite_field_exists($table, 'modified')) {
-        db_query("ALTER TABLE $table ADD COLUMN modified datetime DEFAULT NULL");
-    }
+    _db_add_field('totp_exception_address', 'created', '{DATECURRENT}');
+    _db_add_field('totp_exception_address', 'modified', '{DATECURRENT}');
 }

--- a/templates/users_main.tpl
+++ b/templates/users_main.tpl
@@ -26,7 +26,7 @@
             <td>{$PALANG.pUsersMain_totp}</td>
         </tr>
         <tr>
-            <td nowrap="nowrap"><a class="btn btn-primary" href="{#url_totp_exceptions#}">{$PALANG.pMenu_totp_exceptions}</a></td>
+            <td nowrap="nowrap"><a class="btn btn-primary" href="{#url_user_totp_exceptions#}">{$PALANG.pMenu_totp_exceptions}</a></td>
             <td>{$PALANG.pUsersMain_totp_exceptions}</td>
         </tr>
         {/strip}

--- a/templates/users_menu.tpl
+++ b/templates/users_menu.tpl
@@ -27,7 +27,7 @@
                             <ul class="dropdown-menu">
                                 <li><a class="nav-item dropdown-item" href="password.php"><span class="nav-item bi bi-lock" aria-hidden="true"></span> {$PALANG.change_password}</a></li>
                                 <li><a class="nav-item dropdown-item" href="{#url_totp#}"><span class="nav-item bi bi-lock" aria-hidden="true"></span> {$PALANG.pUsersMenu_totp}</a></li>
-                                <li><a class="nav-item dropdown-item" href="{#url_totp_exceptions#}"><span class="nav-item bi bi-lock" aria-hidden="true"></span> {$PALANG.pMenu_totp_exceptions}</a></li>
+                                <li><a class="nav-item dropdown-item" href="{#url_user_totp_exceptions#}"><span class="nav-item bi bi-lock" aria-hidden="true"></span> {$PALANG.pMenu_totp_exceptions}</a></li>
                                 {if $CONF.app_passwords==='YES'}
                                 <li><a class="nav-item dropdown-item" href="{#url_app_passwords#}"><span class="nav-item bi bi-lock" aria-hidden="true"></span> {$PALANG.pMenu_app_passwords}</a></li>
                                 {/if}


### PR DESCRIPTION
As discussed with @cboltz on IRC - migrates TOTP exceptions from the custom totp-exceptions.php pages to a proper PFAHandler class, so they work with the standard list.php/edit.php infrastructure.

**What changed:**
- New `TotpexceptionHandler` class in `model/TotpexceptionHandler.php`
- Menu links updated to use `list.php?table=totpexception`
- User menu uses `../list.php?table=totpexception` for correct path resolution

**The Handler provides:**
- Standard CRUD via list.php/edit.php
- Role-based visibility (users see own + domain + global, admins see managed domains, global admins see all)
- IP validation in preSave
- Permission checks in preSave and delete
- Post-add/delete script execution (mailbox_post_totp_exception_add_script / _delete_script)

**Not removed yet:**
- The old totp-exceptions.php files (public/ and public/users/) are still present. Can be removed in a follow-up once this is confirmed working.

Two commits for easy review.