### PR TITLE
Add developer documentation for Handler classes

### DIFF
--- a/DOCUMENTS/HANDLER_CLASSES.md
+++ b/DOCUMENTS/HANDLER_CLASSES.md
@@ -101,7 +101,7 @@ protected function initStruct()
 | Type | Description |
 |------|-------------|
 | `text` | Text input |
-| `mail` | Email address (validated) |
+| `mail` | Email address (treated as text unless handler adds `_validate_*`) |
 | `pass` | Password (hashed via `pacrypt()` before storage) |
 | `b64p` | Base64-encoded password |
 | `num` | Numeric |
@@ -114,6 +114,10 @@ protected function initStruct()
 | `vnum` | Virtual numeric (not stored in DB) |
 | `vtxt` | Virtual text (not stored in DB) |
 | `quot` | Quota display |
+
+This list covers the most common types. Additional types may exist in
+`PFAHandler` and individual Handler classes — check the source for the
+full set.
 
 **Additional options via `$multiopt` array:**
 
@@ -173,8 +177,12 @@ public function webformConfig()
 }
 ```
 
-The `user_hardcoded_field` tells `list.php` / `edit.php` / `delete.php` which
-field to automatically set to the logged-in username when in user mode.
+The `user_hardcoded_field` must be set (non-empty) for `list.php` / `edit.php` /
+`delete.php` to allow user-mode access. It names the field that identifies the
+owning user, but note that the web entry points only check that this key is
+non-empty — they do not automatically set the field value. User scoping for
+SELECT queries is handled by `PFAHandler::$user_field`, and write enforcement
+must be done in the Handler itself (e.g. via `_validate_*` or `preSave()`).
 
 ### 7. Auto-increment IDs
 
@@ -297,7 +305,7 @@ Then reference them in templates using `{#url_foo#}`.
 
 ## Lifecycle
 
-1. `list.php`/`edit.php` instantiates the Handler: `new FooHandler($new, $username)`
+1. `list.php`/`edit.php` instantiates the Handler: `new FooHandler($new, $username, $is_admin)`
 2. Constructor calls `initStruct()`, `initMsg()`, sets up `$allowed_domains`
 3. For edit: `init($id)` loads the item, `set($values)` validates input, `save()` writes to DB
 4. `save()` calls `preSave()`, does the INSERT/UPDATE, then calls `postSave()`

--- a/DOCUMENTS/HANDLER_CLASSES.md
+++ b/DOCUMENTS/HANDLER_CLASSES.md
@@ -1,0 +1,304 @@
+# Handler Classes - Developer Guide
+
+This document explains how Handler classes work in PostfixAdmin, and how to
+create new ones.
+
+## Overview
+
+Handler classes extend `PFAHandler` and provide a standardised way to manage
+database entities. Once a Handler is created, it automatically works with:
+
+- `list.php` - list/search view
+- `edit.php` - create/edit form
+- `delete.php` - deletion
+- `editactive.php` - toggle active status
+- CLI via `postfixadmin-cli`
+
+Existing examples: `DkimHandler`, `FetchmailHandler`, `MailboxHandler`,
+`AliasHandler`, `DomainHandler`, `AdminHandler`.
+
+## Creating a Handler
+
+### 1. File and Class Naming
+
+The class name must match the URL parameter: `list.php?table=foo` loads
+`FooHandler` from `model/FooHandler.php`. Note that only the first letter is
+capitalised:
+
+- `table=dkim` -> `DkimHandler`
+- `table=aliasdomain` -> `AliasdomainHandler`
+
+The class autoloader scans `model/` via the `classmap` in `composer.json`.
+
+### 2. Required Properties
+
+```php
+class FooHandler extends PFAHandler
+{
+    protected string $db_table = 'foo';          // database table name
+    protected string $id_field = 'id';           // primary key column
+    protected string $label_field = 'name';      // column used as display label
+    protected ?string $domain_field = 'domain';  // column containing domain (or '' if none)
+    protected string $order_by = 'name';         // ORDER BY clause
+}
+```
+
+If the table has no domain column, set `$domain_field = ''` and override
+`no_domain_field()`:
+
+```php
+protected function no_domain_field()
+{
+    // Prevent the default die() - handle domain filtering yourself
+    $this->allowed_domains = [];
+}
+```
+
+### 3. User Mode
+
+If the Handler should be accessible to non-admin users (via `users/`), set
+`$user_field` to the column that identifies the owning user:
+
+```php
+protected ?string $user_field = 'username';
+```
+
+Also add `user_hardcoded_field` to `webformConfig()` (see below). If
+`$user_field` is empty and a user (non-admin) tries to access the Handler,
+the default `no_user_field()` will call `die()`.
+
+### 4. initStruct() - Field Definitions
+
+Define each field using `pacol()`:
+
+```php
+protected function initStruct()
+{
+    $this->struct = array(
+        'id'   => self::pacol($allow_editing, $display_in_form, $display_in_list,
+                              $type, $PALANG_label, $PALANG_desc, $default,
+                              $options, $multiopt),
+    );
+}
+```
+
+**pacol() parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$allow_editing` | int | 1 = editable, 0 = read-only |
+| `$display_in_form` | int | 1 = show in edit form, 0 = hide |
+| `$display_in_list` | int | 1 = show in list view, 0 = hide |
+| `$type` | string | Field type (see below) |
+| `$PALANG_label` | string | Language key for the field label |
+| `$PALANG_desc` | string | Language key for the help/description text |
+| `$default` | mixed | Default value |
+| `$options` | array | Options for `enum`/`list` types |
+| `$multiopt` | array or int | Named array for additional options, or `$not_in_db` as int |
+
+**Field types:**
+
+| Type | Description |
+|------|-------------|
+| `text` | Text input |
+| `mail` | Email address (validated) |
+| `pass` | Password (hashed via `pacrypt()` before storage) |
+| `b64p` | Base64-encoded password |
+| `num` | Numeric |
+| `bool` | Boolean (converted to database-specific boolean) |
+| `enum` | Dropdown from `$options` array |
+| `list` | Multi-select list |
+| `txta` | Textarea |
+| `txtl` | Text, displayed as list in list view |
+| `ts` | Timestamp (auto-formatted per locale) |
+| `vnum` | Virtual numeric (not stored in DB) |
+| `vtxt` | Virtual text (not stored in DB) |
+| `quot` | Quota display |
+
+**Additional options via `$multiopt` array:**
+
+```php
+self::pacol(0, 0, 1, 'num', 'label', '', '', array(),
+    array('dont_write_to_db' => 1))
+```
+
+| Key | Description |
+|-----|-------------|
+| `not_in_db` | Field doesn't exist in the database table |
+| `dont_write_to_db` | Field exists but should not be written on save |
+| `select` | Custom SQL expression replacing the column name in SELECT |
+| `extrafrom` | SQL fragment added after FROM (for JOINs) |
+| `linkto` | Make the value a link (`%s` replaced with ID) |
+
+### 5. initMsg() - Messages
+
+Define messages used for logging and user feedback:
+
+```php
+protected function initMsg()
+{
+    $this->msg['error_already_exists'] = 'PALANG_key';
+    $this->msg['error_does_not_exist'] = 'PALANG_key';
+    $this->msg['confirm_delete'] = 'PALANG_key';
+
+    if ($this->new) {
+        $this->msg['logname'] = 'create_foo';
+        $this->msg['store_error'] = 'PALANG_error_key';
+        $this->msg['successmessage'] = 'PALANG_success_key';
+    } else {
+        $this->msg['logname'] = 'edit_foo';
+        $this->msg['store_error'] = 'PALANG_error_key';
+        $this->msg['successmessage'] = 'PALANG_success_key';
+    }
+}
+```
+
+### 6. webformConfig() - Form/List Configuration
+
+Controls how `list.php` and `edit.php` render the Handler:
+
+```php
+public function webformConfig()
+{
+    return array(
+        'formtitle_create' => 'PALANG_create_title',
+        'formtitle_edit' => 'PALANG_edit_title',
+        'create_button' => 'PALANG_create_button',
+
+        'required_role' => 'admin',           // 'admin' or 'global-admin'
+        'listview' => 'list.php?table=foo',   // redirect target after edit
+        'early_init' => 0,                    // 1 = call init() before set()
+        'user_hardcoded_field' => 'username', // required if users can access
+    );
+}
+```
+
+The `user_hardcoded_field` tells `list.php` / `edit.php` / `delete.php` which
+field to automatically set to the logged-in username when in user mode.
+
+### 7. Auto-increment IDs
+
+If your table uses auto-increment for the primary key:
+
+```php
+protected function validate_new_id()
+{
+    if ($this->id != '') {
+        $this->errormsg[$this->id_field] = 'auto_increment value, you must pass an empty string!';
+        return false;
+    }
+    return true;
+}
+```
+
+### 8. Field Validation
+
+Create methods named `_validate_FIELDNAME()` for custom validation:
+
+```php
+protected function _validate_ip(string $field, string $value): bool
+{
+    if (!filter_var($value, FILTER_VALIDATE_IP)) {
+        $this->errormsg[$field] = Config::Lang('invalid_ip');
+        return false;
+    }
+    return true;
+}
+```
+
+These are called automatically by `PFAHandler::set()` when processing input.
+
+### 9. Hooks: preSave() and postSave()
+
+Override these to add logic before/after database writes:
+
+```php
+protected function preSave(): bool
+{
+    // Modify $this->values before save
+    // Return false to abort
+    return true;
+}
+
+protected function postSave(): bool
+{
+    // Run after successful save (e.g. hook scripts)
+    return true;
+}
+```
+
+### 10. Custom delete()
+
+Override to add permission checks or post-delete actions:
+
+```php
+public function delete()
+{
+    if (!$this->view()) {
+        $this->errormsg[] = Config::Lang($this->msg['error_does_not_exist']);
+        return false;
+    }
+
+    // Custom permission checks using $this->result
+
+    db_delete($this->db_table, $this->id_field, $this->id);
+
+    db_log($this->domain, 'delete_foo', $this->id);
+    $this->infomsg[] = Config::Lang_f('pDelete_delete_success', $this->result['label']);
+    return true;
+}
+```
+
+### 11. Post-processing Results
+
+Override `read_from_db_postprocess()` to filter or modify results after they
+are read from the database:
+
+```php
+protected function read_from_db_postprocess($db_result)
+{
+    // Filter, modify, or augment results
+    return $db_result;
+}
+```
+
+This is preferred over overriding `read_from_db()` directly.
+
+## Key Internal Variables
+
+| Variable | Description |
+|----------|-------------|
+| `$this->id` | Current item ID (set by `init()`) |
+| `$this->new` | 1 = create mode, 0 = edit mode |
+| `$this->values` | Validated values (set by `set()`) |
+| `$this->result` | Current item data (set by `view()`) |
+| `$this->is_admin` | 1 = admin/superadmin, 0 = user |
+| `$this->is_superadmin` | 1 = global admin, 0 = regular admin or user |
+| `$this->admin_username` | Admin username (empty for users) |
+| `$this->username` | Username (set in user mode) |
+| `$this->allowed_domains` | Domains this admin can manage |
+| `$this->domain` | Domain of current item |
+| `$this->struct` | Field structure definitions |
+
+## Menu Integration
+
+Add URL mappings to `configs/menu.conf`:
+
+```ini
+# admin menu
+url_foo = list.php?table=foo
+url_foo_new = edit.php?table=foo
+
+# user menu (note the ../ prefix for accessing public/ from public/users/)
+url_user_foo = ../list.php?table=foo
+```
+
+Then reference them in templates using `{#url_foo#}`.
+
+## Lifecycle
+
+1. `list.php`/`edit.php` instantiates the Handler: `new FooHandler($new, $username)`
+2. Constructor calls `initStruct()`, `initMsg()`, sets up `$allowed_domains`
+3. For edit: `init($id)` loads the item, `set($values)` validates input, `save()` writes to DB
+4. `save()` calls `preSave()`, does the INSERT/UPDATE, then calls `postSave()`
+5. For list: `getList($condition)` calls `build_select_query()` -> `read_from_db()` -> `read_from_db_postprocess()`

--- a/DOCUMENTS/HANDLER_CLASSES.md
+++ b/DOCUMENTS/HANDLER_CLASSES.md
@@ -54,7 +54,7 @@ protected function no_domain_field()
 }
 ```
 
-### 3. User Mode
+### 3. Non-admin user access
 
 If the Handler should be accessible to non-admin users (via `users/`), set
 `$user_field` to the column that identifies the owning user:
@@ -67,34 +67,42 @@ Also add `user_hardcoded_field` to `webformConfig()` (see below). If
 `$user_field` is empty and a user (non-admin) tries to access the Handler,
 the default `no_user_field()` will call `die()`.
 
-### 4. initStruct() - Field Definitions
+### 4. Field Definitions - initStruct() 
 
-Define each field using `pacol()`:
+The `initStruct()` method is used to define the fields that will be rendered in the list / edit forms. 
+
+Generally these will map onto database fields, but you can create virtual fields if necessary.
+
 
 ```php
 protected function initStruct()
 {
-    $this->struct = array(
+    $this->struct = [
         'id'   => self::pacol($allow_editing, $display_in_form, $display_in_list,
                               $type, $PALANG_label, $PALANG_desc, $default,
                               $options, $multiopt),
-    );
+        // other fields here...                      
+    ];
 }
 ```
 
-**pacol() parameters:**
+#### pacol() parameters
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `$allow_editing` | int | 1 = editable, 0 = read-only |
-| `$display_in_form` | int | 1 = show in edit form, 0 = hide |
-| `$display_in_list` | int | 1 = show in list view, 0 = hide |
-| `$type` | string | Field type (see below) |
-| `$PALANG_label` | string | Language key for the field label |
-| `$PALANG_desc` | string | Language key for the help/description text |
-| `$default` | mixed | Default value |
-| `$options` | array | Options for `enum`/`list` types |
-| `$multiopt` | array or int | Named array for additional options, or `$not_in_db` as int |
+| Parameter           | Type | Description                                                                                                            |
+|---------------------|------|------------------------------------------------------------------------------------------------------------------------|
+| `$allow_editing`    | int | 1 = editable, 0 = read-only                                                                                            |
+| `$display_in_form`  | int | 1 = show in edit form, 0 = hide                                                                                        |
+| `$display_in_list`  | int | 1 = show in list view, 0 = hide                                                                                        |
+| `$type`             | string | Field type (see below)                                                                                                 |
+| `$PALANG_label`     | string | Language key for the field label                                                                                       |
+| `$PALANG_desc`      | string | Language key for the help/description text                                                                             |
+| `$default`          | mixed | Default value                                                                                                          |
+| `$options`          | array | Options for `enum`/`list` types                                                                                        |
+| `$not_in_db`        | int | 1 - not in db, 0 - in db. (LEGACY: named array for additional options to this function)                                |
+| `$dont_write_to_db` | int | Do not write field into DB                                                                                             |
+| `$select`           | string | Custom SQL expression replacing the column name in SELECT, see e.g. AdminHandler's domain_count definition for example |
+| `$extrafrom`        | string | SQL fragment added after FROM (for JOINs)                                                                              |
+| `$linkto`           | string | Make the value a link (`%s` replaced with ID)                                                                          |
 
 **Field types:**
 
@@ -119,24 +127,10 @@ This list covers the most common types. Additional types may exist in
 `PFAHandler` and individual Handler classes — check the source for the
 full set.
 
-**Additional options via `$multiopt` array:**
 
-```php
-self::pacol(0, 0, 1, 'num', 'label', '', '', array(),
-    array('dont_write_to_db' => 1))
-```
+### 5. Messages - initMsg() 
 
-| Key | Description |
-|-----|-------------|
-| `not_in_db` | Field doesn't exist in the database table |
-| `dont_write_to_db` | Field exists but should not be written on save |
-| `select` | Custom SQL expression replacing the column name in SELECT |
-| `extrafrom` | SQL fragment added after FROM (for JOINs) |
-| `linkto` | Make the value a link (`%s` replaced with ID) |
-
-### 5. initMsg() - Messages
-
-Define messages used for logging and user feedback:
+This allows you to override the default messages PostfixAdmin will use when various errors occur, replace PALANG_key with an actual key from a language file, e.g alias_domain_already_exists
 
 ```php
 protected function initMsg()
@@ -157,7 +151,7 @@ protected function initMsg()
 }
 ```
 
-### 6. webformConfig() - Form/List Configuration
+### 6. Form/List Configuration - webformConfig() 
 
 Controls how `list.php` and `edit.php` render the Handler:
 
@@ -230,7 +224,7 @@ protected function preSave(): bool
 
 protected function postSave(): bool
 {
-    // Run after successful save (e.g. hook scripts)
+    // Run after a successful save (e.g. hook scripts)
     return true;
 }
 ```

--- a/model/AdminHandler.php
+++ b/model/AdminHandler.php
@@ -49,8 +49,7 @@ class AdminHandler extends PFAHandler
         $this->struct = array(
             # field name                allow       display in...   type    $PALANG label          $PALANG description   default / options / ...
             #                           editing?    form    list
-            'username'         => self::pacol($this->new, 1,      1,      'text', 'admin'              , 'email_address'     , '', array(),
-                array('linkto' => 'list.php?table=domain&username=%s')),
+            'username'         => self::pacol($this->new, 1,      1,      'text', 'admin'              , 'email_address'   , '', array(), 0, 0, "", "", 'list.php?table=domain&username=%s'),
             'password'         => self::pacol(1,          1,      0,      'pass', 'password'           , ''),
             'password2'        => self::pacol(1,          1,      0,      'pass', 'password_again'     , ''                  , '', array(),
                 /*not_in_db*/ 0,

--- a/model/AliasHandler.php
+++ b/model/AliasHandler.php
@@ -27,8 +27,7 @@ class AliasHandler extends PFAHandler
         $this->struct = array(
             # field name                allow       display in...   type    $PALANG label                     $PALANG description                 default / ...
             #                           editing?    form    list
-            'status'           => self::pacol(0,          0,      0,      'html', ''                              , ''                                , '', array(),
-                array('not_in_db' => 1)),
+            'status'           => self::pacol(0,          0,      0,      'html', ''                              , ''                                , '', array(), 1),
             'address'          => self::pacol($this->new, 1,      1,      'mail', 'alias'                         , 'pCreate_alias_catchall_text'),
             'localpart'        => self::pacol($this->new, 0,      0,      'text', 'alias'                         , 'pCreate_alias_catchall_text'     , '',
                 /*options*/ array(),
@@ -54,10 +53,8 @@ class AliasHandler extends PFAHandler
             'created'          => self::pacol(0,          0,      0,      'ts',   'created'                       , ''),
             'modified'         => self::pacol(0,          0,      1,      'ts',   'last_modified'                 , ''),
             'active'           => self::pacol(1,          1,      1,      'bool', 'active'                        , ''                                , 1),
-            '_can_edit'        => self::pacol(0,          0,      1,      'vnum', ''                              , ''                                , 0 , array(),
-                array('select' => '1 as _can_edit')),
-            '_can_delete'      => self::pacol(0,          0,      1,      'vnum', ''                              , ''                                , 0 , array(),
-                array('select' => '1 as _can_delete')), # read_from_db_postprocess() updates the value
+            '_can_edit'        => self::pacol(0,          0,      1,      'vnum', ''                              , ''                                , 0, array(), 0, 0, '1 as _can_edit'),
+            '_can_delete'      => self::pacol(0,          0,      1,      'vnum', ''                              , ''                                , 0, array(), 0, 0, '1 as _can_delete'), # read_from_db_postprocess() updates the value
                 # aliases listed in $CONF[default_aliases] are read-only for domain admins if $CONF[special_alias_control] is NO.
         );
 

--- a/model/AliasdomainHandler.php
+++ b/model/AliasdomainHandler.php
@@ -18,8 +18,7 @@ class AliasdomainHandler extends PFAHandler
             # field name                allow       display in...   type    $PALANG label                     $PALANG description                 default / options / ...
             #                           editing?    form    list
             'alias_domain'     => self::pacol($this->new, 1,      1,      'enum', 'pCreate_alias_domain_alias'    , 'pCreate_alias_domain_alias_text' , '',
-                /*options, filled below*/ array(),
-                /* multiopt */ array('linkto' => 'list-virtual.php?domain=%s')),
+                /*options, filled below*/ array(), 0, 0, "", "", 'list-virtual.php?domain=%s'),
             'target_domain'    => self::pacol(1,          1,      1,      'enum', 'pCreate_alias_domain_target'   , 'pCreate_alias_domain_target_text', '',
                 /*options*/ array() /* filled below */),
             'created'          => self::pacol(0,          0,      0,      'ts',   'created'                       , ''),

--- a/model/DkimHandler.php
+++ b/model/DkimHandler.php
@@ -19,7 +19,7 @@ class DkimHandler extends PFAHandler
         $this->struct = array(
             # field name                allow       display in...   type     $PALANG label           $PALANG description          default / options / ...
             #                           editing?    form    list
-            'id'               => self::pacol(0,          0,      1,      'num' , 'pFetchmail_field_id' , ''                         , '', array(), array('dont_write_to_db' => 1)),
+            'id'               => self::pacol(0,          0,      1,      'num' , 'pFetchmail_field_id' , ''                         , '', array(), 0, 1),
             'description'      => self::pacol(1,          1,      1,      'text', 'description'         , ''),
             'selector'         => self::pacol(1,          1,      1,      'text', 'pDkim_field_selector', 'pDkim_field_selector_desc'),
             'domain_name'      => self::pacol(1,          1,      1,      'enum', 'domain'              , 'pDkim_field_domain_desc'  , '', $this->allowed_domains),

--- a/model/DkimsigningHandler.php
+++ b/model/DkimsigningHandler.php
@@ -34,7 +34,7 @@ class DkimsigningHandler extends PFAHandler
         $this->struct = array(
             # field name                allow       display in...   type        $PALANG label           $PALANG description       default / options / ...
             #                           editing?    form    list
-            'id'               => self::pacol(0,          0,      1,      'num'     , 'pFetchmail_field_id' , ''                         , '', array(), array('dont_write_to_db' => 1)),
+            'id'               => self::pacol(0,          0,      1,      'num'     , 'pFetchmail_field_id' , ''                         , '', array(), 0, 1),
             'dkim_id'          => self::pacol(1,          1,      1,      'enum'    , 'pDkim_field_dkim_id' , 'pDkim_field_dkim_id_desc' , '', array_keys($dkim_handler->result)),
             'author'           => self::pacol(1,          1,      1,      'enum'    , 'pDkim_field_author'  , 'pDkim_field_author_desc'  , '', $authors),
         );

--- a/model/DomainHandler.php
+++ b/model/DomainHandler.php
@@ -58,8 +58,7 @@ class DomainHandler extends PFAHandler
         $this->struct = array(
             # field name                allow       display in...   type    $PALANG label                    $PALANG description                 default / options / ...
             #                           editing?    form    list
-           'domain'            => self::pacol($this->new, 1,      1,      'text', 'domain'                       , ''                                 , '', array(),
-               array('linkto' => 'list-virtual.php?domain=%s')),
+           'domain'            => self::pacol($this->new, 1,      1,      'text', 'domain'                       , ''                                 ,'', array(), 0, 0, "", "", 'list-virtual.php?domain=%s'),
            'description'       => self::pacol($super,     $super, $super, 'text', 'description'                  , ''),
 
            # Aliases
@@ -70,34 +69,25 @@ class DomainHandler extends PFAHandler
                /*select*/ 'coalesce(__alias_count,0) - coalesce(__mailbox_count,0)  as alias_count',
                /*extrafrom*/ 'left join ( select count(*) as __alias_count, domain as __alias_domain from ' . table_by_key('alias') .
                              ' group by domain) as __alias on domain = __alias_domain'),
-            'aliases_quot'     => self::pacol(0,          0,      1,      'quot', 'aliases'                      , ''                                  , 0, array(),
-                array('select' => db_quota_text('__alias_count - coalesce(__mailbox_count,0)', 'aliases', 'aliases_quot'))),
-            '_aliases_quot_percent' => self::pacol(0, 0,      1,      'vnum', ''                   ,''                   , 0, array(),
-                array('select' => db_quota_percent('__alias_count - coalesce(__mailbox_count,0)', 'aliases', '_aliases_quot_percent'))),
+            'aliases_quot'     => self::pacol(0,          0,      1,      'quot', 'aliases'                      , ''                                  , 0, array(), 0, 0,  db_quota_text('__alias_count - coalesce(__mailbox_count,0)', 'aliases', 'aliases_quot')),
+            '_aliases_quot_percent' => self::pacol(0, 0,      1,      'vnum', ''                   ,''                   , 0, array(), 0, 0, db_quota_percent('__alias_count - coalesce(__mailbox_count,0)', 'aliases', '_aliases_quot_percent')),
 
             # Mailboxes
            'mailboxes'         => self::pacol($super,     $super, 0,      'num' , 'mailboxes'                    , 'pAdminEdit_domain_aliases_text'   , Config::read('mailboxes')),
-           'mailbox_count'     => self::pacol(0,          0,      1,      'vnum', ''                             , ''                                 , '', array(),
-               /*not_in_db*/ 0,
-               /*dont_write_to_db*/ 1,
+           'mailbox_count'     => self::pacol(0,          0,      1,      'vnum', ''                             , ''                                 , '', array(), 0, 1,
                /*select*/ 'coalesce(__mailbox_count,0) as mailbox_count',
                /*extrafrom*/ 'left join ( select count(*) as __mailbox_count, sum(quota) as __total_quota, domain as __mailbox_domain from ' . table_by_key('mailbox') .
                              ' group by domain) as __mailbox on domain = __mailbox_domain'),
-            'mailboxes_quot'   => self::pacol(0,          0,      1,       'quot', 'mailboxes'                    , ''                                 , 0, array(),
-                array('select' => db_quota_text('__mailbox_count', 'mailboxes', 'mailboxes_quot'))),
-            '_mailboxes_quot_percent' => self::pacol(0,  0,      1,       'vnum', ''                             , ''                                 , 0, array(),
-                array('select' => db_quota_percent('__mailbox_count', 'mailboxes', '_mailboxes_quot_percent'))),
+            'mailboxes_quot'   => self::pacol(0,          0,      1,       'quot', 'mailboxes'                    , ''                                 , 0, array(), 0, 0,  db_quota_text('__mailbox_count', 'mailboxes', 'mailboxes_quot')),
+            '_mailboxes_quot_percent' => self::pacol(0,  0,      1,       'vnum', ''                             , ''                                 , 0, array(), 0, 0,   db_quota_percent('__mailbox_count', 'mailboxes', '_mailboxes_quot_percent')),
 
            'maxquota'          => self::pacol($editquota,$editquota,$quota, 'num', 'pOverview_get_quota'          , 'pAdminEdit_domain_maxquota_text'  , Config::read('maxquota')),
 
             # Domain quota
             'quota'            => self::pacol($edit_dom_q,$edit_dom_q, 0, 'num',  'pAdminEdit_domain_quota'      , 'pAdminEdit_domain_maxquota_text'  , $domain_quota_default),
-            'total_quota'      => self::pacol(0,          0,      1,      'vnum', ''                             , ''                                 , '', array(),
-                array('select' => "$query_used_domainquota AS total_quota") /*extrafrom*//* already in mailbox_count */),
-            'total_quot'     => self::pacol(0,          0,      $dom_q,  'quot', 'pAdminEdit_domain_quota'      , ''                                 , 0, array(),
-                array('select' => db_quota_text($query_used_domainquota, 'quota', 'total_quot'))),
-            '_total_quot_percent' => self::pacol(0,      0,      $dom_q,  'vnum', ''                             , ''                                 , 0, array(),
-                array('select' => db_quota_percent($query_used_domainquota, 'quota', '_total_quot_percent'))),
+            'total_quota'      => self::pacol(0,          0,      1,      'vnum', ''                             , ''                                 , '', array(), 0, 0,  "$query_used_domainquota AS total_quota" /*extrafrom*//* already in mailbox_count */),
+            'total_quot'     => self::pacol(0,          0,      $dom_q,  'quot', 'pAdminEdit_domain_quota'      , ''                                 , 0, array(), 0, 0,  db_quota_text($query_used_domainquota, 'quota', 'total_quot')),
+            '_total_quot_percent' => self::pacol(0,      0,      $dom_q,  'vnum', ''                             , ''                                 , 0, array(), 0, 0, db_quota_percent($query_used_domainquota, 'quota', '_total_quot_percent')),
 
            'transport'         => self::pacol($transp,    $transp,$transp,'enum', 'transport'                    , 'pAdminEdit_domain_transport_text' , Config::read('transport_default')     ,
                /*options*/ Config::read_array('transport_options')),

--- a/model/FetchmailHandler.php
+++ b/model/FetchmailHandler.php
@@ -23,8 +23,7 @@ class FetchmailHandler extends PFAHandler
         $this->struct = array(
             # field name                allow       display in...   type    $PALANG label                     $PALANG description                 default / options / ...
             #                           editing?    form    list
-            'id'               => self::pacol(0,          0,      1,      'num' , ''                              , ''                                , '', array(),
-                array('dont_write_to_db' => 1)),
+            'id'               => self::pacol(0,          0,      1,      'num' , ''                              , ''                                , '', array(), 0,  1),
             'domain'           => self::pacol(0,          0,      1,      'text', ''                              , ''),
             'mailbox'          => self::pacol(1,          1,      1,      'enum', 'pFetchmail_field_mailbox'      , 'pFetchmail_desc_mailbox'), # mailbox list
             'src_server'       => self::pacol(1,          1,      1,      'text', 'pFetchmail_field_src_server'   , 'pFetchmail_desc_src_server'),

--- a/model/PFAHandler.php
+++ b/model/PFAHandler.php
@@ -931,22 +931,27 @@ abstract class PFAHandler
     }
 
     /**
+     * @see DOCUMENTS/HANDLER_CLASSES.md
      * Define a db column, also used to control rendering/editing behaviour.
      *
-     * @param int $allow_editing
-     * @param int $display_in_form
-     * @param int display_in_list
+     * @param int $allow_editing (0 - read-only, 1 - editable)
+     * @param int $display_in_form (0 - hide, 1 - show in form)
+     * @param int display_in_list (0 hide, 1 - show in list)
      * @param string $type e.g. text|pass|bool|list|vnum|mail|ts - see PFAHandler::initStruct()
-     * @param string PALANG_label
-     * @param string PALANG_desc
-     * @param any optional $default
-     * @param array $options optional options
-     * @param array|int or $multiopt - if array, can contain the remaining parameters as associated array. Otherwise counts as $not_in_db
+     * @param string PALANG_label (language key for the field label)
+     * @param string PALANG_desc (language key for the help/description text)
+     * @param mixed $default
+     * @param array $options optional options - for enum/list types
+     * @param int $not_in_db (DEPRECATED form: array, can contain the remaining parameters as associated array. Otherwise counts as $not_in_db)
+     * @param int $dont_write_to_db (Skip writing to db)
+     * @param string $select - custom SQL expression replacing the column name in SELECT, see e.g. AdminHandler's domain_count definition for example
+     * @param string $extrafrom
+     * @param string $linkto e.g. list-virtual.php?domain=%s
      * @return array for $struct
      *
      * @see PFAHandler::initStruct() for a list of possible types.
      */
-    public static function pacol(int $allow_editing, int $display_in_form, int $display_in_list, string $type, string $PALANG_label, string $PALANG_desc, $default = "", array $options = array(), $multiopt = 0, int $dont_write_to_db = 0, string $select = "", string $extrafrom = "", string $linkto = ""): array
+    public static function pacol(int $allow_editing, int $display_in_form, int $display_in_list, string $type, string $PALANG_label, string $PALANG_desc, $default = "", array $options = [], $not_in_db = 0, int $dont_write_to_db = 0, string $select = "", string $extrafrom = "", string $linkto = ""): array
     {
         if ($PALANG_label != '') {
             $PALANG_label = Config::lang($PALANG_label);
@@ -955,16 +960,15 @@ abstract class PFAHandler
             $PALANG_desc = Config::lang($PALANG_desc);
         }
 
-        if (is_array($multiopt)) { # remaining parameters provided in named array
-            $not_in_db = 0; # keep default value
-            foreach ($multiopt as $key => $value) {
+        if (is_array($not_in_db)) { # remaining parameters provided in named array
+            trigger_error("PFAHandler::pacol() - passing mutiopt as an array is deprecated, please use the remaining parameters", E_USER_DEPRECATED);
+            foreach ($not_in_db as $key => $value) {
                 $$key = $value; # extract everything to the matching variable
             }
-        } else {
-            $not_in_db = $multiopt;
+            $not_in_db = 0; # keep default value
         }
 
-        return array(
+        return [
             'editable' => $allow_editing,
             'display_in_form' => $display_in_form,
             'display_in_list' => $display_in_list,
@@ -978,7 +982,7 @@ abstract class PFAHandler
             'select' => $select,         # replaces the field name after SELECT
             'extrafrom' => $extrafrom,      # added after FROM xy - useful for JOINs etc.
             'linkto' => $linkto,         # make the value a link - %s will be replaced with the ID
-        );
+        ];
     }
 
 

--- a/model/PFAHandler.php
+++ b/model/PFAHandler.php
@@ -962,10 +962,16 @@ abstract class PFAHandler
 
         if (is_array($not_in_db)) { # remaining parameters provided in named array
             trigger_error("PFAHandler::pacol() - passing mutiopt as an array is deprecated, please use the remaining parameters", E_USER_DEPRECATED);
+            $found = false;
             foreach ($not_in_db as $key => $value) {
+                if ($key === 'not_in_db') {
+                    $found = true;
+                }
                 $$key = $value; # extract everything to the matching variable
             }
-            $not_in_db = 0; # keep default value
+            if (!$found) {
+                $not_in_db = 0; //
+            }
         }
 
         return [


### PR DESCRIPTION
As discussed with @cboltz on IRC - adds a developer guide for creating Handler classes.

Covers the full pattern: class naming, required properties, pacol/struct, field types, initMsg, webformConfig, validation methods, preSave/postSave, delete, read_from_db_postprocess, user mode, menu integration, and the request lifecycle.

Based on PFAHandler.php comments and lessons learned from building TotpexceptionHandler (#1007).