### PR TITLE
Add centralised run_hook_script() helper, refactor duplicated proc_open calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "friendsofphp/php-cs-fixer": "^3.54.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-coveralls/php-coveralls": "*",
-        "phpunit/phpunit": "8.*|9.*",
+        "phpunit/phpunit": "^11.0",
         "psalm/phar":"^4.0|^5.0|^6.0",
         "phpstan/phpstan": "^2.0"
     },
@@ -54,5 +54,13 @@
     "support": {
         "irc": "irc://irc.libera.chat/postfixadmin",
         "issues": "https://github.com/postfixadmin/postfixadmin/issues"
+    },
+    "config": {
+        "audit": {
+            "ignore": {
+                "PKSA-5jz8-6tcw-pbk4": "arg injection via php.ini values, https://github.com/advisories/GHSA-qrr6-mg7r-m243 ... ignore, no php8.2 compatible release",
+                "PKSA-z3gr-8qht-p93v": "unsafe deserialization in phpt code coverage, https://packagist.org/security-advisories/PKSA-z3gr-8qht-p93v ... ignore, no php8.2 compataible release"
+            }
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "postfixadmin/password-hashing": "^0.0.2",
         "endroid/qr-code": "^4.6 | ^5.0", 
         "spomky-labs/otphp": "^11.0",
-        "shardj/zf1-future": "^1.12"
+        "shardj/zf1-future": "^1.12",
+        "symfony/var-dumper": "^7.4"
     },
     "require-dev": {
         "ext-mbstring": "*",

--- a/model/Exec.php
+++ b/model/Exec.php
@@ -1,0 +1,61 @@
+<?php
+
+class Exec
+{
+    public readonly string $stdout;
+    public readonly string $stderr;
+    public readonly int $retval;
+
+    /**
+     *  Run an external command via proc_open.
+     *
+     *  Used for post-creation, post-deletion, post-password-change scripts etc.
+     *  Handles process creation, optional stdin data, stdout capture, and error logging.
+     *
+     *  $command can be either:
+     *  - string: full shell command (callers should escapeshellarg() arguments and append 2>&1)
+     *  - array: [script, arg1, arg2, ...] — PHP handles escaping, no shell involved (preferred)
+     *
+     * @param string|array $command shell command string or array of [script, arg1, arg2, ...]
+     * @param string|null $stdin_data optional data to write to the process stdin
+     * /
+     */
+    public function __construct(string|array $command, ?string $stdin_data = null)
+    {
+        $spec = [
+            0 => ["pipe", "r"], // stdin
+            1 => ["pipe", "w"], // stdout
+            2 => ["pipe", "w"], // stderr
+        ];
+
+        $proc = proc_open($command, $spec, $pipes);
+
+        $cmd_display = is_array($command) ? implode(' ', $command) : $command;
+
+        if (!$proc) {
+            error_log("postfixadmin: can't proc_open: $cmd_display");
+            throw new \RuntimeException("can't proc_open: $cmd_display");
+        }
+
+        if ($stdin_data !== null) {
+            fwrite($pipes[0], $stdin_data);
+        }
+        fclose($pipes[0]);
+
+        $this->stdout = stream_get_contents($pipes[1]);
+        $this->stderr = stream_get_contents($pipes[2]);
+
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $this->retval = proc_close($proc);
+    }
+
+    /**
+     * @see __construct
+     */
+    public static function run(string|array $command, ?string $stdin_data = null): self
+    {
+        return new self($command, $stdin_data);
+    }
+}

--- a/model/Login.php
+++ b/model/Login.php
@@ -164,7 +164,7 @@ class Login
         $stdin = $old_password . "\0" . $new_password . "\0";
 
         $result = PFAHandler::run_hook_script($command, $stdin);
-        if (!$result['success']) {
+        if ($result['retval'] !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -226,7 +226,7 @@ class Login
         $stdin = $app_pass . "\0";
 
         $result = PFAHandler::run_hook_script($command, $stdin);
-        if (!$result['success']) {
+        if ($result['retval'] !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 

--- a/model/Login.php
+++ b/model/Login.php
@@ -158,35 +158,13 @@ class Login
 
         $warnmsg_pw = Config::Lang('mailbox_postpassword_failed');
 
-        // If we have a mailbox_postpassword_script (dovecot only?)
-
-        // Use proc_open call to avoid safe_mode problems and to prevent showing plain password in process table
-        $spec = array(
-            0 => array("pipe", "r"), // stdin
-            1 => array("pipe", "w"), // stdout
-        );
-
         $cmdarg1 = escapeshellarg($username);
         $cmdarg2 = escapeshellarg($domain);
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
+        $stdin = $old_password . "\0" . $new_password . "\0";
 
-        $proc = proc_open($command, $spec, $pipes);
-
-        if (!$proc) {
-            throw new \Exception("can't proc_open $cmd_pw");
-        }
-
-        // Write passwords through pipe to command stdin -- provide old password, then new password.
-        fwrite($pipes[0], $old_password . "\0", 1 + strlen($old_password));
-        fwrite($pipes[0], $new_password . "\0", 1 + strlen($new_password));
-        $output = stream_get_contents($pipes[1]);
-        fclose($pipes[0]);
-        fclose($pipes[1]);
-
-        $retval = proc_close($proc);
-
-        if (0 != $retval) {
-            error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+        $result = PFAHandler::run_hook_script($command, $stdin);
+        if (!$result['success']) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -242,34 +220,13 @@ class Login
 
         $warnmsg_pw = Config::Lang('mailbox_postapppassword_failed');
 
-        // If we have a mailbox_postpppassword_script
-
-        // Use proc_open call to avoid safe_mode problems and to prevent showing plain password in process table
-        $spec = array(
-            0 => array("pipe", "r"), // stdin
-            1 => array("pipe", "w"), // stdout
-        );
-
         $cmdarg1 = escapeshellarg($username);
         $cmdarg2 = escapeshellarg($app_desc);
-
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
+        $stdin = $app_pass . "\0";
 
-        $proc = proc_open($command, $spec, $pipes);
-
-        if (!$proc) {
-            throw new \Exception("can't proc_open $cmd_pw");
-        }
-
-        // Write passwords through pipe to command stdin -- provide old password, then new password.
-        fwrite($pipes[0], $app_pass . "\0", 1 + strlen($app_pass));
-        $output = stream_get_contents($pipes[0]);
-        fclose($pipes[0]);
-
-        $retval = proc_close($proc);
-
-        if (0 != $retval) {
-            error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+        $result = PFAHandler::run_hook_script($command, $stdin);
+        if (!$result['success']) {
             throw new \Exception($warnmsg_pw);
         }
 

--- a/model/Login.php
+++ b/model/Login.php
@@ -163,8 +163,9 @@ class Login
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
         $stdin = $old_password . "\0" . $new_password . "\0";
 
-        $result = PFAHandler::run_hook_script($command, $stdin);
-        if ($result['retval'] !== 0) {
+        $exec = Exec::run($command, $stdin);
+
+        if ($exec->retval !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -225,8 +226,8 @@ class Login
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
         $stdin = $app_pass . "\0";
 
-        $result = PFAHandler::run_hook_script($command, $stdin);
-        if ($result['retval'] !== 0) {
+        $exec = Exec::run($command, $stdin);
+        if ($exec->retval !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -680,35 +680,12 @@ class MailboxHandler extends PFAHandler
         }
 
         if (!empty($cmd_pw)) {
-            // Use proc_open call to avoid safe_mode problems and to prevent showing plain password in process table
-            $spec = array(
-                0 => array("pipe", "r"), // stdin
-                1 => array("pipe", "w"), // stdout
-            );
-
             $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
-
-            $proc = proc_open($command, $spec, $pipes);
-
-            if (!$proc) {
-                error_log("can't proc_open $cmd_pw");
+            $stdin = "\0" . $this->values['password'] . "\0";
+            $result = self::run_hook_script($command, $stdin);
+            if (!$result['success']) {
                 $this->errormsg[] = $warnmsg_pw;
                 $status = false;
-            } else {
-                // Write passwords through pipe to command stdin -- provide old password, then new password.
-                fwrite($pipes[0], "\0", 1);
-                fwrite($pipes[0], $this->values['password'] . "\0", 1 + strlen($this->values['password']));
-                $output = stream_get_contents($pipes[1]);
-                fclose($pipes[0]);
-                fclose($pipes[1]);
-
-                $retval = proc_close($proc);
-
-                if (0 != $retval) {
-                    error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
-                    $this->errormsg[] = $warnmsg_pw;
-                    $status = false;
-                }
             }
         }
 

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -682,8 +682,8 @@ class MailboxHandler extends PFAHandler
         if (!empty($cmd_pw)) {
             $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
             $stdin = "\0" . $this->values['password'] . "\0";
-            $result = self::run_hook_script($command, $stdin);
-            if ($result['retval'] !== 0) {
+            $result = Exec::run($command, $stdin);
+            if ($result->retval !== 0) {
                 $this->errormsg[] = $warnmsg_pw;
                 $status = false;
             }

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -683,7 +683,7 @@ class MailboxHandler extends PFAHandler
             $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
             $stdin = "\0" . $this->values['password'] . "\0";
             $result = self::run_hook_script($command, $stdin);
-            if (!$result['success']) {
+            if ($result['retval'] !== 0) {
                 $this->errormsg[] = $warnmsg_pw;
                 $status = false;
             }

--- a/model/PFAHandler.php
+++ b/model/PFAHandler.php
@@ -1108,15 +1108,19 @@ abstract class PFAHandler
      * Used for post-creation, post-deletion, post-password-change scripts etc.
      * Handles process creation, optional stdin data, stdout capture, and error logging.
      *
-     * Note: only stdout is captured. Callers should append 2>&1 to the command
-     * if stderr output is also needed. Sensitive data (passwords, secrets) should
-     * be passed via $stdin_data rather than command arguments.
+     * $command can be either:
+     * - a string: full shell command (callers should escapeshellarg() arguments and append 2>&1)
+     * - an array: [script, arg1, arg2, ...] — PHP handles escaping, no shell involved (preferred)
      *
-     * @param string $command full shell command to execute (with arguments already escaped)
+     * Note: only stdout is captured via pipe. When using a string command, append 2>&1
+     * to also capture stderr. When using an array command, stderr goes to the parent process.
+     * Sensitive data (passwords, secrets) should be passed via $stdin_data rather than arguments.
+     *
+     * @param string|array $command shell command string or array of [script, arg1, arg2, ...]
      * @param string|null $stdin_data optional data to write to the process stdin
      * @return array{retval: int, output: string}
      */
-    public static function run_hook_script(string $command, ?string $stdin_data = null): array
+    public static function run_hook_script(string|array $command, ?string $stdin_data = null): array
     {
         $spec = [
             0 => ["pipe", "r"], // stdin
@@ -1125,7 +1129,8 @@ abstract class PFAHandler
 
         $proc = proc_open($command, $spec, $pipes);
         if (!$proc) {
-            error_log("can't proc_open: $command");
+            $cmd_display = is_array($command) ? implode(' ', $command) : $command;
+            error_log("can't proc_open: $cmd_display");
             return ['retval' => -1, 'output' => ''];
         }
 
@@ -1140,7 +1145,8 @@ abstract class PFAHandler
         $retval = proc_close($proc);
 
         if (0 != $retval) {
-            error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+            $cmd_display = is_array($command) ? implode(' ', $command) : $command;
+            error_log("Running $cmd_display yielded return value=$retval, output was: " . json_encode($output));
         }
 
         return ['retval' => $retval, 'output' => $output === false ? '' : $output];

--- a/model/PFAHandler.php
+++ b/model/PFAHandler.php
@@ -1106,7 +1106,11 @@ abstract class PFAHandler
      * Run an external hook script via proc_open.
      *
      * Used for post-creation, post-deletion, post-password-change scripts etc.
-     * Handles process creation, optional stdin data, output capture, and error logging.
+     * Handles process creation, optional stdin data, stdout capture, and error logging.
+     *
+     * Note: only stdout is captured. Callers should append 2>&1 to the command
+     * if stderr output is also needed. Sensitive data (passwords, secrets) should
+     * be passed via $stdin_data rather than command arguments.
      *
      * @param string $command full shell command to execute (with arguments already escaped)
      * @param string|null $stdin_data optional data to write to the process stdin
@@ -1139,7 +1143,7 @@ abstract class PFAHandler
             error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
         }
 
-        return ['success' => $retval === 0, 'output' => $output ?: '', 'retval' => $retval];
+        return ['success' => $retval === 0, 'output' => $output === false ? '' : $output, 'retval' => $retval];
     }
 }
 /* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/model/PFAHandler.php
+++ b/model/PFAHandler.php
@@ -1114,7 +1114,7 @@ abstract class PFAHandler
      *
      * @param string $command full shell command to execute (with arguments already escaped)
      * @param string|null $stdin_data optional data to write to the process stdin
-     * @return array{success: bool, output: string, retval: int}
+     * @return array{retval: int, output: string}
      */
     public static function run_hook_script(string $command, ?string $stdin_data = null): array
     {
@@ -1126,7 +1126,7 @@ abstract class PFAHandler
         $proc = proc_open($command, $spec, $pipes);
         if (!$proc) {
             error_log("can't proc_open: $command");
-            return ['success' => false, 'output' => '', 'retval' => -1];
+            return ['retval' => -1, 'output' => ''];
         }
 
         if ($stdin_data !== null) {
@@ -1143,7 +1143,7 @@ abstract class PFAHandler
             error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
         }
 
-        return ['success' => $retval === 0, 'output' => $output === false ? '' : $output, 'retval' => $retval];
+        return ['retval' => $retval, 'output' => $output === false ? '' : $output];
     }
 }
 /* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/model/PFAHandler.php
+++ b/model/PFAHandler.php
@@ -1102,54 +1102,5 @@ abstract class PFAHandler
         return false;
     }
 
-    /**
-     * Run an external hook script via proc_open.
-     *
-     * Used for post-creation, post-deletion, post-password-change scripts etc.
-     * Handles process creation, optional stdin data, stdout capture, and error logging.
-     *
-     * $command can be either:
-     * - a string: full shell command (callers should escapeshellarg() arguments and append 2>&1)
-     * - an array: [script, arg1, arg2, ...] — PHP handles escaping, no shell involved (preferred)
-     *
-     * Note: only stdout is captured via pipe. When using a string command, append 2>&1
-     * to also capture stderr. When using an array command, stderr goes to the parent process.
-     * Sensitive data (passwords, secrets) should be passed via $stdin_data rather than arguments.
-     *
-     * @param string|array $command shell command string or array of [script, arg1, arg2, ...]
-     * @param string|null $stdin_data optional data to write to the process stdin
-     * @return array{retval: int, output: string}
-     */
-    public static function run_hook_script(string|array $command, ?string $stdin_data = null): array
-    {
-        $spec = [
-            0 => ["pipe", "r"], // stdin
-            1 => ["pipe", "w"], // stdout
-        ];
-
-        $proc = proc_open($command, $spec, $pipes);
-        if (!$proc) {
-            $cmd_display = is_array($command) ? implode(' ', $command) : $command;
-            error_log("can't proc_open: $cmd_display");
-            return ['retval' => -1, 'output' => ''];
-        }
-
-        if ($stdin_data !== null) {
-            fwrite($pipes[0], $stdin_data);
-        }
-        fclose($pipes[0]);
-
-        $output = stream_get_contents($pipes[1]);
-        fclose($pipes[1]);
-
-        $retval = proc_close($proc);
-
-        if (0 != $retval) {
-            $cmd_display = is_array($command) ? implode(' ', $command) : $command;
-            error_log("Running $cmd_display yielded return value=$retval, output was: " . json_encode($output));
-        }
-
-        return ['retval' => $retval, 'output' => $output === false ? '' : $output];
-    }
 }
 /* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/model/PFAHandler.php
+++ b/model/PFAHandler.php
@@ -1101,5 +1101,45 @@ abstract class PFAHandler
         $this->errormsg[$field] = $validpass[0]; # TODO: honor all error messages, not only the first one?
         return false;
     }
+
+    /**
+     * Run an external hook script via proc_open.
+     *
+     * Used for post-creation, post-deletion, post-password-change scripts etc.
+     * Handles process creation, optional stdin data, output capture, and error logging.
+     *
+     * @param string $command full shell command to execute (with arguments already escaped)
+     * @param string|null $stdin_data optional data to write to the process stdin
+     * @return array{success: bool, output: string, retval: int}
+     */
+    public static function run_hook_script(string $command, ?string $stdin_data = null): array
+    {
+        $spec = [
+            0 => ["pipe", "r"], // stdin
+            1 => ["pipe", "w"], // stdout
+        ];
+
+        $proc = proc_open($command, $spec, $pipes);
+        if (!$proc) {
+            error_log("can't proc_open: $command");
+            return ['success' => false, 'output' => '', 'retval' => -1];
+        }
+
+        if ($stdin_data !== null) {
+            fwrite($pipes[0], $stdin_data);
+        }
+        fclose($pipes[0]);
+
+        $output = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+
+        $retval = proc_close($proc);
+
+        if (0 != $retval) {
+            error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+        }
+
+        return ['success' => $retval === 0, 'output' => $output ?: '', 'retval' => $retval];
+    }
 }
 /* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/model/TotpPf.php
+++ b/model/TotpPf.php
@@ -252,7 +252,7 @@ class TotpPf
         $stdin = ($TOTP_secret !== null) ? $TOTP_secret . "\0" : "\0";
 
         $result = PFAHandler::run_hook_script($command, $stdin);
-        if (!$result['success']) {
+        if ($result['retval'] !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -386,7 +386,7 @@ class TotpPf
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
 
         $result = PFAHandler::run_hook_script($command);
-        if (!$result['success']) {
+        if ($result['retval'] !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -464,7 +464,7 @@ class TotpPf
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
 
         $result = PFAHandler::run_hook_script($command);
-        if (!$result['success']) {
+        if ($result['retval'] !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 

--- a/model/TotpPf.php
+++ b/model/TotpPf.php
@@ -246,38 +246,13 @@ class TotpPf
 
         $warnmsg_pw = Config::Lang('mailbox_post_TOTP_change_failed');
 
-        // Execute the post-change script
-        // Use proc_open call to avoid safe_mode problems and to prevent showing plain password in process table
-        $spec = array(
-            0 => array("pipe", "r"), // stdin
-            1 => array("pipe", "w"), // stdout
-        );
-
         $cmdarg1 = escapeshellarg($username);
         $cmdarg2 = escapeshellarg($domain);
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
+        $stdin = ($TOTP_secret !== null) ? $TOTP_secret . "\0" : "\0";
 
-        $proc = proc_open($command, $spec, $pipes);
-
-        if (!$proc) {
-            throw new \Exception("can't proc_open $cmd_pw");
-        }
-
-        // Write secret through pipe to command stdin
-        if ($TOTP_secret !== null) {
-            fwrite($pipes[0], $TOTP_secret . "\0", 1 + strlen($TOTP_secret));
-        } else {
-            fwrite($pipes[0], "\0", 1);
-        }
-
-        $output = stream_get_contents($pipes[1]);
-        fclose($pipes[0]);
-        fclose($pipes[1]);
-
-        $retval = proc_close($proc);
-
-        if (0 != $retval) {
-            error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+        $result = PFAHandler::run_hook_script($command, $stdin);
+        if (!$result['success']) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -406,27 +381,12 @@ class TotpPf
 
         $warnmsg_pw = Config::Lang('mailbox_post_totp_exception_add_failed');
 
-        // Use proc_open call to avoid safe_mode problems and to prevent showing sensitive data in process table
-        $spec = array(
-            0 => array("pipe", "r"), // stdin
-            1 => array("pipe", "w"), // stdout
-        );
-
         $cmdarg1 = escapeshellarg($username);
         $cmdarg2 = escapeshellarg($ip_address);
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
 
-        $proc = proc_open($command, $spec, $pipes);
-        if (!$proc) {
-            throw new \Exception("can't proc_open $cmd_pw");
-        }
-
-        fclose($pipes[0]);
-        fclose($pipes[1]);
-
-        $retval = proc_close($proc);
-        if (0 != $retval) {
-            error_log("Running $command yielded return value=$retval, output was: " . json_encode($retval));
+        $result = PFAHandler::run_hook_script($command);
+        if (!$result['success']) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -499,28 +459,12 @@ class TotpPf
 
         $warnmsg_pw = Config::Lang('mailbox_post_totp_exception_delete_failed');
 
-        // Use proc_open call to avoid safe_mode problems and to prevent showing sensitive data in process table
-        $spec = [
-            0 => ["pipe", "r"], // stdin
-            1 => ["pipe", "w"], // stdout
-        ];
-
         $cmdarg1 = escapeshellarg($username);
         $cmdarg2 = escapeshellarg($exception['ip']);
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
 
-        $proc = proc_open($command, $spec, $pipes);
-        if (!$proc) {
-            throw new \Exception("can't proc_open $cmd_pw");
-        }
-
-        $output = stream_get_contents($pipes[1]);
-        fclose($pipes[0]);
-        fclose($pipes[1]);
-
-        $retval = proc_close($proc);
-        if (0 != $retval) {
-            error_log("Running $command yielded return value=$retval, output was: " . json_encode($output));
+        $result = PFAHandler::run_hook_script($command);
+        if (!$result['success']) {
             throw new \Exception($warnmsg_pw);
         }
 

--- a/model/TotpPf.php
+++ b/model/TotpPf.php
@@ -251,8 +251,9 @@ class TotpPf
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
         $stdin = ($TOTP_secret !== null) ? $TOTP_secret . "\0" : "\0";
 
-        $result = PFAHandler::run_hook_script($command, $stdin);
-        if ($result['retval'] !== 0) {
+        $exec = Exec::run($command, $stdin);
+
+        if ($exec->retval !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -385,8 +386,8 @@ class TotpPf
         $cmdarg2 = escapeshellarg($ip_address);
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
 
-        $result = PFAHandler::run_hook_script($command);
-        if ($result['retval'] !== 0) {
+        $exec = Exec::run($command);
+        if ($exec->retval !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 
@@ -463,8 +464,9 @@ class TotpPf
         $cmdarg2 = escapeshellarg($exception['ip']);
         $command = "$cmd_pw $cmdarg1 $cmdarg2 2>&1";
 
-        $result = PFAHandler::run_hook_script($command);
-        if ($result['retval'] !== 0) {
+        $exec = Exec::run($command);
+
+        if ($exec->retval !== 0) {
             throw new \Exception($warnmsg_pw);
         }
 

--- a/tests/ExecTest.php
+++ b/tests/ExecTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ExecTest extends TestCase
+{
+    public function testArrayCommandSuccess()
+    {
+        $p = Exec::run(["ls", "/etc"]);
+        $this->assertEquals(0, $p->retval);
+        $this->assertEquals("", $p->stderr);
+        $this->assertNotEmpty($p->stdout);
+    }
+
+    public function testArrayCommandInvalidArg()
+    {
+        $p = Exec::run(["ls", "/etcasdasdasd"]);
+        $this->assertEquals(2, $p->retval);
+        $this->assertEquals("ls: cannot access '/etcasdasdasd': No such file or directory\n", $p->stderr);
+        $this->assertEmpty($p->stdout);
+    }
+
+
+    public function testStringCommandNotFound()
+    {
+        $p = Exec::run("lsasdasdasdasdasd /etc");
+        $this->assertEquals(127, $p->retval);
+        $this->assertEquals("sh: 1: lsasdasdasdasdasd: not found\n", $p->stderr);
+        $this->assertEmpty($p->stdout);
+    }
+
+    public function testStringCommandStdinUsage()
+    {
+        $p = Exec::run("cat -", "dog");
+        $this->assertEquals(0, $p->retval);
+        $this->assertEquals("dog", $p->stdout);
+        $this->assertEmpty($p->stderr);
+    }
+}

--- a/tests/RemoteAliasTest.php
+++ b/tests/RemoteAliasTest.php
@@ -10,12 +10,6 @@ require_once('RemoteTest.php');
 
 class RemoteAliasTest extends RemoteTest
 {
-    public function __construct()
-    {
-        parent::__construct();
-        global $CONF;
-    }
-
     public function testGet()
     {
         /* although we created an alias record, for users, this isn't returned... */

--- a/tests/RemoteTest.php
+++ b/tests/RemoteTest.php
@@ -2,7 +2,7 @@
 
 abstract class RemoteTest extends \PHPUnit\Framework\TestCase
 {
-    protected $server_url = 'http://change.me/to/work'; // http://orange/david/postfixadmin/xmlrpc.php';
+    protected $server_url = 'http://change.me/to/work';
     protected $username = 'user@example.com';
     protected $password = 'password1';
 


### PR DESCRIPTION
As suggested by @cboltz in the #1007 review - centralises the repeated proc_open boilerplate for running hook scripts into a single `PFAHandler::run_hook_script()` method.

**The helper:**
- Handles process creation, optional stdin data, output capture, error logging
- Returns `['success' => bool, 'output' => string, 'retval' => int]`
- Callers handle their own error messages (throw, errormsg, etc.)

**Refactored call sites:**
- `MailboxHandler` - mailbox_postpassword_script
- `TotpPf` - TOTP secret change, exception add/delete scripts
- `Login` - password change and app password scripts

**Result:** +16/-138 lines. Two commits for easy review.