### PR TITLE
Fix privilege escalation in TOTP exceptions and missing isset() in MFA

### DIFF
--- a/model/TotpPf.php
+++ b/model/TotpPf.php
@@ -312,7 +312,10 @@ class TotpPf
             throw new \Exception(Config::Lang('pPassword_password_current_text_error'));
         }
 
-        if (authentication_has_role('admin')) {
+        if (authentication_has_role('global-admin')) {
+            $admin = 2;
+            // Global admins can do anything
+        } elseif (authentication_has_role('admin')) {
             $admin = 1;
             // Get domains the admin has access to
             $domains = list_domains_for_admin($username);
@@ -328,9 +331,6 @@ class TotpPf
             if ($exception_username != $username && !in_array($Exception_domain, $domains)) {
                 throw new \Exception(Config::Lang('pException_user_entire_domain_error'));
             }
-        } elseif (authentication_has_role('global-admin')) {
-            $admin = 2;
-            // Global admins can do anything
         } else {
             // Regular users can only add exceptions for themselves
             $exception_username = $username;

--- a/public/users/login-mfa.php
+++ b/public/users/login-mfa.php
@@ -35,7 +35,7 @@ if (authentication_has_role("user")) {
     exit(0);
 }
 
-if ($_GET["abort"] == "1" && authentication_mfa_incomplete()) {
+if (isset($_GET["abort"]) && $_GET["abort"] == "1" && authentication_mfa_incomplete()) {
     session_unset();
     session_destroy();
     session_start();


### PR DESCRIPTION
Two security fixes:

**1. Global admin privilege downgrade in TotpPf::addException() (fixes #1012)**

Global admins were incorrectly treated as regular admins because `authentication_has_role('admin')` was checked before `authentication_has_role('global-admin')`. Since global admins have both roles in their session, they matched the admin check first and were restricted to their own domains instead of having unrestricted access.

Fix: reorder to check `global-admin` first. Note: `deleteException()` already had the correct order.

**2. Missing isset() in users/login-mfa.php (fixes #1013)**

`$_GET["abort"]` accessed without isset() check, causing PHP Notice. The admin version at `public/login-mfa.php` already has the correct check.

Two separate commits.