### PR TITLE
Add regression tests for global admin TOTP exception privileges

### DIFF
--- a/tests/DbBasicTest.php
+++ b/tests/DbBasicTest.php
@@ -69,6 +69,69 @@ class DbBasicTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, db_delete('mailbox', 'username', $username));
         $this->assertEquals(1, db_delete('domain', 'domain', $domain));
     }
+
+    /**
+     * Test db_in_clause() generates correct placeholders and params.
+     */
+    public function testDbInClause()
+    {
+        $params = [];
+        $sql = db_in_clause('domain', ['example.com', 'test.org'], $params);
+
+        $this->assertStringContainsString('IN (', $sql);
+        $this->assertCount(2, $params);
+        $this->assertContains('example.com', $params);
+        $this->assertContains('test.org', $params);
+    }
+
+    /**
+     * Test db_in_clause() with empty array returns safe false predicate.
+     */
+    public function testDbInClauseEmpty()
+    {
+        $params = [];
+        $sql = db_in_clause('domain', [], $params);
+
+        $this->assertStringContainsString('1=0', $sql);
+        $this->assertCount(0, $params);
+    }
+
+    /**
+     * Test db_in_clause() generates unique param keys when called multiple times.
+     */
+    public function testDbInClauseUniqueKeys()
+    {
+        $params = [];
+        db_in_clause('domain', ['a.com'], $params);
+        db_in_clause('domain', ['b.com'], $params);
+
+        $this->assertCount(2, $params);
+        $values = array_values($params);
+        $this->assertEquals('a.com', $values[0]);
+        $this->assertEquals('b.com', $values[1]);
+        // Keys must be different
+        $keys = array_keys($params);
+        $this->assertNotEquals($keys[0], $keys[1]);
+    }
+
+    /**
+     * Test db_in_clause() actually works in a real query.
+     */
+    public function testDbInClauseInQuery()
+    {
+        $domain = $this->test_domain;
+        db_insert('domain', ['domain' => $domain, 'description' => 'test', 'transport' => '']);
+
+        $params = [];
+        $in = db_in_clause('domain', [$domain, 'nonexistent.com'], $params);
+        $result = db_query_all("SELECT domain FROM " . table_by_key('domain') . " WHERE $in", $params);
+
+        $domains = array_column($result, 'domain');
+        $this->assertContains($domain, $domains);
+        $this->assertNotContains('nonexistent.com', $domains);
+
+        db_delete('domain', 'domain', $domain);
+    }
 }
 
 /* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/tests/DbBasicTest.php
+++ b/tests/DbBasicTest.php
@@ -78,10 +78,8 @@ class DbBasicTest extends \PHPUnit\Framework\TestCase
         $params = [];
         $sql = db_in_clause('domain', ['example.com', 'test.org'], $params);
 
-        $this->assertStringContainsString('IN (', $sql);
-        $this->assertCount(2, $params);
-        $this->assertContains('example.com', $params);
-        $this->assertContains('test.org', $params);
+        $this->assertEquals(' domain IN (:_in_0_0,:_in_1_1) ', $sql);
+        $this->assertEquals(['_in_0_0' => 'example.com', '_in_1_1' => 'test.org'], $params);
     }
 
     /**
@@ -92,7 +90,7 @@ class DbBasicTest extends \PHPUnit\Framework\TestCase
         $params = [];
         $sql = db_in_clause('domain', [], $params);
 
-        $this->assertStringContainsString('1=0', $sql);
+        $this->assertEquals(' 1=0 ', $sql);
         $this->assertCount(0, $params);
     }
 
@@ -102,16 +100,12 @@ class DbBasicTest extends \PHPUnit\Framework\TestCase
     public function testDbInClauseUniqueKeys()
     {
         $params = [];
-        db_in_clause('domain', ['a.com'], $params);
-        db_in_clause('domain', ['b.com'], $params);
+        $sql1 = db_in_clause('domain', ['a.com'], $params);
+        $sql2 = db_in_clause('domain', ['b.com'], $params);
 
-        $this->assertCount(2, $params);
-        $values = array_values($params);
-        $this->assertEquals('a.com', $values[0]);
-        $this->assertEquals('b.com', $values[1]);
-        // Keys must be different
-        $keys = array_keys($params);
-        $this->assertNotEquals($keys[0], $keys[1]);
+        $this->assertEquals(' domain IN (:_in_0_0) ', $sql1);
+        $this->assertEquals(' domain IN (:_in_1_0) ', $sql2);
+        $this->assertEquals(['_in_0_0' => 'a.com', '_in_1_0' => 'b.com'], $params);
     }
 
     /**

--- a/tests/TotpPfTest.php
+++ b/tests/TotpPfTest.php
@@ -40,11 +40,13 @@ class TotpPfTest extends TestCase
         db_query('DELETE FROM alias_domain');
         db_query('DELETE FROM mailbox');
         db_query('DELETE FROM domain_admins');
+        db_query('DELETE FROM admin');
         db_query('DELETE FROM domain');
 
         db_query('DELETE FROM totp_exception_address');
         db_query('DELETE FROM mailbox_app_password');
 
+        unset($_SESSION['sessid']);
     }
 
 
@@ -121,11 +123,6 @@ class TotpPfTest extends TestCase
             $x->addException('admin@example.com', 'adminpass', '10.0.0.1', 'user@other.org', 'cross-domain test'),
             'Global admin should be able to add TOTP exception for any domain'
         );
-
-        // Clean up session
-        unset($_SESSION['sessid']);
-        db_query("DELETE FROM admin WHERE username = 'admin@example.com'");
-        db_query("DELETE FROM domain WHERE domain = 'other.org'");
     }
 
     /**
@@ -163,11 +160,6 @@ class TotpPfTest extends TestCase
         // Regular admin should NOT be able to add exception for unmanaged domain
         $this->expectException(\Exception::class);
         $x->addException('admin@example.com', 'adminpass', '10.0.0.2', 'user@other.org', 'should fail');
-
-        // Clean up session
-        unset($_SESSION['sessid']);
-        db_query("DELETE FROM admin WHERE username = 'admin@example.com'");
-        db_query("DELETE FROM domain WHERE domain = 'other.org'");
     }
 
     public function testDovecotQuery()

--- a/tests/TotpPfTest.php
+++ b/tests/TotpPfTest.php
@@ -82,6 +82,94 @@ class TotpPfTest extends TestCase
         $this->assertTrue($x->addException('test@example.com', 'foobar', '1.2.3.4', 'another.test@example.com', 'test'));
     }
 
+    /**
+     * Regression test for #1012: global admins with both 'admin' and 'global-admin'
+     * roles must not be downgraded to regular admin permissions.
+     */
+    public function testGlobalAdminNotDowngradedInAddException()
+    {
+        // Set up a second domain that the admin does NOT manage
+        db_execute("INSERT INTO domain(domain, description, transport) values ('other.org', 'other domain', 'foo')", [], true);
+        db_execute(
+            "INSERT INTO admin(username, password, superadmin, active) VALUES(:username, :password, :superadmin, :active)",
+            [
+                'username' => 'admin@example.com',
+                'password' => pacrypt('adminpass'),
+                'superadmin' => db_get_boolean(true),
+                'active' => db_get_boolean(true),
+            ]
+        );
+        db_execute(
+            "INSERT INTO domain_admins(username, domain, active) VALUES(:username, :domain, :active)",
+            [
+                'username' => 'admin@example.com',
+                'domain' => 'example.com',
+                'active' => db_get_boolean(true),
+            ]
+        );
+
+        // Simulate global admin session (has BOTH roles, like real login)
+        $_SESSION['sessid'] = [
+            'username' => 'admin@example.com',
+            'roles' => ['admin', 'global-admin'],
+        ];
+
+        $x = new TotpPf('admin', new Login('admin'));
+
+        // Global admin should be able to add exception for a domain they don't explicitly manage
+        $this->assertTrue(
+            $x->addException('admin@example.com', 'adminpass', '10.0.0.1', 'user@other.org', 'cross-domain test'),
+            'Global admin should be able to add TOTP exception for any domain'
+        );
+
+        // Clean up session
+        unset($_SESSION['sessid']);
+        db_query("DELETE FROM admin WHERE username = 'admin@example.com'");
+        db_query("DELETE FROM domain WHERE domain = 'other.org'");
+    }
+
+    /**
+     * Verify regular admin cannot add exception for domains they don't manage.
+     */
+    public function testRegularAdminRestrictedToDomains()
+    {
+        db_execute("INSERT INTO domain(domain, description, transport) values ('other.org', 'other domain', 'foo')", [], true);
+        db_execute(
+            "INSERT INTO admin(username, password, superadmin, active) VALUES(:username, :password, :superadmin, :active)",
+            [
+                'username' => 'admin@example.com',
+                'password' => pacrypt('adminpass'),
+                'superadmin' => db_get_boolean(false),
+                'active' => db_get_boolean(true),
+            ]
+        );
+        db_execute(
+            "INSERT INTO domain_admins(username, domain, active) VALUES(:username, :domain, :active)",
+            [
+                'username' => 'admin@example.com',
+                'domain' => 'example.com',
+                'active' => db_get_boolean(true),
+            ]
+        );
+
+        // Regular admin - only 'admin' role, NOT 'global-admin'
+        $_SESSION['sessid'] = [
+            'username' => 'admin@example.com',
+            'roles' => ['admin'],
+        ];
+
+        $x = new TotpPf('admin', new Login('admin'));
+
+        // Regular admin should NOT be able to add exception for unmanaged domain
+        $this->expectException(\Exception::class);
+        $x->addException('admin@example.com', 'adminpass', '10.0.0.2', 'user@other.org', 'should fail');
+
+        // Clean up session
+        unset($_SESSION['sessid']);
+        db_query("DELETE FROM admin WHERE username = 'admin@example.com'");
+        db_query("DELETE FROM domain WHERE domain = 'other.org'");
+    }
+
     public function testDovecotQuery()
     {
         db_execute(


### PR DESCRIPTION
Regression tests for the privilege check fix in #1014 / #1012.

Two new tests:
- **testGlobalAdminNotDowngradedInAddException** — verifies a global admin (with both 'admin' and 'global-admin' roles) can add TOTP exceptions for domains they don't explicitly manage
- **testRegularAdminRestrictedToDomains** — verifies a regular admin is correctly restricted to their managed domains

Prevents reintroduction of the bug where role check ordering could downgrade global admins.