### PR TITLE
Add 'description' field to alias and alias_domain tables.

### DIFF
--- a/model/AliasHandler.php
+++ b/model/AliasHandler.php
@@ -34,6 +34,7 @@ class AliasHandler extends PFAHandler
                 /*not_in_db*/ 1),
             'domain'           => self::pacol($this->new, 0,      1,      'enum', ''                              , ''                                , '',
                 /*options*/ $this->allowed_domains),
+           'description'       => self::pacol(1,          1,      1,      'text', 'description'                   , ''),
             'goto'             => self::pacol(1,          1,      1,      'txtl', 'to'                            , 'pEdit_alias_help'                , array()),
             'is_mailbox'       => self::pacol(0,          0,      1,      'int', ''                             , ''                                , 0 ,
                 # technically 'is_mailbox' is bool, but the automatic bool conversion breaks the query. Flagging it as int avoids this problem.

--- a/model/AliasdomainHandler.php
+++ b/model/AliasdomainHandler.php
@@ -21,6 +21,7 @@ class AliasdomainHandler extends PFAHandler
                 /*options, filled below*/ array(), 0, 0, "", "", 'list-virtual.php?domain=%s'),
             'target_domain'    => self::pacol(1,          1,      1,      'enum', 'pCreate_alias_domain_target'   , 'pCreate_alias_domain_target_text', '',
                 /*options*/ array() /* filled below */),
+           'description'       => self::pacol(1,          1,      1,      'text', 'description'                   , ''),
             'created'          => self::pacol(0,          0,      0,      'ts',   'created'                       , ''),
             'modified'         => self::pacol(0,          0,      1,      'ts',   'last_modified'                 , ''),
             'active'           => self::pacol(1,          1,      1,      'bool', 'active'                        , ''                                 , 1),

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2249,5 +2249,5 @@ function upgrade_1854()
     _db_add_field('alias', 'description', "varchar(255) {UTF-8} NOT NULL DEFAULT ''", 'domain');
 
     # add description after 'target_domain' field in alias_domain table
-    _db_add_field('alias_domain', 'description', "varchar(255) {UTF-8} NOT NULL DEFAULT ''", 'domain');
+    _db_add_field('alias_domain', 'description', "varchar(255) {UTF-8} NOT NULL DEFAULT ''", 'target_domain');
 }

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2239,3 +2239,15 @@ function upgrade_1853()
     _db_add_field('totp_exception_address', 'created', '{DATECURRENT}');
     _db_add_field('totp_exception_address', 'modified', '{DATECURRENT}');
 }
+
+/**
+ * Add 'description' field to alias and domainalist tables
+ */
+function upgrade_1854()
+{
+    # add description after 'domain' field in alias table
+    _db_add_field('alias', 'description', "varchar(255) {UTF-8} NOT NULL DEFAULT ''", 'domain');
+
+    # add description after 'target_domain' field in alias_domain table
+    _db_add_field('alias_domain', 'description', "varchar(255) {UTF-8} NOT NULL DEFAULT ''", 'domain');
+}

--- a/tests/AliasHandlerTest.php
+++ b/tests/AliasHandlerTest.php
@@ -165,7 +165,8 @@ class AliasHandlerTest extends \PHPUnit\Framework\TestCase
             'domain' => 'example.com',
             'active' => 1,
             'address' => 'david.test@example.com',
-            'goto' => ['dest@example.com']
+            'goto' => ['dest@example.com'],
+            'description' => 'A reason this exists.'
         ];
 
         $r = $x->init('david.test@example.com');
@@ -190,6 +191,7 @@ class AliasHandlerTest extends \PHPUnit\Framework\TestCase
                 $this->assertEquals('example.com', $details['domain']);
                 $this->assertEquals('david.test@example.com', $details['address']);
                 $this->assertEquals(['dest@example.com'], $details['goto']);
+                $this->assertEquals('A reason this exists.', $details['description']);
                 $found = true;
                 break;
             }


### PR DESCRIPTION
Adds a `description` field to the `alias` and `alias_domain` tables, so you can add a comment explaining why the alias exists.

Partially addresses #1036 
