### PR TITLE
various patches from @trapoSama sent via email

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -804,6 +804,12 @@ $CONF['version'] = '4.0.1';
 // in your Dovecot SQL configuration.
 $CONF['smtp_active_flag'] = 'NO';
 
+// Domain list display.
+// Set these options to YES to hide optional columns in the domain list.
+// Hidden values remain available in the domain tooltip.
+$CONF['domain_list_hide_maxquota'] = 'NO';
+$CONF['domain_list_hide_password_expiry'] = 'NO';
+
 // If you want to keep most settings at default values and/or want to ensure
 // that future updates work without problems, you can use a separate config 
 // file (config.local.php) instead of editing this file and override some

--- a/model/DomainHandler.php
+++ b/model/DomainHandler.php
@@ -41,8 +41,42 @@ class DomainHandler extends PFAHandler
         $edit_dom_q  = min($super, Config::intbool('domain_quota'), $quota);
         $dom_q  = min(Config::intbool('domain_quota'), $quota);
         $pwexp = min($super, Config::intbool('password_expiration'));
+        $show_maxquota = $quota;
+        $show_pwexp = $pwexp;
+        $maxquota_label = 'pOverview_get_quota';
+        $pwexp_label = 'password_expiration';
+
+        if (Config::bool('domain_list_hide_maxquota')) {
+            $maxquota_label = '';
+        }
+        if (Config::bool('domain_list_hide_password_expiry')) {
+            $pwexp_label = '';
+        }
 
         $query_used_domainquota = 'round(coalesce(__total_quota/' . intval(Config::read('quota_multiplier')) . ',0))';
+        $query_display_domainquota = $query_used_domainquota;
+        $mailbox_quota_select = '';
+        $mailbox_quota_join = '';
+        $mailbox_full_select = ', 0 as __full_mailbox_count';
+
+        if (Config::bool('used_quotas')) {
+            $mailbox_table = table_by_key('mailbox');
+
+            if (Config::bool('new_quota_table')) {
+                $quota2_table = table_by_key('quota2');
+                $mailbox_quota_select = ', sum(coalesce(' . $quota2_table . '.bytes,0)) as __used_quota';
+                $mailbox_full_select = ', sum(case when ' . $mailbox_table . '.quota > 0 and (100 * coalesce(' . $quota2_table . '.bytes,0) / ' . $mailbox_table . '.quota) > ' . intval(Config::read('quota_level_high_pct')) . ' then 1 else 0 end) as __full_mailbox_count';
+                $mailbox_quota_join = ' left join ' . $quota2_table . ' on ' . $mailbox_table . '.username=' . $quota2_table . '.username';
+            } else {
+                $quota_table = table_by_key('quota');
+                $mailbox_quota_select = ', sum(coalesce(' . $quota_table . '.current,0)) as __used_quota';
+                $mailbox_full_select = ', sum(case when ' . $mailbox_table . '.quota > 0 and (100 * coalesce(' . $quota_table . '.current,0) / ' . $mailbox_table . '.quota) > ' . intval(Config::read('quota_level_high_pct')) . ' then 1 else 0 end) as __full_mailbox_count';
+                $mailbox_quota_join = ' left join ' . $quota_table . ' on ' . $mailbox_table . '.username=' . $quota_table . '.username'
+                    . " and (" . $quota_table . ".path='quota/storage' or " . $quota_table . ".path is null)";
+            }
+
+            $query_display_domainquota = 'round(coalesce(__used_quota/' . intval(Config::read('quota_multiplier')) . ',0))';
+        }
 
         # NOTE: There are dependencies between alias_count, mailbox_count and total_quota.
         # NOTE: If you disable "display in list" for one of them, the SQL query for the others might break.
@@ -59,6 +93,7 @@ class DomainHandler extends PFAHandler
             # field name                allow       display in...   type    $PALANG label                    $PALANG description                 default / options / ...
             #                           editing?    form    list
            'domain'            => self::pacol($this->new, 1,      1,      'text', 'domain'                       , ''                                 ,'', array(), 0, 0, "", "", 'list-virtual.php?domain=%s'),
+           'full_mailbox_count' => self::pacol(0,          0,      1,      'vnum', ''                             , ''                                 , '', array(), 0, 0, 'coalesce(__full_mailbox_count,0) as full_mailbox_count'),
            'description'       => self::pacol($super,     $super, $super, 'text', 'description'                  , ''),
 
            # Aliases
@@ -76,18 +111,18 @@ class DomainHandler extends PFAHandler
            'mailboxes'         => self::pacol($super,     $super, 0,      'num' , 'mailboxes'                    , 'pAdminEdit_domain_aliases_text'   , Config::read('mailboxes')),
            'mailbox_count'     => self::pacol(0,          0,      1,      'vnum', ''                             , ''                                 , '', array(), 0, 1,
                /*select*/ 'coalesce(__mailbox_count,0) as mailbox_count',
-               /*extrafrom*/ 'left join ( select count(*) as __mailbox_count, sum(quota) as __total_quota, domain as __mailbox_domain from ' . table_by_key('mailbox') .
+               /*extrafrom*/ 'left join ( select count(*) as __mailbox_count, sum(quota) as __total_quota' . $mailbox_quota_select . $mailbox_full_select . ', domain as __mailbox_domain from ' . table_by_key('mailbox') . $mailbox_quota_join .
                              ' group by domain) as __mailbox on domain = __mailbox_domain'),
             'mailboxes_quot'   => self::pacol(0,          0,      1,       'quot', 'mailboxes'                    , ''                                 , 0, array(), 0, 0,  db_quota_text('__mailbox_count', 'mailboxes', 'mailboxes_quot')),
             '_mailboxes_quot_percent' => self::pacol(0,  0,      1,       'vnum', ''                             , ''                                 , 0, array(), 0, 0,   db_quota_percent('__mailbox_count', 'mailboxes', '_mailboxes_quot_percent')),
 
-           'maxquota'          => self::pacol($editquota,$editquota,$quota, 'num', 'pOverview_get_quota'          , 'pAdminEdit_domain_maxquota_text'  , Config::read('maxquota')),
+           'maxquota'          => self::pacol($editquota,$editquota,$show_maxquota, 'num', $maxquota_label       , 'pAdminEdit_domain_maxquota_text'  , Config::read('maxquota')),
 
             # Domain quota
             'quota'            => self::pacol($edit_dom_q,$edit_dom_q, 0, 'num',  'pAdminEdit_domain_quota'      , 'pAdminEdit_domain_maxquota_text'  , $domain_quota_default),
             'total_quota'      => self::pacol(0,          0,      1,      'vnum', ''                             , ''                                 , '', array(), 0, 0,  "$query_used_domainquota AS total_quota" /*extrafrom*//* already in mailbox_count */),
             'total_quot'     => self::pacol(0,          0,      $dom_q,  'quot', 'pAdminEdit_domain_quota'      , ''                                 , 0, array(), 0, 0,  db_quota_text($query_used_domainquota, 'quota', 'total_quot')),
-            '_total_quot_percent' => self::pacol(0,      0,      $dom_q,  'vnum', ''                             , ''                                 , 0, array(), 0, 0, db_quota_percent($query_used_domainquota, 'quota', '_total_quot_percent')),
+            '_total_quot_percent' => self::pacol(0,      0,      $dom_q,  'vnum', ''                             , ''                                 , 0, array(), 0, 0, db_quota_percent($query_display_domainquota, 'quota', '_total_quot_percent')),
 
            'transport'         => self::pacol($transp,    $transp,$transp,'enum', 'transport'                    , 'pAdminEdit_domain_transport_text' , Config::read('transport_default')     ,
                /*options*/ Config::read_array('transport_options')),
@@ -96,7 +131,7 @@ class DomainHandler extends PFAHandler
            'default_aliases'   => self::pacol($this->new, $this->new, 0,  'bool', 'pAdminCreate_domain_defaultaliases', ''                            , 1,array(), /*not in db*/ 1),
            'created'           => self::pacol(0,          0,      0,      'ts',   'created'                      , ''),
            'modified'          => self::pacol(0,          0,      $super, 'ts',   'last_modified'                , ''),
-           'password_expiry'   => self::pacol($super,     $pwexp, $pwexp, 'num',  'password_expiration'          , 'password_expiration_desc'         , 365),
+           'password_expiry'   => self::pacol($super,     $pwexp, $show_pwexp, 'num',  $pwexp_label              , 'password_expiration_desc'         , 365),
             '_can_edit'        => self::pacol(0,          0,      1,      'int', ''                             , ''                                , 0 ,
                 /*options*/ array(),
                 /*not_in_db*/ 0,

--- a/public/css/bootstrap.css
+++ b/public/css/bootstrap.css
@@ -75,25 +75,23 @@ body {
 span.active { font-weight: bold; }
 div#login{ max-width: 35em; }
 
-.quota {
-z-index:99;
-height:14px;
-position: absolute;
-}
-.quota_text {
-  z-index:100;
+.quota_bar {
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+  min-width: 122px;
+  height: 16px;
+  overflow: hidden;
+  background-color: white;
+  border: 1px solid #999;
+  line-height: 14px;
   text-align: center;
-  font-size: 12px;
-  color: #666;
-  cursor: default;
-  position: absolute;
-  width:120px;
-  height:16px;
-  margin-top:-17px;
-  padding-top: -1px;
+  vertical-align: middle;
+  white-space: nowrap;
 }
-.quota_bg { background-color: white; z-index:98; width:122px; height:16px;margin-top:-1px;margin-left:-1px;   border: 1px solid #999;}
-.quota_no_border { border:none; margin:0; }
+.quota_fill { position: absolute; z-index: 1; top: 0; right: auto; bottom: 0; left: 0; max-width: 100%; }
+.quota_label { position: relative; z-index: 2; display: block; height: 14px; padding: 0 4px; font-size: 12px; color: #666; cursor: default; }
+.quota_no_border { min-width: 0; background: transparent; border: none; }
 .quota_high { background: url(../images/quota-colors.png) repeat-x 0 -28px #f90509; }
 .quota_mid  { background: url(../images/quota-colors.png) repeat-x 0 -14px #e3e909; }
 .quota_low  { background: url(../images/quota-colors.png) repeat-x 0 0px #05f905; }
@@ -101,3 +99,55 @@ position: absolute;
 .quota_text_mid { color: #666; }
 .quota_text_low { color: #666; }
 
+/* Domain list column sizing. */
+#admin_table th.list-col-domain,
+#admin_table td.list-col-domain { min-width: 180px; }
+#admin_table th.list-col-description,
+#admin_table td.list-col-description { min-width: 120px; }
+#admin_table th.list-col-aliases_quot,
+#admin_table td.list-col-aliases_quot,
+#admin_table th.list-col-mailboxes_quot,
+#admin_table td.list-col-mailboxes_quot { width: 138px; text-align: center; white-space: nowrap; }
+#admin_table th.list-col-maxquota,
+#admin_table td.list-col-maxquota { width: 80px; text-align: center; white-space: nowrap; }
+#admin_table th.list-col-total_quot,
+#admin_table td.list-col-total_quot { width: 142px; text-align: center; white-space: nowrap; }
+#admin_table th.list-col-transport,
+#admin_table td.list-col-transport { width: 80px; text-align: center; white-space: nowrap; }
+#admin_table th.list-col-backupmx,
+#admin_table td.list-col-backupmx { width: 62px; text-align: center; white-space: nowrap; }
+#admin_table th.list-col-active,
+#admin_table td.list-col-active { width: 70px; text-align: center; white-space: nowrap; }
+#admin_table th.list-col-modified,
+#admin_table td.list-col-modified { width: 110px; text-align: center; white-space: nowrap; }
+#admin_table th.list-col-password_expiry,
+#admin_table td.list-col-password_expiry { width: 64px; text-align: center; white-space: nowrap; }
+#admin_table th.list-col-action,
+#admin_table td.list-col-action { width: 90px; text-align: center; white-space: nowrap; }
+
+.domain-list-scroll { display: block; width: 100%; overflow-x: auto; }
+.domain-list-scroll > #admin_table { min-width: 1240px; margin-bottom: 0; }
+
+/* Keep the essential domain columns and actions visible before scrolling. */
+#admin_table th.list-col-total_quot,
+#admin_table th.list-col-password_expiry { white-space: normal; line-height: 1.2; }
+
+@media (max-width: 1300px) {
+  #admin_table .list-col-modified { display: none; }
+  .domain-list-scroll > #admin_table { min-width: 1120px; }
+}
+
+@media (max-width: 1200px) {
+  #admin_table .list-col-backupmx { display: none; }
+  .domain-list-scroll > #admin_table { min-width: 1060px; }
+}
+
+@media (max-width: 1120px) {
+  #admin_table .list-col-transport { display: none; }
+  .domain-list-scroll > #admin_table { min-width: 980px; }
+}
+
+#admin_table th.list-col-action,
+#admin_table td.list-col-action { width: 46px; }
+#admin_table .list-action-icon,
+#mailbox_table .list-action-icon { width: 34px; padding-left: 0; padding-right: 0; }

--- a/templates/list-virtual_mailbox.tpl
+++ b/templates/list-virtual_mailbox.tpl
@@ -77,11 +77,10 @@
                                 {elseif $divide_quota.percent[$i] > $CONF.quota_level_med_pct}
                                     {assign var="quota_level" value="mid"}
                                 {/if}
-                                <div class="quota quota_{$quota_level}"
-                                    style="width:{$divide_quota.quota_width[$i]}px;"></div>
-                                <div class="quota_bg"></div>
-                                <div class="quota_text quota_text_{$quota_level}">{$divide_quota.current[$i]}
-                                    / {$divide_quota.quota[$i]}</div>
+                                <div class="quota_bar">
+                                    <span class="quota_fill quota_{$quota_level}" style="width:{$divide_quota.percent[$i]}%;"></span>
+                                    <span class="quota_label quota_text_{$quota_level}">{$divide_quota.current[$i]} / {$divide_quota.quota[$i]}</span>
+                                </div>
                             {else}
                                 {$divide_quota.quota[$i]}
                             {/if}
@@ -89,21 +88,21 @@
                     </td>
                 {/if}
                 <td>{$item.modified}</td>
-                <td><a class="btn btn-{if ($item.active==0)}info{else}warning{/if}"
+                <td><a class="btn btn-sm btn-{if ($item.active==0)}info{else}warning{/if} list-action-icon" title="{$PALANG.active}: {if $item.active==1}{$PALANG.YES}{else}{$PALANG.NO}{/if}" aria-label="{$PALANG.active}: {if $item.active==1}{$PALANG.YES}{else}{$PALANG.NO}{/if}"
                     href="{#url_editactive#}mailbox&amp;id={$item.username|escape:"url"}&amp;active={if ($item.active==0)}1{else}0{/if}&amp;token={CSRF_Token type="url"}"
                     >{if $item.active==1}
                             <span class="bi bi-check-lg" aria-hidden="true"></span>
-                            {$PALANG.YES}{else}
+                            {else}
                             <span class="bi bi-square" aria-hidden="true"></span>
-                            {$PALANG.NO}{/if}</a></td>
+                            {/if}</a></td>
                 {if $CONF.smtp_active_flag===YES}
-                    <td><a class="btn btn-{if ($item.smtp_active==0)}info{else}warning{/if}"
+                    <td><a class="btn btn-sm btn-{if ($item.smtp_active==0)}info{else}warning{/if} list-action-icon" title="{$PALANG.smtp_active}: {if $item.smtp_active==1}{$PALANG.YES}{else}{$PALANG.NO}{/if}" aria-label="{$PALANG.smtp_active}: {if $item.smtp_active==1}{$PALANG.YES}{else}{$PALANG.NO}{/if}"
                         href="{#url_editactive#}mailbox&amp;id={$item.username|escape:"url"}&amp;active={if ($item.smtp_active==0)}1{else}0{/if}&amp;field=smtp_active&amp;token={CSRF_Token type="url"}"
                         >{if $item.smtp_active==1}
                                 <span class="bi bi-check-lg" aria-hidden="true"></span>
-                                {$PALANG.YES}{else}
+                                {else}
                                 <span class="bi bi-square" aria-hidden="true"></span>
-                                {$PALANG.NO}{/if}</a></td>
+                                {/if}</a></td>
                 {/if}
                 {if $CONF.vacation_control_admin===YES && $CONF.vacation===YES}
                     {if $item.v_active!==-1}
@@ -112,8 +111,8 @@
                         {else}
                             {assign var="v_active" value=$PALANG.pOverview_vacation_option}
                         {/if}
-                        <td><a class="btn btn-warning"
-                            href="vacation.php?username={$item.username|escape:"url"}">{$v_active}</a></td>
+                        <td><a class="btn btn-sm btn-warning list-action-icon" title="{$v_active}" aria-label="{$v_active}"
+                            href="vacation.php?username={$item.username|escape:"url"}"><span class="bi bi-arrow-repeat" aria-hidden="true"></span></a></td>
                     {/if}
                 {else}
                     <td>&nbsp;</td>
@@ -122,19 +121,19 @@
                 {if $authentication_has_role.global_admin!==true && $CONF.alias_control_admin===YES}{assign var="edit_aliases" value=1}{/if}
                 {if $authentication_has_role.global_admin==true && $CONF.alias_control===YES}{assign var="edit_aliases" value=1}{/if}
                 {if $edit_aliases==1}
-                    <td><a class="btn btn-primary" href="edit.php?table=alias&amp;edit={$item.username|escape:"url"}"><span
-                                    class="bi bi-envelope" aria-hidden="true"></span> {$PALANG.alias}</a></td>
+                    <td><a class="btn btn-sm btn-primary list-action-icon" title="{$PALANG.alias}" aria-label="{$PALANG.alias}" href="edit.php?table=alias&amp;edit={$item.username|escape:"url"}"><span
+                                    class="bi bi-envelope" aria-hidden="true"></span></a></td>
                 {/if}
-                <td><a class="btn btn-primary" href="edit.php?table=mailbox&amp;edit={$item.username|escape:"url"}"><span
-                                class="bi bi-pencil" aria-hidden="true"></span> {$PALANG.edit}</a></td>
+                <td><a class="btn btn-sm btn-primary list-action-icon" title="{$PALANG.edit}" aria-label="{$PALANG.edit}" href="edit.php?table=mailbox&amp;edit={$item.username|escape:"url"}"><span
+                                class="bi bi-pencil" aria-hidden="true"></span></a></td>
                 <td>
                     <form method="post" action="delete.php">
                         <input type="hidden" name="table" value="mailbox">
                         <input type="hidden" name="delete" value="{$item.username|escape:"quotes"}">
                         {CSRF_Token}
-                        <button type="submit" class="btn btn-danger"
+                        <button type="submit" class="btn btn-sm btn-danger list-action-icon" title="{$PALANG.del}" aria-label="{$PALANG.del}"
                                 onclick="return confirm ('{$PALANG.confirm}{$PALANG.mailboxes}: {$item.username}');">
-                            <span class="bi bi-trash" aria-hidden="true"></span> {$PALANG.del}
+                            <span class="bi bi-trash" aria-hidden="true"></span>
                         </button>
                     </form>
                 </td>

--- a/templates/list.tpl
+++ b/templates/list.tpl
@@ -34,17 +34,18 @@
     {/if}
 
     <div class="card-body">
+        {if $table == 'domain'}<div class="domain-list-scroll">{/if}
         <table class="table table-hover table-sm table-striped align-middle" id='admin_table'>
             <!-- TODO: 'admin_table' needed because of CSS for table header -->
             <thead>
             <tr>
                 {foreach key=key item=field from=$struct}
                     {if $field.display_in_list == 1 && $field.label}{* don't show fields without a label *}
-                        <th>{$field.label}</th>
+                        <th class="list-col-{$key}">{$field.label}</th>
                     {/if}
                 {/foreach}
-                <th>&nbsp;</th>
-                <th>&nbsp;</th>
+                <th class="list-col-action">&nbsp;</th>
+                <th class="list-col-action">&nbsp;</th>
             </tr>
             </thead>
             <tbody>
@@ -58,7 +59,21 @@
 
                             {if $field.linkto != '' && ($item.$id_field != '' || $item.$id_field > 0) }
                                 {assign "linkto" "{$field.linkto|replace:'%s':{$item.$id_field|escape:url}}"} {* TODO: use label field instead *}
-                                {assign "linktext" "<a href='{$linkto}'>{$item.{$key}}</a>"}
+                                {assign "linktitle" ""}
+                                {if $table == 'domain' && $key == 'domain'}
+                                    {if isset($struct.maxquota) && $struct.maxquota.label == ''}
+                                        {assign "linktitle" "{$PALANG.pOverview_get_quota}: {$item.maxquota} MB"}
+                                    {/if}
+                                    {if isset($struct.password_expiry) && $struct.password_expiry.label == ''}
+                                        {if $linktitle != ''}{assign "linktitle" "{$linktitle}&#10;"}{/if}
+                                        {assign "linktitle" "{$linktitle}{$PALANG.password_expiration}: {$item.password_expiry}"}
+                                    {/if}
+                                {/if}
+                                {if $linktitle != ''}
+                                    {assign "linktext" "<a href='{$linkto}' title='{$linktitle}'>{$item.{$key}}</a>"}
+                                {else}
+                                    {assign "linktext" "<a href='{$linkto}'>{$item.{$key}}</a>"}
+                                {/if}
                             {else}
                                 {assign "linktext" $item.$key}
                             {/if}
@@ -66,25 +81,26 @@
                             {if $table == 'foo' && $key == 'bar'}
                                 <td>Special handling (complete table row) for {$table} / {$key}</td>
                             {else}
-                                <td>
+                                <td class="list-col-{$key}">
                                     {if $table == 'foo' && $key == 'bar'}
                                         Special handling (td content) for {$table} / {$key}
                                     {elseif $table == 'aliasdomain' && $key == 'target_domain' && $struct.target_domain.linkto == 'target'}
                                         <a href="list-virtual.php?domain={$item.target_domain|escape:"quotes"}">{$item.target_domain}</a>
                                         {* do we need escape:url or escpae:quotes here? see #705 *}
+                                    {elseif $table == 'domain' && $key == 'domain'}
+                                        {$linktext} {if $item.full_mailbox_count > 0}<span class="text-danger">({$item.full_mailbox_count})</span>{/if}
                                         {*                    {elseif $table == 'domain' && $key == 'domain'}
                                                                 <a href="list.php?table=domain&domain={$item.domain|escape:"url"}">{$item.domain}</a>
                                         *}
                                     {elseif $key == 'active'}
                                         {if $item._can_edit}
-                                            <a class="btn btn-sm btn-{if ($item.active==0)}info{else}warning{/if}"
+                                            <a class="btn btn-sm btn-{if ($item.active==0)}info{else}warning{/if} list-action-icon" title="{$field.label}: {$item._active}" aria-label="{$field.label}: {$item._active}"
                                             href="{#url_editactive#}{$table}&amp;id={$RAW_item.$id_field|escape:"url"}&amp;active={if ($item.active==0)}1{else}0{/if}&amp;token={CSRF_Token type="url"}">
                                                 {if $item._active == $PALANG['YES']}
                                                     <span class="bi bi-check-lg" aria-hidden="true"></span>
                                                 {else}
                                                     <span class="bi bi-square" aria-hidden="true"></span>
                                                 {/if}
-                                                {$item._active}
                                             </a>
                                         {else}
                                             {$item._active}
@@ -105,15 +121,14 @@
                                         {else}
                                             {assign var="quota_level" value="low"}
                                         {/if}
-                                        {if $item[$tmpkey] > -1}
-                                            <div class="quota quota_{$quota_level}"
-                                                style="width:{$item[$tmpkey] *1.2}px;"></div>
-                                            <div class="quota_bg"></div>
-                                            <div class="quota_text quota_text_{$quota_level}">{$linktext}</div>
-                                        {else}
-                                            <div class="quota_bg quota_no_border"></div>
-                                            <div class="quota_text">{$linktext}</div>
-                                        {/if}
+                                        <div class="quota_bar{if $item[$tmpkey] <= -1} quota_no_border{/if}">
+                                            {if $item[$tmpkey] > -1}
+                                                <span class="quota_fill quota_{$quota_level}" style="width:{$item[$tmpkey]}%;"></span>
+                                                <span class="quota_label quota_text_{$quota_level}">{$linktext}</span>
+                                            {else}
+                                                <span class="quota_label">{$linktext}</span>
+                                            {/if}
+                                        </div>
 
                                     {elseif $field.type == 'txtl'}
                                         {foreach key=key2 item=field2 from=$item.$key}{$field2}<br>{/foreach}
@@ -127,22 +142,22 @@
                         {/if}
                     {/foreach}
 
-                    <td>{if $item._can_edit}
-                            <a class="btn btn-sm btn-primary"
+                    <td class="list-col-action">{if $item._can_edit}
+                            <a class="btn btn-sm btn-primary list-action-icon" title="{$PALANG.edit}" aria-label="{$PALANG.edit}"
                             href="edit.php?table={$table|escape:"url"}&amp;edit={$RAW_item.$id_field|escape:"url"}"><span
-                                        class="bi bi-pencil" aria-hidden="true"></span> {$PALANG.edit}</a>
+                                        class="bi bi-pencil" aria-hidden="true"></span></a>
                         {else}&nbsp;
                         {/if}
                     </td>
-                    <td>{if $item._can_delete}
+                    <td class="list-col-action">{if $item._can_delete}
                             <form method="post" action="{#url_delete#}">
                                 <input type="hidden" name="table" value="{$table}">
                                 <input type="hidden" name="delete" value="{$RAW_item.$id_field|escape:"quotes"}">
                                 {CSRF_Token}
 
-                                <button class="btn btn-sm btn-danger"
+                                <button class="btn btn-sm btn-danger list-action-icon" title="{$PALANG.del}" aria-label="{$PALANG.del}"
                                         onclick="return confirm('{$PALANG.{$msg.confirm_delete}|replace:'%s':$item.$id_field}')">
-                                    <span class="bi bi-trash" aria-hidden="true"></span> {$PALANG.del}
+                                    <span class="bi bi-trash" aria-hidden="true"></span>
                                 </button>
                             </form>
                         {else}&nbsp;{/if}
@@ -151,6 +166,7 @@
             {/foreach}
             </tbody>
         </table>
+        {if $table == 'domain'}</div>{/if}
     </div>
 
     <div class="card-footer">

--- a/templates/list.tpl
+++ b/templates/list.tpl
@@ -61,10 +61,10 @@
                                 {assign "linkto" "{$field.linkto|replace:'%s':{$item.$id_field|escape:url}}"} {* TODO: use label field instead *}
                                 {assign "linktitle" ""}
                                 {if $table == 'domain' && $key == 'domain'}
-                                    {if isset($struct.maxquota) && $struct.maxquota.label == ''}
+                                    {if isset($struct.maxquota) && $struct.maxquota.label == '' && isset($item.maxquota)}
                                         {assign "linktitle" "{$PALANG.pOverview_get_quota}: {$item.maxquota} MB"}
                                     {/if}
-                                    {if isset($struct.password_expiry) && $struct.password_expiry.label == ''}
+                                    {if isset($struct.password_expiry) && $struct.password_expiry.label == '' && isset($item.password_expiry)}
                                         {if $linktitle != ''}{assign "linktitle" "{$linktitle}&#10;"}{/if}
                                         {assign "linktitle" "{$linktitle}{$PALANG.password_expiration}: {$item.password_expiry}"}
                                     {/if}


### PR DESCRIPTION

 * Keeps the assigned domain quota text and uses real mailbox usage for the quota bar color and fill.
 * Shows a red count next to a domain when one or more mailboxes exceed the configured quota alert threshold. Requires patch 1.
 * Adds optional configuration to hide mailbox quota and password expiry columns while retaining those values in the domain tooltip.
 * Corrects the quota-bar markup and aligns domain-list columns.
 * Replaces the quota bars in the domain overview and mailbox list with a unified bar component, preventing the fill, label, and border from separating. It hides Modified, Backup MX, and Transport progressively on reduced desktop widths, then uses horizontal scrolling as the final fallback. Requires patches 1 through 4.
 * Uses icon-only controls with translated tooltips in domain and mailbox lists: active state, SMTP active state, autoresponder, alias, edit, and delete. Active-state tooltips show the current value, for example `Activo: SI` or `Activo: NO`. Requires patch 5.