### PR TITLE
Polish virtual form labels and search spacing

### DIFF
--- a/languages/en.lang
+++ b/languages/en.lang
@@ -110,6 +110,7 @@ $PALANG['no_domains_for_this_admin'] = 'You don\'t have permissions for any doma
 $PALANG['no_domains_exist'] = 'You have to create at least one domain before you can use virtual list.'; # "virtual list" should match $PALANG['pAdminMenu_list_virtual']
 
 $PALANG['domain'] = 'Domain';
+$PALANG['search_domains'] = 'Search for domains...';
 $PALANG['pOverview_get_alias_domains'] = 'Domain Aliases';
 $PALANG['mailboxes'] = 'Mailboxes';
 $PALANG['pOverview_get_quota'] = 'Mailbox Quota (MB)';

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -102,6 +102,7 @@ $PALANG['no_domains_for_this_admin'] = 'No tienes permisos sobre ningún dominio
 $PALANG['no_domains_exist'] = 'Debes crear al menos un dominio antes de usar la lista virtual.';
 
 $PALANG['domain'] = 'Dominio';
+$PALANG['search_domains'] = 'Buscar dominios...';
 $PALANG['pOverview_get_alias_domains'] = 'Alias de Dominios'; 
 $PALANG['mailboxes'] = 'Buzones';
 $PALANG['pOverview_get_quota'] = 'Cuota de buzón (MB)';

--- a/model/AliasHandler.php
+++ b/model/AliasHandler.php
@@ -32,7 +32,7 @@ class AliasHandler extends PFAHandler
             'localpart'        => self::pacol($this->new, 0,      0,      'text', 'alias'                         , 'pCreate_alias_catchall_text'     , '',
                 /*options*/ array(),
                 /*not_in_db*/ 1),
-            'domain'           => self::pacol($this->new, 0,      1,      'enum', ''                              , ''                                , '',
+            'domain'           => self::pacol($this->new, 0,      1,      'enum', 'domain'                        , ''                                , '',
                 /*options*/ $this->allowed_domains),
            'description'       => self::pacol(1,          1,      1,      'text', 'description'                   , ''),
             'goto'             => self::pacol(1,          1,      1,      'txtl', 'to'                            , 'pEdit_alias_help'                , array()),

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -34,7 +34,7 @@ class MailboxHandler extends PFAHandler
             'local_part' => self::pacol($this->new, 0, 0, 'text', 'pEdit_mailbox_username', '', '',
                 /*options*/ array('legal_chars' => Config::read('username_legal_chars'), 'legal_char_warning' => Config::lang('pLegal_char_warning'))
             ),
-            'domain' => self::pacol($this->new, 0, 1, 'enum', '', '', '',
+            'domain' => self::pacol($this->new, 0, 1, 'enum', 'domain', '', '',
                 /*options*/ $this->allowed_domains),
             # TODO: maildir: display in list is needed to include maildir in SQL result (for post_edit hook)
             # TODO:          (not a perfect solution, but works for now - maybe we need a separate "include in SELECT query" field?)

--- a/public/css/bootstrap.css
+++ b/public/css/bootstrap.css
@@ -156,3 +156,5 @@ div#login{ max-width: 35em; }
 .mailbox-list-scroll > #mailbox_table { min-width: 820px; margin-bottom: 0; }
 .virtual-list-scroll { display: block; width: 100%; overflow-x: auto; }
 .virtual-list-scroll > #admin_table { min-width: 720px; margin-bottom: 0; }
+.virtual-search form { margin-bottom: .25rem; }
+.virtual-search .form-control { margin-left: auto; max-width: 18rem; }

--- a/templates/editform.tpl
+++ b/templates/editform.tpl
@@ -31,17 +31,17 @@
                                                        name="value[{$key}]"{if {$value_{$key}} == 1} checked="checked"{/if}/>
                                             </label></div>
                                     {elseif $field.type == 'enum'}
-                                        <select class="form-control" name="value[{$key}]" id="{$key}">
+                                        <select class="form-select" name="value[{$key}]" id="{$key}">
                                             {html_options output=$struct.{$key}.options values=$struct.{$key}.options selected=$value_{$key}}
                                         </select>
                                     {elseif $field.type == 'enma'}
-                                        <select class="form-control" name="value[{$key}]" id="{$key}">
+                                        <select class="form-select" name="value[{$key}]" id="{$key}">
                                             {html_options options=$struct.{$key}.options selected=$value_{$key}}
                                         </select>
                                     {elseif $field.type == 'list'}
                                         <input type="text" class="form-control" style="margin-bottom : 25px;"
                                                id="id_searchDomains" onkeyup="searchDomains()"
-                                               placeholder="Search for domains..." title="search domains">
+                                              placeholder="{$PALANG.search_domains}" title="{$PALANG.search_domains}">
                                         <ul id="domainsList" name="value[{$key}][]"
                                             style="max-height : 250px; overflow: auto;">
                                             {foreach from=$struct.{$key}.options item=domain}

--- a/templates/list-virtual.tpl
+++ b/templates/list-virtual.tpl
@@ -9,7 +9,7 @@
                     <noscript><input class="button" type="submit" name="go" value="{$PALANG.go}"/></noscript>
                 </form>
             </div>
-            <div class="col-md-5 offset-md-2 text-right">{#form_search#}</div>
+            <div class="col-md-5 offset-md-2 text-right virtual-search">{#form_search#}</div>
         </div>
     </div>
     <div class="card-body">


### PR DESCRIPTION
This PR contains small UI and translation fixes for virtual/admin forms.\n\nChanges:\n- Adds PALANG entry for the domain search placeholder.\n- Replaces the hardcoded domain search placeholder in edit forms.\n- Shows the Domain label when creating aliases and mailboxes.\n- Uses Bootstrap 5 form-select for generated select controls.\n- Adds minor spacing for the virtual search field.\n\nValidated locally with PHP syntax checks for the touched PHP/lang/template files.