### PR TITLE
Handle expired sessions for invalid tokens

### DIFF
--- a/languages/en.lang
+++ b/languages/en.lang
@@ -518,6 +518,10 @@ $PALANG['pLegal_char_warning']              = 'Illegal character';
 $PALANG['TOTP_already_configured']          = 'TOTP is already configured for this account, do you want to change your secret?';
 $PALANG['pApp_passwords_add']               = 'Add application-specific password';
 
+$PALANG['session_expired_title'] = 'Session expired';
+$PALANG['session_expired_message'] = 'Your session has expired. Please log in again.';
+$PALANG['session_expired_redirect'] = 'You will be redirected to the login page in 5 seconds.';
+$PALANG['session_expired_button'] = 'Go to login';
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -519,9 +519,8 @@ $PALANG['TOTP_already_configured']          = 'TOTP is already configured for th
 $PALANG['pApp_passwords_add']               = 'Add application-specific password';
 
 $PALANG['session_expired_title'] = 'Session expired';
-$PALANG['session_expired_message'] = 'Your session has expired. Please log in again.';
-$PALANG['session_expired_redirect'] = 'You will be redirected to the login page in 5 seconds.';
-$PALANG['session_expired_button'] = 'Go to login';
+$PALANG['session_expired_message'] = 'The page token is no longer valid. Please return and try again.';
+$PALANG['session_expired_button'] = 'Continue';
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -498,6 +498,10 @@ $PALANG['TOTP_already_configured'] = 'TOTP ya está configurado para esta cuenta
 
 $PALANG['pApp_passwords_add'] = 'Añadir contraseña específica para aplicaciones';
 
+$PALANG['session_expired_title'] = 'Sesión expirada';
+$PALANG['session_expired_message'] = 'Tu sesión ha expirado. Ingresa nuevamente.';
+$PALANG['session_expired_redirect'] = 'Serás redirigido al inicio de sesión en 5 segundos.';
+$PALANG['session_expired_button'] = 'Ir al login';
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -499,9 +499,8 @@ $PALANG['TOTP_already_configured'] = 'TOTP ya está configurado para esta cuenta
 $PALANG['pApp_passwords_add'] = 'Añadir contraseña específica para aplicaciones';
 
 $PALANG['session_expired_title'] = 'Sesión expirada';
-$PALANG['session_expired_message'] = 'Tu sesión ha expirado. Ingresa nuevamente.';
-$PALANG['session_expired_redirect'] = 'Serás redirigido al inicio de sesión en 5 segundos.';
-$PALANG['session_expired_button'] = 'Ir al login';
+$PALANG['session_expired_message'] = 'El token de la página ya no es válido. Vuelve e intenta nuevamente.';
+$PALANG['session_expired_button'] = 'Continuar';
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/public/broadcast-message.php
+++ b/public/broadcast-message.php
@@ -48,7 +48,7 @@ $smtp_from_email = smtp_get_admin_email();
 $allowed_domains = list_domains_for_admin(authentication_get_username());
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/broadcast-message.php
+++ b/public/broadcast-message.php
@@ -49,7 +49,7 @@ $allowed_domains = list_domains_for_admin(authentication_get_username());
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     if (empty($_POST['subject']) || empty($_POST['message']) || empty($_POST['name']) || empty($_POST['domains']) || !is_array($_POST['domains'])) {

--- a/public/common.php
+++ b/public/common.php
@@ -1,3 +1,42 @@
 <?php
 
 require_once(dirname(__FILE__) . '/../common.php');
+
+function pfa_handle_invalid_token(): void
+{
+    http_response_code(419); // HTTP 419 Page Expired.
+
+    $loginUrl = 'login.php';
+    $title = Config::lang('session_expired_title') ?: 'Session expired';
+    $message = Config::lang('session_expired_message') ?: 'Your session has expired. Please log in again.';
+    $redirect = Config::lang('session_expired_redirect') ?: 'You will be redirected to the login page in 5 seconds.';
+    $button = Config::lang('session_expired_button') ?: 'Go to login';
+
+    echo <<<HTML
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="5;url={$loginUrl}">
+    <title>{$title}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; background: #f6f7f9; color: #222; }
+        main { max-width: 520px; margin: 12vh auto; padding: 2rem; background: #fff; border: 1px solid #ddd; border-radius: .5rem; text-align: center; }
+        h1 { margin-top: 0; font-size: 1.5rem; }
+        p { line-height: 1.45; }
+        a { display: inline-block; margin-top: 1rem; padding: .65rem 1rem; background: #337ab7; color: #fff; text-decoration: none; border-radius: 4px; }
+    </style>
+</head>
+<body>
+<main>
+    <h1>{$title}</h1>
+    <p>{$message}</p>
+    <p>{$redirect}</p>
+    <a href="{$loginUrl}">{$button}</a>
+</main>
+</body>
+</html>
+HTML;
+    exit(0);
+}

--- a/public/common.php
+++ b/public/common.php
@@ -6,11 +6,10 @@ function pfa_handle_invalid_token(): void
 {
     http_response_code(419); // HTTP 419 Page Expired.
 
-    $loginUrl = 'login.php';
+    $returnUrl = 'main.php';
     $title = Config::lang('session_expired_title') ?: 'Session expired';
-    $message = Config::lang('session_expired_message') ?: 'Your session has expired. Please log in again.';
-    $redirect = Config::lang('session_expired_redirect') ?: 'You will be redirected to the login page in 5 seconds.';
-    $button = Config::lang('session_expired_button') ?: 'Go to login';
+    $message = Config::lang('session_expired_message') ?: 'The page token is no longer valid. Please return and try again.';
+    $button = Config::lang('session_expired_button') ?: 'Continue';
 
     echo <<<HTML
 <!doctype html>
@@ -18,7 +17,6 @@ function pfa_handle_invalid_token(): void
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="refresh" content="5;url={$loginUrl}">
     <title>{$title}</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 0; background: #f6f7f9; color: #222; }
@@ -32,8 +30,7 @@ function pfa_handle_invalid_token(): void
 <main>
     <h1>{$title}</h1>
     <p>{$message}</p>
-    <p>{$redirect}</p>
-    <a href="{$loginUrl}">{$button}</a>
+    <a href="{$returnUrl}">{$button}</a>
 </main>
 </body>
 </html>

--- a/public/delete.php
+++ b/public/delete.php
@@ -21,7 +21,7 @@
 require_once('common.php');
 
 
-if (safepost('token') != $_SESSION['PFA_token']) {
+if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
     pfa_handle_invalid_token();
 }
 

--- a/public/delete.php
+++ b/public/delete.php
@@ -22,7 +22,7 @@ require_once('common.php');
 
 
 if (safepost('token') != $_SESSION['PFA_token']) {
-    die('Invalid token!');
+    pfa_handle_invalid_token();
 }
 
 $username = authentication_get_username(); # enforce login

--- a/public/edit.php
+++ b/public/edit.php
@@ -104,7 +104,7 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     $inp_values = [];

--- a/public/edit.php
+++ b/public/edit.php
@@ -103,7 +103,7 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
 
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/editactive.php
+++ b/public/editactive.php
@@ -21,7 +21,7 @@
 
 require_once('common.php');
 
-if (safeget('token') != $_SESSION['PFA_token']) {
+if (safeget('token') != ($_SESSION['PFA_token'] ?? '')) {
     pfa_handle_invalid_token();
 }
 

--- a/public/editactive.php
+++ b/public/editactive.php
@@ -22,7 +22,7 @@
 require_once('common.php');
 
 if (safeget('token') != $_SESSION['PFA_token']) {
-    die('Invalid token!');
+    pfa_handle_invalid_token();
 }
 
 $username = authentication_get_username(); # enforce login

--- a/public/login-mfa.php
+++ b/public/login-mfa.php
@@ -55,11 +55,11 @@ if (isset($_GET["abort"]) && $_GET["abort"] == "1" && authentication_mfa_incompl
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (!isset($_SESSION['PFA_token'])) {
-        die("Invalid token (session timeout; refresh the page and try again?)");
+        pfa_handle_invalid_token();
     }
 
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token! (CSRF check failed)');
+        pfa_handle_invalid_token();
     }
 
     $totppf = new TotpPf('admin', new Login('admin'));

--- a/public/login-mfa.php
+++ b/public/login-mfa.php
@@ -58,7 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         pfa_handle_invalid_token();
     }
 
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/login.php
+++ b/public/login.php
@@ -50,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         pfa_handle_invalid_token();
     }
 
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/login.php
+++ b/public/login.php
@@ -47,11 +47,11 @@ if (authentication_mfa_incomplete()) {
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (!isset($_SESSION['PFA_token'])) {
-        die("Invalid token (session timeout; refresh the page and try again?)");
+        pfa_handle_invalid_token();
     }
 
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token! (CSRF check failed)');
+        pfa_handle_invalid_token();
     }
 
 

--- a/public/sendmail.php
+++ b/public/sendmail.php
@@ -44,7 +44,7 @@ $smtp_from_email = smtp_get_admin_email();
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     $fTo = safepost('fTo');

--- a/public/sendmail.php
+++ b/public/sendmail.php
@@ -43,7 +43,7 @@ $smtp_from_email = smtp_get_admin_email();
 
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/users/app-passwords.php
+++ b/public/users/app-passwords.php
@@ -52,7 +52,7 @@ if (authentication_has_role('global-admin')) {
 
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/users/app-passwords.php
+++ b/public/users/app-passwords.php
@@ -53,7 +53,7 @@ if (authentication_has_role('global-admin')) {
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     if (isset($_POST['fCancel'])) {

--- a/public/users/edit-alias.php
+++ b/public/users/edit-alias.php
@@ -63,7 +63,7 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     // user clicked on cancel button

--- a/public/users/edit-alias.php
+++ b/public/users/edit-alias.php
@@ -62,7 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
 }
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/users/login-mfa.php
+++ b/public/users/login-mfa.php
@@ -50,11 +50,11 @@ $smarty->configureTheme('../');
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (!isset($_SESSION['PFA_token'])) {
-        die("Invalid token (session timeout; refresh the page and try again?)");
+        pfa_handle_invalid_token();
     }
 
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token! (CSRF check failed)');
+        pfa_handle_invalid_token();
     }
 
     $totppf = new TotpPf('mailbox', new Login('mailbox'));

--- a/public/users/login-mfa.php
+++ b/public/users/login-mfa.php
@@ -53,7 +53,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         pfa_handle_invalid_token();
     }
 
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/users/login.php
+++ b/public/users/login.php
@@ -44,7 +44,7 @@ if (authentication_mfa_incomplete()) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/users/login.php
+++ b/public/users/login.php
@@ -45,7 +45,7 @@ if (authentication_mfa_incomplete()) {
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     $login = new Login('mailbox');

--- a/public/users/password.php
+++ b/public/users/password.php
@@ -40,7 +40,7 @@ $pPassword_password_current_text = "";
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     if (isset($_POST['fCancel'])) {

--- a/public/users/password.php
+++ b/public/users/password.php
@@ -39,7 +39,7 @@ $pPassword_password_current_text = "";
 
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/users/totp-exceptions.php
+++ b/public/users/totp-exceptions.php
@@ -57,7 +57,7 @@ if (authentication_has_role('global-admin')) {
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     if (isset($_POST['fCancel'])) {

--- a/public/users/totp-exceptions.php
+++ b/public/users/totp-exceptions.php
@@ -56,7 +56,7 @@ if (authentication_has_role('global-admin')) {
 
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/users/totp.php
+++ b/public/users/totp.php
@@ -51,7 +51,7 @@ if (authentication_has_role('admin')) {
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
     if (isset($_POST['fCancel'])) {

--- a/public/users/totp.php
+++ b/public/users/totp.php
@@ -50,7 +50,7 @@ if (authentication_has_role('admin')) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 

--- a/public/vacation.php
+++ b/public/vacation.php
@@ -118,7 +118,7 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
     if (safepost('token') != $_SESSION['PFA_token']) {
-        die('Invalid token!');
+        pfa_handle_invalid_token();
     }
 
 

--- a/public/vacation.php
+++ b/public/vacation.php
@@ -117,7 +117,7 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
 }
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-    if (safepost('token') != $_SESSION['PFA_token']) {
+    if (safepost('token') != ($_SESSION['PFA_token'] ?? '')) {
         pfa_handle_invalid_token();
     }
 


### PR DESCRIPTION
## Summary

This backports the invalid-token/session-expired UX improvement to the 4.0 branch.

When a session expires and an old CSRF token is submitted, PostfixAdmin currently shows a raw invalid token error. This change renders a translated session-expired page instead, returns HTTP 419, provides a login button, and redirects to login after 5 seconds.

## Validation

- php -l public/common.php
- php -l languages/en.lang
- php -l languages/es.lang
- git diff --check