### PR TITLE
viewlog: add "All domains" option to the log viewer (#1059)

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1953,6 +1953,37 @@ function db_in_clause(string $field, array $values, array &$params = []): string
 }
 
 /**
+ * Build the log-table domain restriction for viewlog.php.
+ *
+ * Global admins may view every domain; any other admin is restricted to the
+ * domains they manage, so the "All domains" option can never leak log entries
+ * belonging to other admins' domains.
+ *
+ * @param bool $show_all - whether the "All domains" option is selected
+ * @param bool $is_global_admin - whether the current admin is a global admin
+ * @param string $fDomain - the single selected domain (ignored when $show_all)
+ * @param array $allowed_domains - domains the current admin may view
+ * @param array &$params - bound query parameters (appended to)
+ * @return string - SQL condition for a WHERE clause, or '' for no restriction
+ */
+function viewlog_domain_condition(bool $show_all, bool $is_global_admin, string $fDomain, array $allowed_domains, array &$params): string
+{
+    if ($show_all) {
+        if ($is_global_admin) {
+            return ''; # no restriction - every domain
+        }
+        return db_in_clause('domain', $allowed_domains, $params);
+    }
+
+    if ($fDomain !== '') {
+        $params['domain'] = $fDomain;
+        return 'domain = :domain';
+    }
+
+    return '';
+}
+
+/**
  * db_where_clause
  * Action: builds and returns a WHERE clause for database queries. All given conditions will be AND'ed.
  * Call: db_where_clause (array $conditions, array $struct)

--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -207,6 +207,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Разглеждане на последните %s действия за ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Дата';
 $PALANG['pViewlog_action'] = 'Действие';
 $PALANG['pViewlog_data'] = 'Данни';

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -205,6 +205,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Veure les últimes %s accions per ';
 $PALANG['pViewlog_welcome_all'] = 'Veure les últimes %s accions ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acció';
 $PALANG['pViewlog_data'] = 'Dades';

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = '查看最新的%s项操作日志 域名: ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = '时间';
 $PALANG['pViewlog_action'] = '操作';
 $PALANG['pViewlog_data'] = '内容';

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Odpovědět jednou za týden';
 
 $PALANG['pViewlog_welcome'] = 'Prohlížet %s posledních akcí pro ';
 $PALANG['pViewlog_welcome_all'] = 'Prohlížet %s posledních akcí ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Časová značka';
 $PALANG['pViewlog_action'] = 'Akce';
 $PALANG['pViewlog_data'] = 'Poznámka';

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -213,6 +213,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vis de sidste %s poster for ';
 $PALANG['pViewlog_welcome_all'] = 'Vis de sidste %s poster ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Tidsstempel';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -210,6 +210,7 @@ $PALANG['reply_once_per_week'] = 'Einmal pro Woche antworten';
 
 $PALANG['pViewlog_welcome'] = 'Zeigt die letzten %s Aktionen für ';
 $PALANG['pViewlog_welcome_all'] = 'Zeigt die letzten %s Aktionen ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Zeitpunkt';
 $PALANG['pViewlog_action'] = 'Aktion';
 $PALANG['pViewlog_data'] = 'Daten';

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -274,6 +274,7 @@ $PALANG['reply_once_per_week'] = 'Reply once a week';
 
 $PALANG['pViewlog_welcome'] = 'View the last %s actions for ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Timestamp';
 $PALANG['pViewlog_action'] = 'Action';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Responder una vez por semana';
 
 $PALANG['pViewlog_welcome'] = 'Ver las últimas %s acciones para ';
 $PALANG['pViewlog_welcome_all'] = 'Ver las últimas %s acciones ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Fecha/Hora';
 $PALANG['pViewlog_action'] = 'Acción';
 $PALANG['pViewlog_data'] = 'Datos';

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vaata %s viimast muudatust domeeniga ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Ajatempel';
 $PALANG['pViewlog_action'] = 'Toiming';
 $PALANG['pViewlog_data'] = 'Andmed';

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -204,6 +204,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Honen azken %s ekintzak ikusi ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Data/ordua';
 $PALANG['pViewlog_action'] = 'Ekintza';
 $PALANG['pViewlog_data'] = 'Datuak';

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Näytä viimeiset kymmenen tapahtumaa domainille ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Aikaleima';
 $PALANG['pViewlog_action'] = 'Tapahtuma';
 $PALANG['pViewlog_data'] = 'Tiedot';

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vís seinastu %s hendingarnar fyri ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Tíðarstempul';
 $PALANG['pViewlog_action'] = 'Hending';
 $PALANG['pViewlog_data'] = 'Dáta';

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -210,6 +210,7 @@ $PALANG['reply_once_per_week'] = 'Répondre une fois par semaine';
 
 $PALANG['pViewlog_welcome'] = 'Visualiser les %s dernières actions pour ';
 $PALANG['pViewlog_welcome_all'] = 'Visualiser les %s dernières actions ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Date/Heure';
 $PALANG['pViewlog_action'] = 'Action';
 $PALANG['pViewlog_data'] = 'Information';

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -205,6 +205,7 @@ $PALANG['reply_once_per_week'] = 'Respostar unha vez á semana'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Ver as últimas %s accións para ';
 $PALANG['pViewlog_welcome_all'] = 'Ver as últimas %s accións ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acción';
 $PALANG['pViewlog_data'] = 'Datos';

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -205,6 +205,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Pogledaj zadnjih %s akcija za ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Vrijeme';
 $PALANG['pViewlog_action'] = 'Akcija';
 $PALANG['pViewlog_data'] = 'Podaci';

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -210,6 +210,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Az utolsó %s esemény megtekintése: ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Idõbélyeg';
 $PALANG['pViewlog_action'] = 'Akció';
 $PALANG['pViewlog_data'] = 'Adat';

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Skoða síðustu %s aðgerðir fyrir ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Tími';
 $PALANG['pViewlog_action'] = 'aðgerð';
 $PALANG['pViewlog_data'] = 'gögn';

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -207,6 +207,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Elenca gli ultimi %s eventi per ';
 $PALANG['pViewlog_welcome_all'] = 'Elenca gli ultimi %s eventi ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Orario';
 $PALANG['pViewlog_action'] = 'Azione';
 $PALANG['pViewlog_data'] = 'Dati';

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -210,6 +210,7 @@ $PALANG['reply_once_per_week'] = '週に一度返信';
 
 $PALANG['pViewlog_welcome'] = '過去 %s 個のアクション ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'タイムスタンプ';
 $PALANG['pViewlog_action'] = 'アクション';
 $PALANG['pViewlog_data'] = 'データ';

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -207,6 +207,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Peržiūrėti paskutinius %s vartotojo veiksmų ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Laikas';
 $PALANG['pViewlog_action'] = 'Veiksmas';
 $PALANG['pViewlog_data'] = 'Duomenys';

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Преглед на последните %s операции за: ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Маркер (Timestamp)';
 $PALANG['pViewlog_action'] = 'Операција';
 $PALANG['pViewlog_data'] = 'Датум';

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -207,6 +207,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vis de %s siste handlingene for ';
 $PALANG['pViewlog_welcome_all'] = 'Vis de %s siste handlingene ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Klokkeslett';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -209,6 +209,7 @@ $PALANG['reply_once_per_week'] = 'Beantwoord een keer per week';
 
 $PALANG['pViewlog_welcome'] = 'Laat de laatste %s actie\'s zien van ';
 $PALANG['pViewlog_welcome_all'] = 'Laat de laatste %s actie\'s zien ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Tijd';
 $PALANG['pViewlog_action'] = 'Actie';
 $PALANG['pViewlog_data'] = 'Aanpassing';

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -205,6 +205,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Vis de %s siste handlingene ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Klokkeslett';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -209,6 +209,7 @@ $PALANG['reply_once_per_week'] = 'Odpowiedz raz na tydzień';
 
 $PALANG['pViewlog_welcome'] = 'Pokaż %s ostatnich działań dla ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Data';
 $PALANG['pViewlog_action'] = 'Działanie';
 $PALANG['pViewlog_data'] = 'Dane';

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -212,6 +212,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Últimas %s ações para ';
 $PALANG['pViewlog_welcome_all'] = 'Últimas %s ações ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Ação';
 $PALANG['pViewlog_data'] = 'Descrição';

--- a/languages/pt-pt.lang
+++ b/languages/pt-pt.lang
@@ -212,6 +212,7 @@ $PALANG['reply_once_per_week'] = 'Responder uma vez por semana'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Últimas %s acções para ';
 $PALANG['pViewlog_welcome_all'] = 'Últimas %s acções ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acção';
 $PALANG['pViewlog_data'] = 'Descrição';

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -210,6 +210,7 @@ $PALANG['reply_once_per_week'] = 'Raspunde odata pe saptamana';
 
 $PALANG['pViewlog_welcome'] = 'Vizualizati ultimele %s operatii pentru ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Data si ora';
 $PALANG['pViewlog_action'] = 'Operatie';
 $PALANG['pViewlog_data'] = 'Detalii';

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -213,6 +213,7 @@ $PALANG['reply_once_per_week'] = 'Отвечать один раз в недел
 
 $PALANG['pViewlog_welcome'] = 'Просмотр %s последних действий для ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Время создания/модификации';
 $PALANG['pViewlog_action'] = 'Действие';
 $PALANG['pViewlog_data'] = 'Данные';

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -207,6 +207,7 @@ $PALANG['reply_once_per_week'] = 'Odpovedať raz za týždeň';
 
 $PALANG['pViewlog_welcome'] = 'Prehľad %s posledných akcií pre ';
 $PALANG['pViewlog_welcome_all'] = 'Prehľad %s posledných akcií ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Časová značka';
 $PALANG['pViewlog_action'] = 'Akcia';
 $PALANG['pViewlog_data'] = 'Podrobnosti';

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 
 $PALANG['pViewlog_welcome'] = 'Seznam zadnjih %s operacij za ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Čas';
 $PALANG['pViewlog_action'] = 'Operacija';
 $PALANG['pViewlog_data'] = 'Podatki';

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -211,6 +211,7 @@ $PALANG['reply_once_per_week'] = 'Svara en gång i veckan';
 
 $PALANG['pViewlog_welcome'] = 'Visa de senaste %s åtgärderna för ';
 $PALANG['pViewlog_welcome_all'] = 'Visa de senaste %s åtgärderna ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Tidpunkt';
 $PALANG['pViewlog_action'] = 'Åtgärd';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -206,6 +206,7 @@ $PALANG['reply_once_per_week'] = 'Haftada bir kez yanıtla';
 
 $PALANG['pViewlog_welcome'] = 'Son %s hareketi:';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Timestamp'; # XXX
 $PALANG['pViewlog_action'] = 'Hareket';
 $PALANG['pViewlog_data'] = 'Veri';

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -208,6 +208,7 @@ $PALANG['reply_once_per_week'] = '每星期回覆一次';
 
 $PALANG['pViewlog_welcome'] = '查看最新的%s項操作日誌 網域: ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = '時間';
 $PALANG['pViewlog_action'] = '操作';
 $PALANG['pViewlog_data'] = '內容';

--- a/languages/ua.lang
+++ b/languages/ua.lang
@@ -212,6 +212,7 @@ $PALANG['reply_once_per_week'] = 'Відповідати один раз на т
 
 $PALANG['pViewlog_welcome'] = 'Перегляд %s останніх дій для ';
 $PALANG['pViewlog_welcome_all'] = 'Перегляд останніх %s дій ';
+$PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_timestamp'] = 'Час створення/модифікації';
 $PALANG['pViewlog_action'] = 'Дія';
 $PALANG['pViewlog_data'] = 'Данні';

--- a/public/viewlog.php
+++ b/public/viewlog.php
@@ -44,24 +44,30 @@ if (authentication_has_role('global-admin')) {
 
 $fDomain = '';
 $error = 0;
+$show_all = false;
+$all_domains_value = '*'; # dropdown sentinel for the "All domains" option
 
 
 if ($_SERVER['REQUEST_METHOD'] == "GET") {
     if (isset($_GET['page']) && $_GET['fDomain']) {
         $fDomain_aux = $_GET['fDomain'];
-        $flag_fDomain = 0;
-        if ((is_array($list_domains) and sizeof($list_domains) > 0)) {
-            foreach ($list_domains as $domain) {
-                if ($domain == $fDomain_aux) {
-                    $fDomain = $domain;
-                    $flag_fDomain = 1;
-                    break;
+        if ($fDomain_aux === $all_domains_value) {
+            $show_all = true;
+        } else {
+            $flag_fDomain = 0;
+            if ((is_array($list_domains) and sizeof($list_domains) > 0)) {
+                foreach ($list_domains as $domain) {
+                    if ($domain == $fDomain_aux) {
+                        $fDomain = $domain;
+                        $flag_fDomain = 1;
+                        break;
+                    }
                 }
             }
-        }
 
-        if ($flag_fDomain == 0) {
-            throw new InvalidArgumentException('Unknown domain');
+            if ($flag_fDomain == 0) {
+                throw new InvalidArgumentException('Unknown domain');
+            }
         }
 
         $page_number = (int)($_GET['page'] ?? 0);
@@ -76,14 +82,18 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
     }
 } elseif ($_SERVER['REQUEST_METHOD'] == "POST") {
     $page_number = 1;
-    if (isset($_POST['fDomain']) && in_array($_POST['fDomain'], $list_domains)) {
+    if (isset($_POST['fDomain']) && $_POST['fDomain'] === $all_domains_value) {
+        $show_all = true;
+    } elseif (isset($_POST['fDomain']) && in_array($_POST['fDomain'], $list_domains)) {
         $fDomain = $_POST['fDomain'];
     }
 } else {
     throw new InvalidArgumentException('Unsupported request method');
 }
 
-if (!(check_owner($username, $fDomain) || authentication_has_role('global-admin'))) {
+# When "All domains" is selected, the query is scoped to the admin's domains
+# (see viewlog_domain_condition()), so the per-domain ownership check is skipped.
+if (!$show_all && !(check_owner($username, $fDomain) || authentication_has_role('global-admin'))) {
     $error = 1;
     flash_error($PALANG['pViewlog_result_error']);
 }
@@ -95,17 +105,9 @@ if ($error != 1) {
     $page_size = isset($CONF['page_size']) ? intval($CONF['page_size']) : 35;
 
 
-    $where = [];
     $params = [];
-    if ($fDomain) {
-        $where[] = 'domain = :domain';
-        $params['domain'] = $fDomain;
-    }
-
-    $where_sql = '';
-    if (!empty($where)) {
-        $where_sql = 'WHERE ' . implode(' AND ', $where);
-    }
+    $condition = viewlog_domain_condition($show_all, authentication_has_role('global-admin'), $fDomain, $list_domains, $params);
+    $where_sql = ($condition !== '') ? "WHERE $condition" : '';
 
 
     $number_of_logs = 0;
@@ -159,6 +161,9 @@ $smarty->assign('domain_list', $list_domains);
 $smarty->assign('domain_selected', $fDomain);
 $smarty->assign('tLog', $tLog, false);
 $smarty->assign('fDomain', $fDomain);
+$smarty->assign('show_all', $show_all);
+$smarty->assign('all_domains_value', $all_domains_value);
+$smarty->assign('domain_param', $show_all ? $all_domains_value : $fDomain);
 
 $smarty->assign('number_of_pages', $number_of_pages);
 $smarty->assign('page_number', $page_number);

--- a/public/viewlog.php
+++ b/public/viewlog.php
@@ -122,7 +122,9 @@ if ($error != 1) {
     }
     $number_of_pages = ceil($number_of_logs / $page_size);
 
-    if ($page_number > $number_of_pages) {
+    # An empty result set (no matching log entries) has 0 pages; page 1 should
+    # then render an empty table rather than throwing.
+    if ($number_of_pages > 0 && $page_number > $number_of_pages) {
         throw new InvalidArgumentException('Unknown page number');
     }
 

--- a/templates/viewlog.tpl
+++ b/templates/viewlog.tpl
@@ -1,7 +1,12 @@
 <div class="card">
     <div class="card-header">
         <form name="frmOverview" method="post" action="">
-	    {html_options name='fDomain' output=$domain_list values=$domain_list selected=$domain_selected onchange="this.form.submit();"}
+	    <select name="fDomain" class="form-control" onchange="this.form.submit();">
+		<option value="{$all_domains_value}"{if $show_all} selected{/if}>{$PALANG.pViewlog_all_domains}</option>
+		{foreach from=$domain_list item=d}
+		    <option value="{$d|escape}"{if !$show_all && $d==$domain_selected} selected{/if}>{$d|escape}</option>
+		{/foreach}
+	    </select>
             <noscript><input class="button" type="submit" name="go" value="{$PALANG.go}"/></noscript>
         </form>
     </div>
@@ -109,6 +114,6 @@
 
 <script>
         function go2page(page){
-                window.location.href = '{$url}?page='+page+'&fDomain={$fDomain}';
+                window.location.href = '{$url}?page='+page+'&fDomain={$domain_param|escape:"url"}';
         }
 </script>

--- a/tests/ViewlogDomainConditionTest.php
+++ b/tests/ViewlogDomainConditionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Unit tests for viewlog_domain_condition() - the domain restriction used by
+ * viewlog.php's "All domains" option.
+ * @see https://github.com/postfixadmin/postfixadmin/issues/1059
+ */
+class ViewlogDomainConditionTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSingleDomainProducesEqualityCondition()
+    {
+        $params = [];
+        $cond = viewlog_domain_condition(false, false, 'example.com', ['example.com'], $params);
+        $this->assertSame('domain = :domain', $cond);
+        $this->assertSame(['domain' => 'example.com'], $params);
+    }
+
+    public function testNoDomainAndNotAllProducesNoCondition()
+    {
+        $params = [];
+        $cond = viewlog_domain_condition(false, false, '', ['example.com'], $params);
+        $this->assertSame('', $cond);
+        $this->assertSame([], $params);
+    }
+
+    public function testGlobalAdminAllHasNoRestriction()
+    {
+        $params = [];
+        $cond = viewlog_domain_condition(true, true, '', ['a.com', 'b.com'], $params);
+        // A global admin sees every domain, so there is no WHERE restriction.
+        $this->assertSame('', $cond);
+        $this->assertSame([], $params);
+    }
+
+    /**
+     * The security-critical case: a non-global admin selecting "All" must be
+     * restricted to exactly the domains they manage.
+     */
+    public function testDomainAdminAllIsScopedToOwnedDomains()
+    {
+        $params = [];
+        $allowed = ['one.example.com', 'two.example.com'];
+        $cond = viewlog_domain_condition(true, false, '', $allowed, $params);
+
+        // Must be an IN clause on the domain column, not an unrestricted query.
+        $this->assertNotSame('', $cond);
+        $this->assertMatchesRegularExpression('/domain\s+IN\s*\(/i', $cond);
+
+        // Exactly the allowed domains are bound - nothing more, nothing less.
+        $this->assertEqualsCanonicalizing($allowed, array_values($params));
+
+        // Every placeholder in the clause has a matching bound parameter.
+        preg_match_all('/:([a-zA-Z0-9_]+)/', $cond, $m);
+        foreach ($m[1] as $placeholder) {
+            $this->assertArrayHasKey($placeholder, $params);
+        }
+    }
+
+    /**
+     * Defence in depth: a non-global admin with no domains must NOT fall back
+     * to an unrestricted "all domains" query.
+     */
+    public function testDomainAdminAllWithNoDomainsMatchesNothing()
+    {
+        $params = [];
+        $cond = viewlog_domain_condition(true, false, '', [], $params);
+        // db_in_clause() returns a false predicate for an empty set.
+        $this->assertStringContainsString('1=0', $cond);
+        $this->assertSame([], $params);
+    }
+}


### PR DESCRIPTION
## What

Adds an **"All domains"** option to the View Log domain dropdown, so an admin managing many domains can see log entries across all of them in one view instead of picking each domain individually.

Closes #1059.

## How

- New helper `viewlog_domain_condition()` in `functions.inc.php` builds the log query's domain restriction:
  - **global admin + All** → no restriction (every domain);
  - **any other admin + All** → `WHERE domain IN (...)` scoped to `list_domains_for_admin()`;
  - single domain → `domain = :domain` (unchanged).
- `viewlog.php` uses a `*` sentinel for "All" that is threaded through the POST `<select>` and the GET pagination links (an empty value would collide with the existing "no domain → default to first domain" logic). The per-domain `check_owner()` check is skipped only when All is selected, because the query is then scoped by the helper instead.
- Template: the dropdown gains an "All domains" `<option>`; the existing `pViewlog_welcome_all` heading (already present but previously unreachable) is now shown for the All view.
- `pViewlog_all_domains` added to all language files (English text; translators can localise later — PostfixAdmin loads only the selected language file, no English fallback).

## Security

The whole point of extracting `viewlog_domain_condition()` is that a **domain admin's "All" view must not leak other admins' logs**. This is enforced by the `IN (...)` scoping and covered by tests:

- `testDomainAdminAllIsScopedToOwnedDomains` — asserts the clause is an `IN` on `domain` bound to exactly the admin's domains.
- `testDomainAdminAllWithNoDomainsMatchesNothing` — an admin with no domains gets a false predicate (`1=0`), never an unrestricted query.
- plus global-admin-all (no restriction) and single-domain cases.

## Testing

- New `tests/ViewlogDomainConditionTest.php` (5 tests). Full suite green: **103 tests, 1042 assertions** on the SQLite test DB.
- `php-cs-fixer` (dry-run) and lang-file lint clean.
- Manual QA of the dropdown + pagination in the All view recommended on a populated DB.
