### PR TITLE
viewlog: per-page selector + Bootstrap 5 pager, fix footer layout (#1062)

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1984,6 +1984,48 @@ function viewlog_domain_condition(bool $show_all, bool $is_global_admin, string 
 }
 
 /**
+ * Compute the page numbers to display in a windowed pager.
+ *
+ * Always includes page 1 and the last page, plus a window of $radius pages on
+ * either side of the current page. Gaps between those ranges are represented by
+ * a null entry (rendered as an ellipsis). For example current=20, total=50,
+ * radius=5 yields: [1, null, 15..25, null, 50].
+ *
+ * @param int $current - the current page number (1-based)
+ * @param int $total_pages - total number of pages
+ * @param int $radius - how many pages to show either side of $current
+ * @return array<int|null> - ordered page numbers, null marks an ellipsis gap
+ */
+function pagination_window(int $current, int $total_pages, int $radius = 5): array
+{
+    if ($total_pages <= 1) {
+        return $total_pages == 1 ? [1] : [];
+    }
+
+    $current = max(1, min($current, $total_pages));
+
+    $pages = [];
+    for ($i = 1; $i <= $total_pages; $i++) {
+        if ($i == 1 || $i == $total_pages || ($i >= $current - $radius && $i <= $current + $radius)) {
+            $pages[] = $i;
+        }
+    }
+
+    # insert null markers where there is a gap between consecutive page numbers
+    $result = [];
+    $previous = 0;
+    foreach ($pages as $page) {
+        if ($previous && $page > $previous + 1) {
+            $result[] = null;
+        }
+        $result[] = $page;
+        $previous = $page;
+    }
+
+    return $result;
+}
+
+/**
  * db_where_clause
  * Action: builds and returns a WHERE clause for database queries. All given conditions will be AND'ed.
  * Call: db_where_clause (array $conditions, array $struct)

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -2003,23 +2003,29 @@ function pagination_window(int $current, int $total_pages, int $radius = 5): arr
     }
 
     $current = max(1, min($current, $total_pages));
+    $start = max(1, $current - $radius);
+    $end = min($total_pages, $current + $radius);
 
-    $pages = [];
-    for ($i = 1; $i <= $total_pages; $i++) {
-        if ($i == 1 || $i == $total_pages || ($i >= $current - $radius && $i <= $current + $radius)) {
-            $pages[] = $i;
+    # Only the window itself is built (O(radius)), with page 1 / the last page
+    # and ellipsis markers (null) prepended/appended as needed.
+    $result = [];
+
+    if ($start > 1) {
+        $result[] = 1;
+        if ($start > 2) {
+            $result[] = null; # gap between page 1 and the window
         }
     }
 
-    # insert null markers where there is a gap between consecutive page numbers
-    $result = [];
-    $previous = 0;
-    foreach ($pages as $page) {
-        if ($previous && $page > $previous + 1) {
-            $result[] = null;
+    for ($i = $start; $i <= $end; $i++) {
+        $result[] = $i;
+    }
+
+    if ($end < $total_pages) {
+        if ($end < $total_pages - 1) {
+            $result[] = null; # gap between the window and the last page
         }
-        $result[] = $page;
-        $previous = $page;
+        $result[] = $total_pages;
     }
 
     return $result;

--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -217,6 +217,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Разглеждане на последните %s действия за ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Дата';
 $PALANG['pViewlog_action'] = 'Действие';
 $PALANG['pViewlog_data'] = 'Данни';

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -215,6 +215,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Veure les últimes %s accions per ';
 $PALANG['pViewlog_welcome_all'] = 'Veure les últimes %s accions ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acció';
 $PALANG['pViewlog_data'] = 'Dades';

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = '查看最新的%s项操作日志 域名: ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = '时间';
 $PALANG['pViewlog_action'] = '操作';
 $PALANG['pViewlog_data'] = '内容';

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -226,6 +226,7 @@ $PALANG['reply_once_per_week'] = 'Odpovědět jednou za týden';
 $PALANG['pViewlog_welcome'] = 'Prohlížet %s posledních akcí pro ';
 $PALANG['pViewlog_welcome_all'] = 'Prohlížet %s posledních akcí ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Časová značka';
 $PALANG['pViewlog_action'] = 'Akce';
 $PALANG['pViewlog_data'] = 'Poznámka';

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -223,6 +223,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Vis de sidste %s poster for ';
 $PALANG['pViewlog_welcome_all'] = 'Vis de sidste %s poster ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tidsstempel';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -220,6 +220,7 @@ $PALANG['reply_once_per_week'] = 'Einmal pro Woche antworten';
 $PALANG['pViewlog_welcome'] = 'Zeigt die letzten %s Aktionen für ';
 $PALANG['pViewlog_welcome_all'] = 'Zeigt die letzten %s Aktionen ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Zeitpunkt';
 $PALANG['pViewlog_action'] = 'Aktion';
 $PALANG['pViewlog_data'] = 'Daten';

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -275,6 +275,7 @@ $PALANG['reply_once_per_week'] = 'Reply once a week';
 $PALANG['pViewlog_welcome'] = 'View the last %s actions for ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Timestamp';
 $PALANG['pViewlog_action'] = 'Action';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -217,6 +217,7 @@ $PALANG['reply_once_per_week'] = 'Responder una vez por semana';
 $PALANG['pViewlog_welcome'] = 'Ver las últimas %s acciones para ';
 $PALANG['pViewlog_welcome_all'] = 'Ver las últimas %s acciones ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Fecha/Hora';
 $PALANG['pViewlog_action'] = 'Acción';
 $PALANG['pViewlog_data'] = 'Datos';

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Vaata %s viimast muudatust domeeniga ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Ajatempel';
 $PALANG['pViewlog_action'] = 'Toiming';
 $PALANG['pViewlog_data'] = 'Andmed';

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -214,6 +214,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Honen azken %s ekintzak ikusi ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/ordua';
 $PALANG['pViewlog_action'] = 'Ekintza';
 $PALANG['pViewlog_data'] = 'Datuak';

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Näytä viimeiset kymmenen tapahtumaa domainille ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Aikaleima';
 $PALANG['pViewlog_action'] = 'Tapahtuma';
 $PALANG['pViewlog_data'] = 'Tiedot';

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Vís seinastu %s hendingarnar fyri ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tíðarstempul';
 $PALANG['pViewlog_action'] = 'Hending';
 $PALANG['pViewlog_data'] = 'Dáta';

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -220,6 +220,7 @@ $PALANG['reply_once_per_week'] = 'Répondre une fois par semaine';
 $PALANG['pViewlog_welcome'] = 'Visualiser les %s dernières actions pour ';
 $PALANG['pViewlog_welcome_all'] = 'Visualiser les %s dernières actions ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Date/Heure';
 $PALANG['pViewlog_action'] = 'Action';
 $PALANG['pViewlog_data'] = 'Information';

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -215,6 +215,7 @@ $PALANG['reply_once_per_week'] = 'Respostar unha vez á semana'; # XXX
 $PALANG['pViewlog_welcome'] = 'Ver as últimas %s accións para ';
 $PALANG['pViewlog_welcome_all'] = 'Ver as últimas %s accións ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acción';
 $PALANG['pViewlog_data'] = 'Datos';

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -215,6 +215,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Pogledaj zadnjih %s akcija za ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Vrijeme';
 $PALANG['pViewlog_action'] = 'Akcija';
 $PALANG['pViewlog_data'] = 'Podaci';

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -220,6 +220,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Az utolsó %s esemény megtekintése: ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Idõbélyeg';
 $PALANG['pViewlog_action'] = 'Akció';
 $PALANG['pViewlog_data'] = 'Adat';

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Skoða síðustu %s aðgerðir fyrir ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tími';
 $PALANG['pViewlog_action'] = 'aðgerð';
 $PALANG['pViewlog_data'] = 'gögn';

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -217,6 +217,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Elenca gli ultimi %s eventi per ';
 $PALANG['pViewlog_welcome_all'] = 'Elenca gli ultimi %s eventi ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Orario';
 $PALANG['pViewlog_action'] = 'Azione';
 $PALANG['pViewlog_data'] = 'Dati';

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -220,6 +220,7 @@ $PALANG['reply_once_per_week'] = '週に一度返信';
 $PALANG['pViewlog_welcome'] = '過去 %s 個のアクション ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'タイムスタンプ';
 $PALANG['pViewlog_action'] = 'アクション';
 $PALANG['pViewlog_data'] = 'データ';

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -217,6 +217,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Peržiūrėti paskutinius %s vartotojo veiksmų ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Laikas';
 $PALANG['pViewlog_action'] = 'Veiksmas';
 $PALANG['pViewlog_data'] = 'Duomenys';

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Преглед на последните %s операции за: ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Маркер (Timestamp)';
 $PALANG['pViewlog_action'] = 'Операција';
 $PALANG['pViewlog_data'] = 'Датум';

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -217,6 +217,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Vis de %s siste handlingene for ';
 $PALANG['pViewlog_welcome_all'] = 'Vis de %s siste handlingene ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Klokkeslett';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -219,6 +219,7 @@ $PALANG['reply_once_per_week'] = 'Beantwoord een keer per week';
 $PALANG['pViewlog_welcome'] = 'Laat de laatste %s actie\'s zien van ';
 $PALANG['pViewlog_welcome_all'] = 'Laat de laatste %s actie\'s zien ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tijd';
 $PALANG['pViewlog_action'] = 'Actie';
 $PALANG['pViewlog_data'] = 'Aanpassing';

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -215,6 +215,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Vis de %s siste handlingene ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Klokkeslett';
 $PALANG['pViewlog_action'] = 'Handling';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -219,6 +219,7 @@ $PALANG['reply_once_per_week'] = 'Odpowiedz raz na tydzień';
 $PALANG['pViewlog_welcome'] = 'Pokaż %s ostatnich działań dla ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data';
 $PALANG['pViewlog_action'] = 'Działanie';
 $PALANG['pViewlog_data'] = 'Dane';

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -222,6 +222,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Últimas %s ações para ';
 $PALANG['pViewlog_welcome_all'] = 'Últimas %s ações ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Ação';
 $PALANG['pViewlog_data'] = 'Descrição';

--- a/languages/pt-pt.lang
+++ b/languages/pt-pt.lang
@@ -222,6 +222,7 @@ $PALANG['reply_once_per_week'] = 'Responder uma vez por semana'; # XXX
 $PALANG['pViewlog_welcome'] = 'Últimas %s acções para ';
 $PALANG['pViewlog_welcome_all'] = 'Últimas %s acções ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acção';
 $PALANG['pViewlog_data'] = 'Descrição';

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -220,6 +220,7 @@ $PALANG['reply_once_per_week'] = 'Raspunde odata pe saptamana';
 $PALANG['pViewlog_welcome'] = 'Vizualizati ultimele %s operatii pentru ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data si ora';
 $PALANG['pViewlog_action'] = 'Operatie';
 $PALANG['pViewlog_data'] = 'Detalii';

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -223,6 +223,7 @@ $PALANG['reply_once_per_week'] = 'Отвечать один раз в недел
 $PALANG['pViewlog_welcome'] = 'Просмотр %s последних действий для ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Время создания/модификации';
 $PALANG['pViewlog_action'] = 'Действие';
 $PALANG['pViewlog_data'] = 'Данные';

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -217,6 +217,7 @@ $PALANG['reply_once_per_week'] = 'Odpovedať raz za týždeň';
 $PALANG['pViewlog_welcome'] = 'Prehľad %s posledných akcií pre ';
 $PALANG['pViewlog_welcome_all'] = 'Prehľad %s posledných akcií ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Časová značka';
 $PALANG['pViewlog_action'] = 'Akcia';
 $PALANG['pViewlog_data'] = 'Podrobnosti';

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Reply once per week'; # XXX
 $PALANG['pViewlog_welcome'] = 'Seznam zadnjih %s operacij za ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Čas';
 $PALANG['pViewlog_action'] = 'Operacija';
 $PALANG['pViewlog_data'] = 'Podatki';

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -221,6 +221,7 @@ $PALANG['reply_once_per_week'] = 'Svara en gång i veckan';
 $PALANG['pViewlog_welcome'] = 'Visa de senaste %s åtgärderna för ';
 $PALANG['pViewlog_welcome_all'] = 'Visa de senaste %s åtgärderna ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tidpunkt';
 $PALANG['pViewlog_action'] = 'Åtgärd';
 $PALANG['pViewlog_data'] = 'Data';

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -216,6 +216,7 @@ $PALANG['reply_once_per_week'] = 'Haftada bir kez yanıtla';
 $PALANG['pViewlog_welcome'] = 'Son %s hareketi:';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Timestamp'; # XXX
 $PALANG['pViewlog_action'] = 'Hareket';
 $PALANG['pViewlog_data'] = 'Veri';

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -218,6 +218,7 @@ $PALANG['reply_once_per_week'] = '每星期回覆一次';
 $PALANG['pViewlog_welcome'] = '查看最新的%s項操作日誌 網域: ';
 $PALANG['pViewlog_welcome_all'] = 'View the last %s actions '; # XXX
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = '時間';
 $PALANG['pViewlog_action'] = '操作';
 $PALANG['pViewlog_data'] = '內容';

--- a/languages/ua.lang
+++ b/languages/ua.lang
@@ -222,6 +222,7 @@ $PALANG['reply_once_per_week'] = 'Відповідати один раз на т
 $PALANG['pViewlog_welcome'] = 'Перегляд %s останніх дій для ';
 $PALANG['pViewlog_welcome_all'] = 'Перегляд останніх %s дій ';
 $PALANG['pViewlog_all_domains'] = 'All domains';
+$PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Час створення/модифікації';
 $PALANG['pViewlog_action'] = 'Дія';
 $PALANG['pViewlog_data'] = 'Данні';

--- a/public/viewlog.php
+++ b/public/viewlog.php
@@ -49,7 +49,7 @@ $all_domains_value = '*'; # dropdown sentinel for the "All domains" option
 
 
 if ($_SERVER['REQUEST_METHOD'] == "GET") {
-    if (isset($_GET['page']) && $_GET['fDomain']) {
+    if (isset($_GET['page']) && isset($_GET['fDomain']) && $_GET['fDomain']) {
         $fDomain_aux = $_GET['fDomain'];
         if ($fDomain_aux === $all_domains_value) {
             $show_all = true;
@@ -131,7 +131,6 @@ if ($error != 1) {
 
 
     $number_of_logs = 0;
-    $number_of_pages = 0;
     //get number of total logs
     $query = "SELECT count(*) as number_of_logs FROM $table_log $where_sql";
 
@@ -143,7 +142,7 @@ if ($error != 1) {
     $number_of_pages = ceil($number_of_logs / $page_size);
 
     # An empty result set (no matching log entries) has 0 pages; page 1 should
-    # then render an empty table rather than throwing.
+    # then be accepted (the template simply shows no log rows) rather than throwing.
     if ($number_of_pages > 0 && $page_number > $number_of_pages) {
         throw new InvalidArgumentException('Unknown page number');
     }

--- a/public/viewlog.php
+++ b/public/viewlog.php
@@ -98,12 +98,32 @@ if (!$show_all && !(check_owner($username, $fDomain) || authentication_has_role(
     flash_error($PALANG['pViewlog_result_error']);
 }
 
+# Number of log entries per page - user-selectable but whitelisted so a crafted
+# value can't request an unbounded LIMIT. The configured $CONF['page_size'] is
+# always offered so existing setups keep their default.
+$page_size_options = array(10, 25, 50, 100, 1000);
+$default_page_size = (int)($CONF['page_size'] ?? 10);
+if (!in_array($default_page_size, $page_size_options, true)) {
+    $page_size_options[] = $default_page_size;
+}
+sort($page_size_options);
+
+if (isset($_POST['page_size'])) {
+    $requested_page_size = (int)$_POST['page_size'];
+} elseif (isset($_GET['page_size'])) {
+    $requested_page_size = (int)$_GET['page_size'];
+} else {
+    $requested_page_size = (int)($_SESSION['viewlog:page_size'] ?? $default_page_size);
+}
+$page_size = in_array($requested_page_size, $page_size_options, true) ? $requested_page_size : $default_page_size;
+$_SESSION['viewlog:page_size'] = $page_size;
+
 $tLog = array();
+$number_of_pages = 0;
+$page_window = array();
 
 if ($error != 1) {
     $table_log = table_by_key('log');
-    $page_size = isset($CONF['page_size']) ? intval($CONF['page_size']) : 35;
-
 
     $params = [];
     $condition = viewlog_domain_condition($show_all, authentication_has_role('global-admin'), $fDomain, $list_domains, $params);
@@ -127,6 +147,8 @@ if ($error != 1) {
     if ($number_of_pages > 0 && $page_number > $number_of_pages) {
         throw new InvalidArgumentException('Unknown page number');
     }
+
+    $page_window = pagination_window($page_number, (int)$number_of_pages, 5);
 
     if ($page_number == 1) {
         $offset = 0;
@@ -166,6 +188,9 @@ $smarty->assign('fDomain', $fDomain);
 $smarty->assign('show_all', $show_all);
 $smarty->assign('all_domains_value', $all_domains_value);
 $smarty->assign('domain_param', $show_all ? $all_domains_value : $fDomain);
+$smarty->assign('page_size', $page_size);
+$smarty->assign('page_size_options', $page_size_options);
+$smarty->assign('page_window', $page_window);
 
 $smarty->assign('number_of_pages', $number_of_pages);
 $smarty->assign('page_number', $page_number);

--- a/templates/viewlog.tpl
+++ b/templates/viewlog.tpl
@@ -7,8 +7,8 @@
                     <option value="{$d|escape}"{if !$show_all && $d==$domain_selected} selected{/if}>{$d|escape}</option>
                 {/foreach}
             </select>
-            <label class="col-form-label">{$PALANG.pViewlog_per_page}</label>
-            <select name="page_size" class="form-select w-auto" onchange="this.form.submit();">
+            <label for="page_size_select" class="col-form-label">{$PALANG.pViewlog_per_page}</label>
+            <select id="page_size_select" name="page_size" class="form-select w-auto" onchange="this.form.submit();">
                 {foreach from=$page_size_options item=ps}
                     <option value="{$ps}"{if $ps==$page_size} selected{/if}>{$ps}</option>
                 {/foreach}
@@ -51,12 +51,13 @@
             <div class="card-footer">
                 <nav aria-label="{$PALANG.pViewlog_action}">
                     <ul class="pagination justify-content-end mb-0">
-                        <li class="page-item{if $page_number <= 1} disabled{/if}">
-                            <a class="page-link" href="#" onclick="go2page(1); return false;" aria-label="First">&laquo;</a>
-                        </li>
-                        <li class="page-item{if $page_number <= 1} disabled{/if}">
-                            <a class="page-link" href="#" onclick="go2page({$page_number-1}); return false;" aria-label="Previous">&lsaquo;</a>
-                        </li>
+                        {if $page_number <= 1}
+                            <li class="page-item disabled"><span class="page-link" aria-hidden="true">&laquo;</span></li>
+                            <li class="page-item disabled"><span class="page-link" aria-hidden="true">&lsaquo;</span></li>
+                        {else}
+                            <li class="page-item"><a class="page-link" href="#" onclick="go2page(1); return false;" aria-label="First">&laquo;</a></li>
+                            <li class="page-item"><a class="page-link" href="#" onclick="go2page({$page_number-1}); return false;" aria-label="Previous">&lsaquo;</a></li>
+                        {/if}
                         {foreach from=$page_window item=p}
                             {if $p}
                                 <li class="page-item{if $p == $page_number} active{/if}">
@@ -66,12 +67,13 @@
                                 <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
                             {/if}
                         {/foreach}
-                        <li class="page-item{if $page_number >= $number_of_pages} disabled{/if}">
-                            <a class="page-link" href="#" onclick="go2page({$page_number+1}); return false;" aria-label="Next">&rsaquo;</a>
-                        </li>
-                        <li class="page-item{if $page_number >= $number_of_pages} disabled{/if}">
-                            <a class="page-link" href="#" onclick="go2page({$number_of_pages}); return false;" aria-label="Last">&raquo;</a>
-                        </li>
+                        {if $page_number >= $number_of_pages}
+                            <li class="page-item disabled"><span class="page-link" aria-hidden="true">&rsaquo;</span></li>
+                            <li class="page-item disabled"><span class="page-link" aria-hidden="true">&raquo;</span></li>
+                        {else}
+                            <li class="page-item"><a class="page-link" href="#" onclick="go2page({$page_number+1}); return false;" aria-label="Next">&rsaquo;</a></li>
+                            <li class="page-item"><a class="page-link" href="#" onclick="go2page({$number_of_pages}); return false;" aria-label="Last">&raquo;</a></li>
+                        {/if}
                     </ul>
                 </nav>
             </div>
@@ -81,6 +83,7 @@
 
 <script>
         function go2page(page){
+                page = Math.max(1, Math.min(page, {$number_of_pages}));
                 window.location.href = '{$url}?page='+page+'&fDomain={$domain_param|escape:"url"}&page_size={$page_size}';
         }
 </script>

--- a/templates/viewlog.tpl
+++ b/templates/viewlog.tpl
@@ -1,21 +1,27 @@
 <div class="card">
     <div class="card-header">
-        <form name="frmOverview" method="post" action="">
-	    <select name="fDomain" class="form-control" onchange="this.form.submit();">
-		<option value="{$all_domains_value}"{if $show_all} selected{/if}>{$PALANG.pViewlog_all_domains}</option>
-		{foreach from=$domain_list item=d}
-		    <option value="{$d|escape}"{if !$show_all && $d==$domain_selected} selected{/if}>{$d|escape}</option>
-		{/foreach}
-	    </select>
+        <form name="frmOverview" method="post" action="" class="d-flex flex-wrap gap-2 align-items-center">
+            <select name="fDomain" class="form-select w-auto" onchange="this.form.submit();">
+                <option value="{$all_domains_value}"{if $show_all} selected{/if}>{$PALANG.pViewlog_all_domains}</option>
+                {foreach from=$domain_list item=d}
+                    <option value="{$d|escape}"{if !$show_all && $d==$domain_selected} selected{/if}>{$d|escape}</option>
+                {/foreach}
+            </select>
+            <label class="col-form-label">{$PALANG.pViewlog_per_page}</label>
+            <select name="page_size" class="form-select w-auto" onchange="this.form.submit();">
+                {foreach from=$page_size_options item=ps}
+                    <option value="{$ps}"{if $ps==$page_size} selected{/if}>{$ps}</option>
+                {/foreach}
+            </select>
             <noscript><input class="button" type="submit" name="go" value="{$PALANG.go}"/></noscript>
         </form>
     </div>
     {if $tLog}
         <div class="card-body">
-	    {if $domain_selected}
-                <h4>{$PALANG.pViewlog_welcome|replace:"%s":$CONF.page_size} {$fDomain} </h4>
+            {if $domain_selected}
+                <h4>{$PALANG.pViewlog_welcome|replace:"%s":$page_size} {$fDomain} </h4>
             {else}
-                <h4>{$PALANG.pViewlog_welcome_all|replace:"%s":$CONF.page_size}</h4>
+                <h4>{$PALANG.pViewlog_welcome_all|replace:"%s":$page_size}</h4>
             {/if}
         </div>
         <table id="log_table" class="table">
@@ -40,80 +46,41 @@
                 </tr>
             {/foreach}
         </table>
-   	
-		<div class="row">
-	  		<div class="container">
-				
-	    		<div class="col-md-4">
-	    		</div>
 
-	    		<div class="col-md-4 offset-md-4">
-					<div class="float-end" style="margin: 10px;">
-
-			   			{if $number_of_pages < 6}
-							<div class="btn-group mr-2" role="group">
-								{for $i=1 to $number_of_pages}
-									<button type="button" onclick=go2page({$i}) class="btn btn-secondary">{$i}</button>
-								{/for}
-							</div>
-			   			{elseif $page_number > 3 && $page_number < ($number_of_pages -2 )}
-							<div class="btn-group mr-2" role="group">
-								<button type="button" onclick=go2page(1) class="btn btn-secondary">1</button>
-							</div>
-							<div class="btn-group mr-2" role="group">
-								<button type="button" onclick=go2page({$page_number-1}) class="btn btn-secondary">{$page_number-1}</button>
-								<button type="button" onclick=go2page({$page_number}) class="btn btn-secondary">{$page_number}</button>
-								<button type="button" onclick=go2page({$page_number+1}) class="btn btn-secondary">{$page_number+1}</button>
-							</div>
-							<div class="btn-group mr-2" role="group">
-								<button type="button" onclick=go2page({$number_of_pages}) class="btn btn-secondary">{$number_of_pages}</button>
-							</div>
-
-							
-			   			{else}
-							{if $page_number < 4}
-								<div class="btn-group mr-2" role="group">
-									<button type="button" onclick=go2page(1) class="btn btn-secondary">1</button>
-									<button type="button" onclick=go2page(2) class="btn btn-secondary">2</button>
-									<button type="button" onclick=go2page(3) class="btn btn-secondary">3</button>
-									<button type="button" onclick=go2page(4) class="btn btn-secondary">4</button>
-								</div>
-								<div class="btn-group mr-2" role="group">
-									<button type="button" onclick=go2page({$number_of_pages}) class="btn btn-secondary">{$number_of_pages}</button>
-								</div>
-								
-							{else}
-								<div class="btn-group mr-2" role="group">
-									<button type="button" onclick=go2page(1) class="btn btn-secondary">1</button>
-								</div>
-								<div class="btn-group mr-2" role="group">
-									<button type="button" onclick=go2page({$number_of_pages-3}) class="btn btn-secondary">{$number_of_pages-3}</button>
-									<button type="button" onclick=go2page({$number_of_pages-2}) class="btn btn-secondary">{$number_of_pages-2}</button>
-									<button type="button" onclick=go2page({$number_of_pages-1}) class="btn btn-secondary">{$number_of_pages-1}</button>
-									<button type="button" onclick=go2page({$number_of_pages}) class="btn btn-secondary">{$number_of_pages}</button>
-								</div>
-			  		 		{/if}
-						{/if}
-
-						<div class="btn-group" role="group"><div class="dropdown">
-							<button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown">Page <span class="caret"></span></button>
-								<ul class="dropdown-menu" style="max-height: 200px; overflow: auto">
-									{for $i=1 to $number_of_pages}
-										<li><a onclick=go2page({$i}) href="#">{$i}</a></li>
-									{/for}
-								</ul>
-						</div>
-
-			    	</div>
-		  		</div>
-			</div>
-		</div>	
-	
+        {if $number_of_pages > 1}
+            <div class="card-footer">
+                <nav aria-label="{$PALANG.pViewlog_action}">
+                    <ul class="pagination justify-content-end mb-0">
+                        <li class="page-item{if $page_number <= 1} disabled{/if}">
+                            <a class="page-link" href="#" onclick="go2page(1); return false;" aria-label="First">&laquo;</a>
+                        </li>
+                        <li class="page-item{if $page_number <= 1} disabled{/if}">
+                            <a class="page-link" href="#" onclick="go2page({$page_number-1}); return false;" aria-label="Previous">&lsaquo;</a>
+                        </li>
+                        {foreach from=$page_window item=p}
+                            {if $p}
+                                <li class="page-item{if $p == $page_number} active{/if}">
+                                    <a class="page-link" href="#" onclick="go2page({$p}); return false;">{$p}</a>
+                                </li>
+                            {else}
+                                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                            {/if}
+                        {/foreach}
+                        <li class="page-item{if $page_number >= $number_of_pages} disabled{/if}">
+                            <a class="page-link" href="#" onclick="go2page({$page_number+1}); return false;" aria-label="Next">&rsaquo;</a>
+                        </li>
+                        <li class="page-item{if $page_number >= $number_of_pages} disabled{/if}">
+                            <a class="page-link" href="#" onclick="go2page({$number_of_pages}); return false;" aria-label="Last">&raquo;</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
+        {/if}
     {/if}
 </div>
 
 <script>
         function go2page(page){
-                window.location.href = '{$url}?page='+page+'&fDomain={$domain_param|escape:"url"}';
+                window.location.href = '{$url}?page='+page+'&fDomain={$domain_param|escape:"url"}&page_size={$page_size}';
         }
 </script>

--- a/tests/PaginationWindowTest.php
+++ b/tests/PaginationWindowTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Unit tests for pagination_window() - the windowed page list used by the
+ * viewlog.php pager.
+ * @see https://github.com/postfixadmin/postfixadmin/issues/1062
+ */
+class PaginationWindowTest extends \PHPUnit\Framework\TestCase
+{
+    public function testEmptyAndSinglePage()
+    {
+        $this->assertSame([], pagination_window(1, 0, 5));
+        $this->assertSame([1], pagination_window(1, 1, 5));
+    }
+
+    public function testAllPagesShownWhenWithinWindow()
+    {
+        // radius 5 around page 3 covers everything up to page 7 - no ellipsis.
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7], pagination_window(3, 7, 5));
+    }
+
+    public function testEllipsisOnBothSides()
+    {
+        $expected = [1, null, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, null, 50];
+        $this->assertSame($expected, pagination_window(20, 50, 5));
+    }
+
+    public function testTrailingEllipsisOnly()
+    {
+        // Near the start: window reaches page 8, then a gap to the last page.
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7, 8, null, 50], pagination_window(3, 50, 5));
+    }
+
+    public function testLeadingEllipsisOnly()
+    {
+        // Near the end: page 1, a gap, then the window through the last page.
+        $this->assertSame([1, null, 43, 44, 45, 46, 47, 48, 49, 50], pagination_window(48, 50, 5));
+    }
+
+    public function testCurrentPageClampedIntoRange()
+    {
+        // An out-of-range current page is clamped to the last page.
+        $this->assertSame([1, null, 8, 9, 10], pagination_window(999, 10, 2));
+    }
+
+    public function testNeverTwoAdjacentEllipses()
+    {
+        $window = pagination_window(25, 100, 5);
+        $previous = 1;
+        foreach ($window as $entry) {
+            $this->assertFalse($entry === null && $previous === null, 'two ellipses in a row');
+            $previous = $entry;
+        }
+        // First and last real entries are always page 1 and the last page.
+        $this->assertSame(1, $window[0]);
+        $this->assertSame(100, $window[count($window) - 1]);
+    }
+}


### PR DESCRIPTION
## What

Two pager improvements to the View Log page, plus a layout bug fix.

Closes #1062.

- **Per-page selector** — choose **10 / 25 / 50 / 100 / 1000** log entries per page (the configured `$CONF['page_size']` is always included so existing setups keep their default). Previously the page size was fixed to the global config with no UI. The value is **whitelisted** (a crafted `page_size` can't request an unbounded `LIMIT`) and persisted per session.
- **Bootstrap 5 pager** — replaces the hand-rolled `btn-group` pagination and the separate "Page" jump-dropdown with a standard `.pagination` component: first/prev, a window of ±5 pages around the current page with ellipses, next/last. The window is computed by a new testable helper `pagination_window()`.
- **Layout fix** — the old pager markup had an **unclosed `<div>`** (the `btn-group` wrapper opened two divs but closed one), which left the card `<div>` unclosed so the footer's grey background started at the log div instead of spanning full width. The rewrite balances the markup (verified: equal `<div>`/`</div>`).

> **Depends on #1060** (viewlog "All domains"). This branch is stacked on it — the diff currently includes #1060's commits; the pager change is the last commit. Merge #1060 first and I'll rebase this onto master so it shows only its own change.

## Testing

- New `tests/PaginationWindowTest.php` (7 tests) covers the window helper: empty/single page, no-ellipsis, leading/trailing/both ellipses, current-page clamping, and the "never two adjacent ellipses / always includes first+last" invariant.
- Full suite green: **110 tests, 1066 assertions** on the SQLite test DB.
- `php-cs-fixer` (dry-run) and lang-file lint clean; template `<div>` balance verified.
- Manual QA of the selector + pager navigation + the footer background recommended on a populated DB.
