### PR TITLE
CI: run the build workflow on pull requests (#1065)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,6 +1,13 @@
 name: GitHubBuild
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint_etc:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,9 +1,6 @@
 name: GitHubBuild
 
-on:
-  push:
-    branches: [master]
-  pull_request:
+on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Implements #1065 — run the `GitHubBuild` workflow on pull requests so PR checks are visible in this repository (today the workflow is `push`-only, so fork-PR checks run in the fork and never show on the PR).

```yaml
on: [push, pull_request]

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

- `pull_request` → PRs get visible build/test results here.
- `push` kept on all branches (per the discussion in #1065) so builds still run on stable branches (master, `postfixadmin_4.0`, …) after a PR is merged into them.
- `concurrency` + `cancel-in-progress` → a new push to a branch cancels the previous in-progress run, so rapid pushes don't stack up.

No jobs were changed, only the triggers.

Note: because `pull_request` runs use the workflow file from the base branch, this change can't demonstrate itself on its own PR — it takes effect once it's on `master`.
