### PR TITLE
Improve invalid CSRF token response

### DIFF
--- a/languages/en.lang
+++ b/languages/en.lang
@@ -548,6 +548,10 @@ $PALANG['pUpdate_changelog'] = 'Changelog';
 $PALANG['pUpdate_fetch_error'] = 'Neither cURL nor allow_url_fopen is available. Cannot check for updates.';
 $PALANG['pUpdate_network_error'] = 'Could not fetch release information from GitHub. Check that your server can reach api.github.com.';
 
+$PALANG['session_expired_title'] = 'Session expired';
+$PALANG['session_expired_message'] = 'The page token is no longer valid. Please return and try again.';
+$PALANG['session_expired_button'] = 'Continue';
+
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -527,6 +527,9 @@ $PALANG['pUpdate_fetch_error'] = 'Neither cURL nor allow_url_fopen is available.
 $PALANG['pUpdate_network_error'] = 'No se pudo recuperar la versión desde GitHub. Revisa si el servidor tiene acceso a la api.github.com.'; # XXX
 $PALANG['pDkim_field_domain_and_selector'] = 'Domain:Selector'; # XXX
 $PALANG['pDkim_field_description'] = 'Descripción'; # XXX
+$PALANG['session_expired_title'] = 'Sesión expirada';
+$PALANG['session_expired_message'] = 'El token de la página ya no es válido. Vuelve e intenta nuevamente.';
+$PALANG['session_expired_button'] = 'Continuar';
 $PALANG['please_keep_this_as_last_entry'] = ''; # needed for language-check.sh
 /* vim: set expandtab ft=php softtabstop=3 tabstop=3 shiftwidth=3: */
 ?>

--- a/model/CsrfToken.php
+++ b/model/CsrfToken.php
@@ -26,7 +26,7 @@ class CsrfToken
      */
     public static function assertValid(string $token): bool
     {
-        if (!is_array($_SESSION['CSRF_Tokens'])) {
+        if (!isset($_SESSION['CSRF_Tokens']) || !is_array($_SESSION['CSRF_Tokens'])) {
             $_SESSION['CSRF_Tokens'] = [];
         }
 

--- a/public/common.php
+++ b/public/common.php
@@ -7,7 +7,16 @@ set_exception_handler(function ($exception) {
     // we could do something much better here - e.g. if the user is logged in, and an admin, show a full stack trace etc.
     if ($exception instanceof CsrfInvalidException) {
         http_response_code(419); // HTTP 419 Page Expired.
-        echo "<p><strong>PostfixAdmin Error:</strong></p><p>Invalid CSRF token. Try going back, and refreshing the page before trying again.</p>\n";
+        $title = Config::lang('session_expired_title') ?: 'Session expired';
+        $message = Config::lang('session_expired_message') ?: 'The page token is no longer valid. Please return and try again.';
+        $button = Config::lang('session_expired_button') ?: 'Continue';
+
+        echo "<!doctype html>\n";
+        echo "<html><head><meta charset=\"utf-8\"><title>" . htmlentities($title) . "</title></head><body>\n";
+        echo "<p><strong>" . htmlentities($title) . "</strong></p>\n";
+        echo "<p>" . htmlentities($message) . "</p>\n";
+        echo "<p><a href=\"main.php\">" . htmlentities($button) . "</a></p>\n";
+        echo "</body></html>\n";
         exit(0);
     }
 


### PR DESCRIPTION
This ports the invalid CSRF token handling improvement from the 4.0 branch to master.\n\nChanges:\n- Keeps the HTTP 419 response for invalid CSRF tokens.\n- Replaces the raw hardcoded error with localized PALANG text.\n- Does not redirect to login.php, avoiding session destruction in multi-tab workflows.\n- Provides a simple Continue link back to main.php so normal authentication flow can decide whether login is needed.\n\nRelated to the 4.0 branch fix in PR #1055.