### PR TITLE
Harden optional mailbox hooks and add Rspamd DKIM examples

### DIFF
--- a/ADDITIONS/README.md
+++ b/ADDITIONS/README.md
@@ -74,6 +74,17 @@ no-op so an interrupted hook can be retried safely.
 requires Dovecot 2.3.19 or newer. Its default private-password setting name is
 for Dovecot 2.3; follow the comment in the script when using Dovecot 2.4.
 
+## Optional Rspamd DKIM hooks
+
+- postfixadmin-rspamd-dkim-postcreation.sh
+- postfixadmin-rspamd-dkim-postdeletion.sh
+- postfixadmin-domain-postdeletion-with-rspamd.sh
+
+These examples keep Rspamd DKIM key management separate from the generic
+Maildir hooks and run each operation as its owning service account. See
+`DOCUMENTS/RSPAMD-DKIM-HOOKS.md` for installation, `config.local.php`, sudoers
+and recovery guidance.
+
 
 ## Cyrus Quota Usage
 

--- a/ADDITIONS/README.md
+++ b/ADDITIONS/README.md
@@ -48,22 +48,33 @@ See also :  https://github.com/postfixadmin/postfixadmin/tree/master/ADDITIONS/s
 by George Vieira <george at citadelcomputer dot com dot au>
 Deletes all unused mailboxes
 
-## Example mailbox / domain scripts for Postfixadmin
+## Example mailbox / domain scripts for PostfixAdmin
 
 - postfixadmin-mailbox-postcreation.sh
 - postfixadmin-mailbox-postdeletion.sh
 - postfixadmin-domain-postdeletion.sh
+
 by Troels Arvin <troels@arvin.dk>
 
-Examples of scripts relevant to the optional 
+Examples relevant to the optional `mailbox_postcreation_script`,
+`mailbox_postdeletion_script` and `domain_postdeletion_script` configuration
+options.
 
+Review and adjust `basedir` and `trashbase` before installing the scripts. Run
+them as the account that owns the Maildirs, not as root. If sudo is required,
+grant the web server permission to run only the exact script as that account;
+never grant access to a generic `mv` command. Install privileged hooks in a
+root-owned directory that is not writable by the web server or mail users.
 
-$CONF['mailbox_postcreation_script'],
-$CONF['mailbox_postdeletion_script'] and
-$CONF['domain_postdeletion_script']  configuration options.
+The scripts validate the argument contracts documented in `config.inc.php`.
+Deletion is idempotent: an already absent Maildir is reported as a successful
+no-op so an interrupted hook can be retried safely.
+
+`postfixadmin-mailbox-postpassword.sh` is an example for Dovecot mail-crypt. It
+requires Dovecot 2.3.19 or newer. Its default private-password setting name is
+for Dovecot 2.3; follow the comment in the script when using Dovecot 2.4.
 
 
 ## Cyrus Quota Usage
 
 See https://github.com/o-m-d/cyrus-quotausage-to-pfa
-

--- a/ADDITIONS/postfixadmin-domain-postdeletion-with-rspamd.sh
+++ b/ADDITIONS/postfixadmin-domain-postdeletion-with-rspamd.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Optional composite domain-postdeletion hook for a Maildir installation that
+# also manages per-domain Rspamd DKIM keys.
+#
+# Run this wrapper as the Maildir owner. It calls the generic Maildir helper as
+# the current user and the DKIM helper through a narrowly scoped sudoers rule.
+
+# Adjust these installation paths before enabling the hook.
+maildir_delete_script=/usr/local/libexec/postfixadmin/postfixadmin-domain-postdeletion.sh
+dkim_delete_script=/usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postdeletion.sh
+sudo_path=/usr/bin/sudo
+rspamd_user=_rspamd
+
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
+    exit 1
+}
+
+[ "$#" -eq 1 ] || fail "expected exactly one domain argument"
+domain=$1
+
+[ -x "$maildir_delete_script" ] || fail "Maildir helper '$maildir_delete_script' is not executable"
+[ -x "$dkim_delete_script" ] || fail "DKIM helper '$dkim_delete_script' is not executable"
+[ -x "$sudo_path" ] || fail "sudo executable '$sudo_path' was not found"
+
+status=0
+if ! "$maildir_delete_script" "$domain"; then
+    printf '%s\n' "$0: Maildir deletion helper failed for '$domain'" >&2
+    status=1
+fi
+
+if ! "$sudo_path" -n -u "$rspamd_user" -- "$dkim_delete_script" "$domain"; then
+    printf '%s\n' "$0: Rspamd DKIM deletion helper failed for '$domain'" >&2
+    status=1
+fi
+
+exit "$status"

--- a/ADDITIONS/postfixadmin-domain-postdeletion.sh
+++ b/ADDITIONS/postfixadmin-domain-postdeletion.sh
@@ -1,62 +1,75 @@
 #!/bin/sh
 
-# Example script for removing a Maildir domain top-level folder
-# from a Courier-IMAP virtual mail hierarchy.
+# Example script for moving a deleted Maildir domain to a recovery directory.
+# PostfixAdmin passes the domain as argument 1.
 
-# The script only looks at argument 1, assuming that it 
-# indicates the relative name of a domain, such as
-# "somedomain.com". If $basedir/somedomain.com exists, it will
-# be removed.
+# Run this script as the user that owns the Maildirs. If the web server needs
+# sudo, restrict the sudoers rule to that user and this exact script. Do not
+# grant a generic mv command.
 
-# The script will not actually delete the directory. It moves it
-# to a special directory which may once in a while be cleaned up
-# by the system administrator.
-
-# This script should be run as the user which owns the maildirs. If 
-# the script is actually run by the apache user (e.g. through PHP),
-# then you could use "sudo" to grant apache the rights to run
-# this script as the relevant user.
-# Assume this script has been saved as
-# /usr/local/bin/postfixadmin-domain-postdeletion.sh and has been
-# made executable. Now, an example /etc/sudoers line:
-# apache ALL=(courier) NOPASSWD: /usr/local/bin/postfixadmin-domain-postdeletion.sh
-# The line states that the apache user may run the script as the
-# user "courier" without providing a password.
-
-
-# Change this to where you keep your virtual mail users' maildirs.
+# Change these paths to match the virtual mail layout.
 basedir=/var/spool/maildirs
-
-# Change this to where you would like deleted maildirs to reside.
 trashbase=/var/spool/deleted-maildirs
 
-if [ `echo $1 | fgrep '..'` ]; then
-    echo "First argument contained a double-dot sequence; bailing out."
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
     exit 1
-fi
+}
 
-if [ ! -e "$trashbase" ]; then
-    echo "trashbase '$trashbase' does not exist; bailing out."
-    exit 1
-fi
+valid_domain()
+{
+    candidate=$1
 
-trashdir="${trashbase}/`date +%F_%T`_$1"
-domaindir="${basedir}/$1"
+    [ -n "$candidate" ] && [ "${#candidate}" -le 253 ] || return 1
+    case "$candidate" in
+        -*|.*|*.|*..*|*/*|*\\*|*[!A-Za-z0-9.-]*) return 1 ;;
+    esac
+
+    remainder=$candidate
+    while :; do
+        case "$remainder" in
+            *.*)
+                label=${remainder%%.*}
+                remainder=${remainder#*.}
+                ;;
+            *)
+                label=$remainder
+                remainder=
+                ;;
+        esac
+
+        [ -n "$label" ] && [ "${#label}" -le 63 ] || return 1
+        case "$label" in
+            -*|*-) return 1 ;;
+        esac
+        [ -n "$remainder" ] || break
+    done
+}
+
+[ "$#" -eq 1 ] || fail "expected exactly one domain argument"
+domain=$1
+valid_domain "$domain" || fail "invalid domain '$domain'"
+
+[ -d "$basedir" ] || fail "basedir '$basedir' is not a directory"
+[ -d "$trashbase" ] || fail "trashbase '$trashbase' is not a directory"
+
+domaindir="${basedir%/}/$domain"
+[ "$domaindir" != "${trashbase%/}" ] || fail "refusing to move trashbase itself"
 
 if [ ! -e "$domaindir" ]; then
-    echo "Directory '$domaindir' does not exits; nothing to do."
-    exit 0;
+    printf '%s\n' "$0: directory '$domaindir' does not exist; nothing to do."
+    exit 0
 fi
-if [ ! -d "$domaindir" ]; then
-    echo "'$domaindir' is not a directory; bailing out."
-    exit 1
-fi
-if [ -e "$trashdir" ]; then
-    echo "Directory '$trashdir' already exits; bailing out."
-    exit 1;
+[ -d "$domaindir" ] || fail "'$domaindir' is not a directory"
+
+timestamp=$(date '+%Y%m%dT%H%M%S') || fail "could not generate a timestamp"
+trashdir="${trashbase%/}/${timestamp}_$$_${domain}"
+[ ! -e "$trashdir" ] || fail "trash destination '$trashdir' already exists"
+
+if ! mv "$domaindir" "$trashdir"; then
+    fail "could not move '$domaindir' to '$trashdir'"
 fi
 
-mv $domaindir $trashdir
-
-exit $?
-
+printf '%s\n' "$0: moved '$domaindir' to '$trashdir'."
+exit 0

--- a/ADDITIONS/postfixadmin-mailbox-postcreation.sh
+++ b/ADDITIONS/postfixadmin-mailbox-postcreation.sh
@@ -1,71 +1,79 @@
 #!/bin/sh
 
 # Example script for adding a Maildir to a Courier-IMAP virtual mail
-# hierarchy.
+# hierarchy. PostfixAdmin passes username, domain, Maildir and quota as
+# arguments 1 through 4. This example uses only the relative Maildir path.
 
-# The script only looks at argument 3, assuming that it 
-# indicates the relative name of a maildir, such as
-# "somedomain.com/peter/".
+# Run this script as the user that owns the Maildirs. If the web server needs
+# sudo, restrict the sudoers rule to that user and this exact script.
 
-# This script should be run as the user which owns the maildirs. If 
-# the script is actually run by the apache user (e.g. through PHP),
-# then you could use "sudo" to grant apache the rights to run
-# this script as the relevant user.
-# Assume this script has been saved as
-# /usr/local/bin/postfixadmin-mailbox-postcreation.sh and has been
-# made executable. Now, an example /etc/sudoers line:
-# apache ALL=(courier) NOPASSWD: /usr/local/bin/postfixadmin-mailbox-postcreation.sh
-# The line states that the apache user may run the script as the
-# user "courier" without providing a password.
-
-
-# Change this to where you keep your virtual mail users' maildirs.
+# Change this to where you keep your virtual mail users' Maildirs.
 basedir=/var/spool/maildirs
 
-if [ ! -e "$basedir" ]; then
-    echo "$0: basedir '$basedir' does not exist; bailing out."
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
     exit 1
-fi
+}
 
-if [ `echo $3 | fgrep '..'` ]; then
-    echo "$0: An argument contained a double-dot sequence; bailing out."
-    exit 1
-fi
+valid_relative_maildir()
+{
+    candidate=${1%/}
 
-maildir="${basedir}/$3"
-parent=`dirname "$maildir"`
+    [ -n "$candidate" ] || return 1
+    case "$candidate" in
+        /*|*\\*|*//*|*[![:print:]]*) return 1 ;;
+    esac
+
+    remainder=$candidate
+    while :; do
+        case "$remainder" in
+            */*)
+                component=${remainder%%/*}
+                remainder=${remainder#*/}
+                ;;
+            *)
+                component=$remainder
+                remainder=
+                ;;
+        esac
+
+        case "$component" in
+            ''|.|..) return 1 ;;
+        esac
+        [ -n "$remainder" ] || break
+    done
+}
+
+[ "$#" -eq 4 ] || fail "expected username, domain, Maildir and quota arguments"
+relative_maildir=${3%/}
+valid_relative_maildir "$relative_maildir" || fail "invalid relative Maildir '$3'"
+
+[ -d "$basedir" ] || fail "basedir '$basedir' is not a directory"
+
+maildir="${basedir%/}/$relative_maildir"
+parent=$(dirname "$maildir") || fail "could not determine the parent directory"
+
 if [ ! -d "$parent" ]; then
-    if [ -e "$parent" ]; then
-        echo "$0: strange - directory '$parent' exists, but is not a directory; bailing out."
-        exit 1
-    else
-        mkdir -p "${parent}"
-        if [ $? -ne 0 ]; then
-            echo "$0: mkdir -p '$parent' returned non-zero; bailing out."
-            exit 1
-        fi
+    [ ! -e "$parent" ] || fail "'$parent' exists but is not a directory"
+    if ! mkdir -p "$parent"; then
+        fail "could not create parent directory '$parent'"
     fi
 fi
 
-if [ -e "$maildir" ]; then
-    echo "$0: Directory '$maildir' already exists! bailing out"
-    exit 1
+[ ! -e "$maildir" ] || fail "Maildir '$maildir' already exists"
+
+if maildirmake_path=$(command -v maildirmake 2>/dev/null); then
+    :
+elif maildirmake_path=$(command -v courier-maildirmake 2>/dev/null); then
+    :
+else
+    fail "could not find maildirmake or courier-maildirmake in PATH"
 fi
 
-
-# try looking for maildirmake ...
-MDM=`which maildirmake || which courier-maildirmake`
-
-if [ "x${MDM}" = "x" ]; then
-    echo "Couldn't find maildirmake or courier-maildirmake in your PATH etc (via which)" >/dev/stderr
-    exit 1
+if ! "$maildirmake_path" "$maildir"; then
+    fail "maildirmake failed for '$maildir'"
 fi
-
-"${MDM}" "${maildir}"
-
-if [ ! -d "$maildir" ]; then
-    echo "$0: maildirmake didn't produce a directory; bailing out."
-    exit 1
-fi
+[ -d "$maildir" ] || fail "maildirmake did not create '$maildir'"
 
 exit 0

--- a/ADDITIONS/postfixadmin-mailbox-postdeletion.sh
+++ b/ADDITIONS/postfixadmin-mailbox-postdeletion.sh
@@ -1,77 +1,95 @@
 #!/bin/sh
 
-# Example script for removing a Maildir from a Courier-IMAP virtual mail
-# hierarchy.
+# Example script for moving a deleted Maildir to a recovery directory.
+# PostfixAdmin passes username and domain as arguments 1 and 2.
 
-# The script looks at arguments 1 and 2, assuming that they 
-# indicate username and domain, respectively.
+# Run this script as the user that owns the Maildirs. If the web server needs
+# sudo, restrict the sudoers rule to that user and this exact script. Do not
+# grant a generic mv command.
 
-# The script will not actually delete the maildir. It moves it
-# to a special directory which may once in a while be cleaned up
-# by the system administrator.
-
-# This script should be run as the user which owns the maildirs. If 
-# the script is actually run by the apache user (e.g. through PHP),
-# then you could use "sudo" to grant apache the rights to run
-# this script as the relevant user.
-# Assume this script has been saved as
-# /usr/local/bin/postfixadmin-mailbox-postdeletion.sh and has been
-# made executable. Now, an example /etc/sudoers line:
-# apache ALL=(courier) NOPASSWD: /usr/local/bin/postfixadmin-mailbox-postdeletion.sh
-# The line states that the apache user may run the script as the
-# user "courier" without providing a password.
-
-
-# Change this to where you keep your virtual mail users' maildirs.
+# Change these paths to match the virtual mail layout.
 basedir=/var/spool/maildirs
-
-# Change this to where you would like deleted maildirs to reside.
 trashbase=/var/spool/deleted-maildirs
 
-
-if [ ! -e "$trashbase" ]; then
-    echo "trashbase '$trashbase' does not exist; bailing out."
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
     exit 1
+}
+
+valid_domain()
+{
+    candidate=$1
+
+    [ -n "$candidate" ] && [ "${#candidate}" -le 253 ] || return 1
+    case "$candidate" in
+        -*|.*|*.|*..*|*/*|*\\*|*[!A-Za-z0-9.-]*) return 1 ;;
+    esac
+
+    remainder=$candidate
+    while :; do
+        case "$remainder" in
+            *.*)
+                label=${remainder%%.*}
+                remainder=${remainder#*.}
+                ;;
+            *)
+                label=$remainder
+                remainder=
+                ;;
+        esac
+
+        [ -n "$label" ] && [ "${#label}" -le 63 ] || return 1
+        case "$label" in
+            -*|*-) return 1 ;;
+        esac
+        [ -n "$remainder" ] || break
+    done
+}
+
+valid_mailbox_component()
+{
+    case "$1" in
+        ''|.|..|*/*|*\\*|*[![:print:]]*) return 1 ;;
+    esac
+}
+
+[ "$#" -eq 2 ] || fail "expected username and domain arguments"
+username=$1
+domain=$2
+valid_domain "$domain" || fail "invalid domain '$domain'"
+
+case "$username" in
+    *@"$domain") subdir=${username%"@$domain"} ;;
+    *) fail "username '$username' does not belong to domain '$domain'" ;;
+esac
+valid_mailbox_component "$subdir" || fail "unsafe mailbox directory component"
+
+[ -d "$basedir" ] || fail "basedir '$basedir' is not a directory"
+[ -d "$trashbase" ] || fail "trashbase '$trashbase' is not a directory"
+
+maildir="${basedir%/}/$domain/$subdir"
+if [ ! -e "$maildir" ]; then
+    printf '%s\n' "$0: Maildir '$maildir' does not exist; nothing to do."
+    exit 0
 fi
+[ -d "$maildir" ] || fail "'$maildir' is not a directory"
 
-if [ `echo $1 | fgrep '..'` ]; then
-    echo "First argument contained a double-dot sequence; bailing out."
-    exit 1
-fi
-if [ `echo $2 | fgrep '..'` ]; then
-    echo "First argument contained a double-dot sequence; bailing out."
-    exit 1
-fi
-
-subdir=`echo "$1" | sed 's/@.*//'`
-
-maildir="${basedir}/$2/${subdir}"
-trashdir="${trashbase}/$2/`date +%F_%T`_${subdir}"
-
-parent=`dirname "$trashdir"`
-if [ ! -d "$parent" ]; then
-    if [ -e "$parent" ]; then
-        echo "Strainge - directory '$parent' exists, but is not a directory."
-        echo "Bailing out."
-        exit 1
-    else
-        mkdir -p "$parent"
-        if [ $? -ne 0 ]; then
-            echo "mkdir -p '$parent' returned non-zero; bailing out."
-            exit 1
-        fi
+trashparent="${trashbase%/}/$domain"
+if [ ! -d "$trashparent" ]; then
+    [ ! -e "$trashparent" ] || fail "'$trashparent' exists but is not a directory"
+    if ! mkdir -p "$trashparent"; then
+        fail "could not create trash directory '$trashparent'"
     fi
 fi
 
-if [ ! -e "$maildir" ]; then
-    echo "maildir '$maildir' does not exist; nothing to do."
-    exit 1
-fi
-if [ -e "$trashdir" ]; then
-    echo "trashdir '$trashdir' already exists; bailing out."
-    exit 1
+timestamp=$(date '+%Y%m%dT%H%M%S') || fail "could not generate a timestamp"
+trashdir="${trashparent}/${timestamp}_$$_${subdir}"
+[ ! -e "$trashdir" ] || fail "trash destination '$trashdir' already exists"
+
+if ! mv "$maildir" "$trashdir"; then
+    fail "could not move '$maildir' to '$trashdir'"
 fi
 
-mv $maildir $trashdir
-
-exit $?
+printf '%s\n' "$0: moved '$maildir' to '$trashdir'."
+exit 0

--- a/ADDITIONS/postfixadmin-mailbox-postpassword.sh
+++ b/ADDITIONS/postfixadmin-mailbox-postpassword.sh
@@ -1,19 +1,46 @@
 #!/bin/bash
 
-# Example script for dovecot mail-crypt-plugin
-# https://doc.dovecot.org/configuration_manual/mail_crypt_plugin/
+# Example script for Dovecot's mail-crypt plugin.
+# Requires Dovecot 2.3.19 or newer for the -O/-N prompt behaviour.
+# https://doc.dovecot.org/2.3/configuration_manual/mail_crypt_plugin/
 
-IFS= read -r -d $'\0' OLD_PASSWORD
-IFS= read -r -d $'\0' NEW_PASSWORD
+# Dovecot 2.3 setting name. For Dovecot 2.4, use:
+# private_password_setting=crypt_user_key_password
+private_password_setting=plugin/mail_crypt_private_password
 
-# New user
-if [ -z "$OLD_PASSWORD" ]; then
-    OLD_PASSWORD="$(openssl rand -hex 16)"
-    doveadm -o plugin/mail_crypt_private_password="$OLD_PASSWORD" mailbox cryptokey generate -u "$1" -U
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
+    exit 1
+}
+
+[[ $# -eq 2 ]] || fail "expected username and domain arguments"
+username=$1
+domain=$2
+[[ -n $username && -n $domain && $username == *@"$domain" ]] || fail "invalid username or domain"
+
+IFS= read -r -d '' old_password || fail "could not read the NUL-terminated old password"
+IFS= read -r -d '' new_password || fail "could not read the NUL-terminated new password"
+[[ -n $new_password ]] || fail "new password must not be empty"
+
+openssl_path=$(command -v openssl 2>/dev/null) || fail "could not find openssl in PATH"
+doveadm_path=$(command -v doveadm 2>/dev/null) || fail "could not find doveadm in PATH"
+
+if [[ -z $old_password ]]; then
+    old_password=$("$openssl_path" rand -hex 16) || fail "could not generate a temporary password"
+    [[ -n $old_password ]] || fail "openssl returned an empty temporary password"
+
+    if ! "$doveadm_path" -o "$private_password_setting=$old_password" \
+        mailbox cryptokey generate -u "$username" -U; then
+        fail "could not generate the mailbox cryptokey"
+    fi
 fi
 
-# If you're using dovecot >= 2.3.19, try this instead (See: https://github.com/postfixadmin/postfixadmin/issues/646)
-# printf "%s\n%s\n" "$OLD_PASSWORD" "$NEW_PASSWORD" "$NEW_PASSWORD" | doveadm mailbox cryptokey password -u "$1" -N -O 
+# Since Dovecot 2.3.19, -O asks for the old password and -N asks for the new
+# password twice. Keep passwords on stdin instead of command-line arguments.
+if ! printf '%s\n%s\n%s\n' "$old_password" "$new_password" "$new_password" | \
+    "$doveadm_path" mailbox cryptokey password -u "$username" -O -N; then
+    fail "could not update the mailbox cryptokey password"
+fi
 
-# Password change
-printf "%s\n%s\n" "$OLD_PASSWORD" "$NEW_PASSWORD" | doveadm mailbox cryptokey password -u "$1" -N -O ""
+exit 0

--- a/ADDITIONS/postfixadmin-rspamd-dkim-postcreation.sh
+++ b/ADDITIONS/postfixadmin-rspamd-dkim-postcreation.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+# Optional PostfixAdmin domain-postcreation hook for Rspamd DKIM keys.
+# Run this script as the Rspamd service account, never as root.
+
+# Adjust these values for the local Rspamd installation.
+dkimdir=/var/db/rspamd/dkim
+selector=default
+key_bits=2048
+
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
+    exit 1
+}
+
+valid_domain()
+{
+    candidate=$1
+
+    [ -n "$candidate" ] && [ "${#candidate}" -le 253 ] || return 1
+    case "$candidate" in
+        -*|.*|*.|*..*|*/*|*\\*|*[!A-Za-z0-9.-]*) return 1 ;;
+    esac
+
+    remainder=$candidate
+    while :; do
+        case "$remainder" in
+            *.*)
+                label=${remainder%%.*}
+                remainder=${remainder#*.}
+                ;;
+            *)
+                label=$remainder
+                remainder=
+                ;;
+        esac
+
+        [ -n "$label" ] && [ "${#label}" -le 63 ] || return 1
+        case "$label" in
+            -*|*-) return 1 ;;
+        esac
+        [ -n "$remainder" ] || break
+    done
+}
+
+temporary_private=
+temporary_public=
+# Invoked by the traps installed below.
+# shellcheck disable=SC2329
+cleanup()
+{
+    [ -z "$temporary_private" ] || rm -f "$temporary_private"
+    [ -z "$temporary_public" ] || rm -f "$temporary_public"
+}
+trap cleanup 0
+trap 'exit 1' HUP INT TERM
+
+[ "$#" -eq 1 ] || fail "expected exactly one domain argument"
+domain=$1
+valid_domain "$domain" || fail "invalid domain '$domain'"
+
+[ -d "$dkimdir" ] || fail "DKIM directory '$dkimdir' does not exist"
+[ -w "$dkimdir" ] || fail "DKIM directory '$dkimdir' is not writable"
+
+rspamadm_path=$(command -v rspamadm 2>/dev/null) || fail "could not find rspamadm in PATH"
+mktemp_path=$(command -v mktemp 2>/dev/null) || fail "could not find mktemp in PATH"
+
+private_key="${dkimdir%/}/${domain}.${selector}.private"
+public_record="${dkimdir%/}/${domain}.${selector}.txt"
+
+if [ -e "$private_key" ] || [ -L "$private_key" ] ||
+    [ -e "$public_record" ] || [ -L "$public_record" ]; then
+    fail "DKIM files already exist for domain '$domain' and selector '$selector'"
+fi
+
+umask 077
+temporary_private=$("$mktemp_path" "${dkimdir%/}/.${domain}.${selector}.private.XXXXXX") ||
+    fail "could not create a temporary private-key file"
+temporary_public=$("$mktemp_path" "${dkimdir%/}/.${domain}.${selector}.txt.XXXXXX") ||
+    fail "could not create a temporary public-record file"
+
+if ! "$rspamadm_path" dkim_keygen -k "$temporary_private" -b "$key_bits" \
+    -s "$selector" -d "$domain" > "$temporary_public"; then
+    fail "rspamadm could not generate DKIM keys for '$domain'"
+fi
+
+[ -s "$temporary_private" ] || fail "rspamadm produced an empty private key"
+[ -s "$temporary_public" ] || fail "rspamadm produced an empty public record"
+chmod 600 "$temporary_private" || fail "could not protect the private key"
+chmod 644 "$temporary_public" || fail "could not set public-record permissions"
+
+# Hard links publish both files without overwriting an existing key created by
+# another concurrent invocation. The temporary files are on the same filesystem.
+if ! ln "$temporary_private" "$private_key"; then
+    fail "could not publish private key '$private_key'"
+fi
+if ! ln "$temporary_public" "$public_record"; then
+    rm -f "$private_key"
+    fail "could not publish public record '$public_record'"
+fi
+
+rm -f "$temporary_private" "$temporary_public"
+temporary_private=
+temporary_public=
+trap - 0 HUP INT TERM
+
+printf '%s\n' "$0: generated DKIM files for '$domain':"
+printf '  %s\n  %s\n' "$private_key" "$public_record"
+exit 0

--- a/ADDITIONS/postfixadmin-rspamd-dkim-postdeletion.sh
+++ b/ADDITIONS/postfixadmin-rspamd-dkim-postdeletion.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+# Optional Rspamd DKIM deletion helper. It moves all selector files belonging
+# to a domain into a Rspamd-owned recovery directory. Run it as the Rspamd
+# service account, never as root.
+
+# Adjust these values for the local Rspamd installation.
+dkimdir=/var/db/rspamd/dkim
+trashbase=/var/db/rspamd/deleted-dkim
+
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
+    exit 1
+}
+
+valid_domain()
+{
+    candidate=$1
+
+    [ -n "$candidate" ] && [ "${#candidate}" -le 253 ] || return 1
+    case "$candidate" in
+        -*|.*|*.|*..*|*/*|*\\*|*[!A-Za-z0-9.-]*) return 1 ;;
+    esac
+
+    remainder=$candidate
+    while :; do
+        case "$remainder" in
+            *.*)
+                label=${remainder%%.*}
+                remainder=${remainder#*.}
+                ;;
+            *)
+                label=$remainder
+                remainder=
+                ;;
+        esac
+
+        [ -n "$label" ] && [ "${#label}" -le 63 ] || return 1
+        case "$label" in
+            -*|*-) return 1 ;;
+        esac
+        [ -n "$remainder" ] || break
+    done
+}
+
+[ "$#" -eq 1 ] || fail "expected exactly one domain argument"
+domain=$1
+valid_domain "$domain" || fail "invalid domain '$domain'"
+
+[ -d "$dkimdir" ] || fail "DKIM directory '$dkimdir' does not exist"
+[ -d "$trashbase" ] || fail "DKIM trash directory '$trashbase' does not exist"
+[ -w "$dkimdir" ] || fail "DKIM directory '$dkimdir' is not writable"
+[ -w "$trashbase" ] || fail "DKIM trash directory '$trashbase' is not writable"
+
+timestamp=$(date '+%Y%m%dT%H%M%S') || fail "could not generate a timestamp"
+trashdir="${trashbase%/}/${timestamp}_$$_${domain}"
+found=false
+status=0
+
+umask 077
+for keyfile in "${dkimdir%/}/${domain}".*; do
+    if [ ! -e "$keyfile" ] && [ ! -L "$keyfile" ]; then
+        continue
+    fi
+    found=true
+
+    if [ -L "$keyfile" ] || [ ! -f "$keyfile" ]; then
+        printf '%s\n' "$0: refusing non-regular DKIM entry '$keyfile'" >&2
+        status=1
+        continue
+    fi
+
+    if [ ! -d "$trashdir" ] && ! mkdir "$trashdir"; then
+        fail "could not create DKIM recovery directory '$trashdir'"
+    fi
+    if ! mv "$keyfile" "$trashdir/"; then
+        printf '%s\n' "$0: could not move '$keyfile' to '$trashdir'" >&2
+        status=1
+    fi
+done
+
+if [ "$found" = false ]; then
+    printf '%s\n' "$0: no DKIM files exist for '$domain'; nothing to do."
+    exit 0
+fi
+
+if [ "$status" -ne 0 ]; then
+    fail "one or more DKIM files could not be moved"
+fi
+
+printf '%s\n' "$0: moved DKIM files for '$domain' to '$trashdir'."
+exit 0

--- a/DOCUMENTS/RSPAMD-DKIM-HOOKS.md
+++ b/DOCUMENTS/RSPAMD-DKIM-HOOKS.md
@@ -1,0 +1,126 @@
+# Optional Rspamd DKIM hooks
+
+PostfixAdmin can invoke scripts after creating or deleting a domain. The
+scripts in this guide add optional per-domain Rspamd DKIM key management while
+keeping the generic Maildir hooks independent of Rspamd.
+
+These examples intentionally separate privileges:
+
+* the virtual-mail user owns and moves Maildirs;
+* the Rspamd service user owns and moves DKIM keys;
+* neither account receives permission to run commands as root.
+
+The example paths and account names must be reviewed for each operating
+system. In particular, `_rspamd`, `/var/db/rspamd` and `/usr/bin/sudo` are not
+portable defaults.
+
+## Included scripts
+
+`ADDITIONS/postfixadmin-rspamd-dkim-postcreation.sh`
+: Generates a private key and DNS record without overwriting existing files.
+  Run it as the Rspamd service user.
+
+`ADDITIONS/postfixadmin-rspamd-dkim-postdeletion.sh`
+: Moves every selector file for a domain into an Rspamd-owned recovery
+  directory. Run it as the Rspamd service user.
+
+`ADDITIONS/postfixadmin-domain-postdeletion-with-rspamd.sh`
+: Runs the generic Maildir deletion hook as the current virtual-mail user and
+  delegates DKIM cleanup to the Rspamd helper.
+
+All deletion operations are idempotent. Missing Maildirs or DKIM files are
+successful no-ops, which allows an interrupted domain hook to be retried.
+
+## Installation
+
+The scripts executed through sudo must be installed outside the web root in a
+root-owned directory that is not writable by the web server, virtual-mail or
+Rspamd accounts. For example:
+
+```text
+/usr/local/libexec/postfixadmin/
+```
+
+Create the runtime directories once as an administrator. Example commands for
+a system whose Rspamd account is `_rspamd` are:
+
+```console
+install -d -o _rspamd -g _rspamd -m 0700 /var/db/rspamd/dkim
+install -d -o _rspamd -g _rspamd -m 0700 /var/db/rspamd/deleted-dkim
+install -d -o vmail -g vmail -m 0700 /var/vmail/deleted-maildirs
+```
+
+Review the constants at the beginning of every script. A `/var/vmail` layout,
+for example, requires changing `basedir` in the generic Maildir scripts. On a
+system where sudo is `/usr/local/bin/sudo`, update `sudo_path` in the composite
+hook.
+
+The creation helper stores the private key as mode `0600` and the DNS record
+as mode `0644`. It writes temporary files in the DKIM directory and publishes
+them without replacing an existing key. The `.txt` file contains the standard
+zone-record output produced by `rspamadm dkim_keygen`.
+
+## PostfixAdmin configuration
+
+For an installation using Apache, `vmail` and `_rspamd`, the relevant
+`config.local.php` settings can look like:
+
+```php
+$CONF['domain_postcreation_script'] =
+    '/usr/bin/sudo -n -u _rspamd -- /usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postcreation.sh';
+
+$CONF['domain_postdeletion_script'] =
+    '/usr/bin/sudo -n -u vmail -- /usr/local/libexec/postfixadmin/postfixadmin-domain-postdeletion-with-rspamd.sh';
+
+$CONF['mailbox_postdeletion_script'] =
+    '/usr/bin/sudo -n -u vmail -- /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postdeletion.sh';
+```
+
+The `-n` option makes a sudo configuration error fail immediately instead of
+waiting for an interactive password prompt.
+
+An installation without Rspamd should configure the generic
+`postfixadmin-domain-postdeletion.sh` directly and does not need any of the
+Rspamd helpers.
+
+## Sudoers example
+
+Use `visudo` to edit and validate the rules. Restrict both the target account
+and executable path:
+
+```sudoers
+apache ALL=(_rspamd) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postcreation.sh
+apache ALL=(vmail) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-domain-postdeletion-with-rspamd.sh
+apache ALL=(vmail) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postdeletion.sh
+vmail ALL=(_rspamd) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postdeletion.sh
+```
+
+Do not use `(ALL)` as the run-as account and never grant a service account
+permission to run a general-purpose command such as `/usr/bin/mv`. A rule that
+names a command without arguments permits arbitrary arguments, so every helper
+must retain its own strict validation even when sudoers also constrains the
+command.
+
+After installation, verify ownership and permissions on every script and all
+parent directories. A script writable by `apache`, `vmail` or `_rspamd` must
+not be referenced by sudoers.
+
+## Recovery and operations
+
+Maildirs and DKIM keys use separate recovery locations because they have
+different owners and sensitivity:
+
+```text
+/var/vmail/deleted-maildirs/
+/var/db/rspamd/deleted-dkim/
+```
+
+The composite hook attempts both operations even if one fails, then returns a
+failure status if either helper reported a real error. PostfixAdmin can report
+that failure, and an administrator can safely rerun the hook after correcting
+permissions or storage problems.
+
+Before enabling the hooks in production, test creation, deletion, repeated
+deletion and restoration with a non-production domain. Also confirm the local
+`rspamadm dkim_keygen` output and publish the generated DNS record before
+enabling DKIM signing for the domain.


### PR DESCRIPTION
## Summary

- harden the existing optional Maildir domain, mailbox creation/deletion and Dovecot mail-crypt hooks
- validate hook argument contracts and keep all derived paths below their configured base directories
- quote filesystem operations, check command failures and make deletion hooks safely retryable
- update the Dovecot password example for the prompt behaviour available since Dovecot 2.3.19, with a Dovecot 2.4 setting note
- add optional Rspamd DKIM creation/deletion helpers, a privilege-separated composite domain hook and deployment documentation

The generic hook hardening and the optional Rspamd integration are intentionally kept in separate commits.

## Why

The existing example deletion scripts accept missing arguments, so a direct or incorrectly configured invocation can derive the Maildir base directory itself as the move source. They also use unquoted paths, weak double-dot checks and incomplete exit-status handling. The password hook keeps the pre-2.3.19 Dovecot command active while only commenting the newer invocation.

The Rspamd examples document a practical integration without granting root access or a general-purpose `mv` command. Maildirs remain owned by the virtual-mail account and DKIM files remain owned by the Rspamd account.

## Impact

These hooks remain optional and disabled by default. Administrators must review the configured paths and service-account names before installation. The mail-crypt password example now requires Dovecot 2.3.19 or newer; its comment identifies the setting name needed by Dovecot 2.4.

## Validation

- ShellCheck at style severity for every changed or added shell script
- `sh -n` and `bash -n` syntax validation
- isolated functional tests for Maildir creation, domain/mailbox deletion, invalid traversal input, retryable deletion and DKIM create/delete/no-overwrite behaviour
- NUL-delimited password-hook tests with simulated `openssl` and `doveadm`
- GNU `patch -p1 --dry-run` and full sequential application from a clean `origin/master` worktree
- exact tree comparison between the applied patches and the two commits
