### PR TITLE
Add optional Rspamd DKIM hook examples

### DIFF
--- a/ADDITIONS/README.md
+++ b/ADDITIONS/README.md
@@ -74,6 +74,17 @@ no-op so an interrupted hook can be retried safely.
 requires Dovecot 2.3.19 or newer. Its default private-password setting name is
 for Dovecot 2.3; follow the comment in the script when using Dovecot 2.4.
 
+## Optional Rspamd DKIM hooks
+
+- postfixadmin-rspamd-dkim-postcreation.sh
+- postfixadmin-rspamd-dkim-postdeletion.sh
+- postfixadmin-domain-postdeletion-with-rspamd.sh
+
+These examples keep Rspamd DKIM key management separate from the generic
+Maildir hooks and run each operation as its owning service account. See
+`DOCUMENTS/RSPAMD-DKIM-HOOKS.md` for installation, `config.local.php`, sudoers
+and recovery guidance.
+
 
 ## Cyrus Quota Usage
 

--- a/ADDITIONS/README.md
+++ b/ADDITIONS/README.md
@@ -66,6 +66,26 @@ grant the web server permission to run only the exact script as that account;
 never grant access to a generic `mv` command. Install privileged hooks in a
 root-owned directory that is not writable by the web server or mail users.
 
+### Sudoers applies to every enabled hook
+
+Sudoers is not specific to the optional Rspamd integration. Every hook enabled
+in `config.local.php` that is invoked through sudo needs its own rule with the
+exact target account and installed script path. For example, after replacing
+the account names and paths to match the local system:
+
+```sudoers
+apache ALL=(courier) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postcreation.sh
+apache ALL=(courier) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postdeletion.sh
+apache ALL=(courier) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-domain-postdeletion.sh
+apache ALL=(dovecot) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postpassword.sh
+```
+
+Only add rules for hooks that are actually configured. If the optional Rspamd
+hooks are installed, their rules extend this base policy. The composite Rspamd
+domain-deletion hook replaces the direct domain-deletion rule; unrelated
+mailbox and Dovecot rules remain in effect. See
+`DOCUMENTS/RSPAMD-DKIM-HOOKS.md` for the complete mapping.
+
 The scripts validate the argument contracts documented in `config.inc.php`.
 Deletion is idempotent: an already absent Maildir is reported as a successful
 no-op so an interrupted hook can be retried safely.

--- a/ADDITIONS/postfixadmin-domain-postdeletion-with-rspamd.sh
+++ b/ADDITIONS/postfixadmin-domain-postdeletion-with-rspamd.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Optional composite domain-postdeletion hook for a Maildir installation that
+# also manages per-domain Rspamd DKIM keys.
+#
+# Run this wrapper as the Maildir owner. It calls the generic Maildir helper as
+# the current user and the DKIM helper through a narrowly scoped sudoers rule.
+
+# Adjust these installation paths before enabling the hook.
+maildir_delete_script=/usr/local/libexec/postfixadmin/postfixadmin-domain-postdeletion.sh
+dkim_delete_script=/usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postdeletion.sh
+sudo_path=/usr/bin/sudo
+rspamd_user=_rspamd
+
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
+    exit 1
+}
+
+[ "$#" -eq 1 ] || fail "expected exactly one domain argument"
+domain=$1
+
+[ -x "$maildir_delete_script" ] || fail "Maildir helper '$maildir_delete_script' is not executable"
+[ -x "$dkim_delete_script" ] || fail "DKIM helper '$dkim_delete_script' is not executable"
+[ -x "$sudo_path" ] || fail "sudo executable '$sudo_path' was not found"
+
+status=0
+if ! "$maildir_delete_script" "$domain"; then
+    printf '%s\n' "$0: Maildir deletion helper failed for '$domain'" >&2
+    status=1
+fi
+
+if ! "$sudo_path" -n -u "$rspamd_user" -- "$dkim_delete_script" "$domain"; then
+    printf '%s\n' "$0: Rspamd DKIM deletion helper failed for '$domain'" >&2
+    status=1
+fi
+
+exit "$status"

--- a/ADDITIONS/postfixadmin-rspamd-dkim-postcreation.sh
+++ b/ADDITIONS/postfixadmin-rspamd-dkim-postcreation.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+# Optional PostfixAdmin domain-postcreation hook for Rspamd DKIM keys.
+# Run this script as the Rspamd service account, never as root.
+
+# Adjust these values for the local Rspamd installation.
+dkimdir=/var/db/rspamd/dkim
+selector=default
+key_bits=2048
+
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
+    exit 1
+}
+
+valid_domain()
+{
+    candidate=$1
+
+    [ -n "$candidate" ] && [ "${#candidate}" -le 253 ] || return 1
+    case "$candidate" in
+        -*|.*|*.|*..*|*/*|*\\*|*[!A-Za-z0-9.-]*) return 1 ;;
+    esac
+
+    remainder=$candidate
+    while :; do
+        case "$remainder" in
+            *.*)
+                label=${remainder%%.*}
+                remainder=${remainder#*.}
+                ;;
+            *)
+                label=$remainder
+                remainder=
+                ;;
+        esac
+
+        [ -n "$label" ] && [ "${#label}" -le 63 ] || return 1
+        case "$label" in
+            -*|*-) return 1 ;;
+        esac
+        [ -n "$remainder" ] || break
+    done
+}
+
+temporary_private=
+temporary_public=
+# Invoked by the traps installed below.
+# shellcheck disable=SC2329
+cleanup()
+{
+    [ -z "$temporary_private" ] || rm -f "$temporary_private"
+    [ -z "$temporary_public" ] || rm -f "$temporary_public"
+}
+trap cleanup 0
+trap 'exit 1' HUP INT TERM
+
+[ "$#" -eq 1 ] || fail "expected exactly one domain argument"
+domain=$1
+valid_domain "$domain" || fail "invalid domain '$domain'"
+
+[ -d "$dkimdir" ] || fail "DKIM directory '$dkimdir' does not exist"
+[ -w "$dkimdir" ] || fail "DKIM directory '$dkimdir' is not writable"
+
+rspamadm_path=$(command -v rspamadm 2>/dev/null) || fail "could not find rspamadm in PATH"
+mktemp_path=$(command -v mktemp 2>/dev/null) || fail "could not find mktemp in PATH"
+
+private_key="${dkimdir%/}/${domain}.${selector}.private"
+public_record="${dkimdir%/}/${domain}.${selector}.txt"
+
+if [ -e "$private_key" ] || [ -L "$private_key" ] ||
+    [ -e "$public_record" ] || [ -L "$public_record" ]; then
+    fail "DKIM files already exist for domain '$domain' and selector '$selector'"
+fi
+
+umask 077
+temporary_private=$("$mktemp_path" "${dkimdir%/}/.${domain}.${selector}.private.XXXXXX") ||
+    fail "could not create a temporary private-key file"
+temporary_public=$("$mktemp_path" "${dkimdir%/}/.${domain}.${selector}.txt.XXXXXX") ||
+    fail "could not create a temporary public-record file"
+
+if ! "$rspamadm_path" dkim_keygen -k "$temporary_private" -b "$key_bits" \
+    -s "$selector" -d "$domain" > "$temporary_public"; then
+    fail "rspamadm could not generate DKIM keys for '$domain'"
+fi
+
+[ -s "$temporary_private" ] || fail "rspamadm produced an empty private key"
+[ -s "$temporary_public" ] || fail "rspamadm produced an empty public record"
+chmod 600 "$temporary_private" || fail "could not protect the private key"
+chmod 644 "$temporary_public" || fail "could not set public-record permissions"
+
+# Hard links publish both files without overwriting an existing key created by
+# another concurrent invocation. The temporary files are on the same filesystem.
+if ! ln "$temporary_private" "$private_key"; then
+    fail "could not publish private key '$private_key'"
+fi
+if ! ln "$temporary_public" "$public_record"; then
+    rm -f "$private_key"
+    fail "could not publish public record '$public_record'"
+fi
+
+rm -f "$temporary_private" "$temporary_public"
+temporary_private=
+temporary_public=
+trap - 0 HUP INT TERM
+
+printf '%s\n' "$0: generated DKIM files for '$domain':"
+printf '  %s\n  %s\n' "$private_key" "$public_record"
+exit 0

--- a/ADDITIONS/postfixadmin-rspamd-dkim-postdeletion.sh
+++ b/ADDITIONS/postfixadmin-rspamd-dkim-postdeletion.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+# Optional Rspamd DKIM deletion helper. It moves all selector files belonging
+# to a domain into a Rspamd-owned recovery directory. Run it as the Rspamd
+# service account, never as root.
+
+# Adjust these values for the local Rspamd installation.
+dkimdir=/var/db/rspamd/dkim
+trashbase=/var/db/rspamd/deleted-dkim
+
+fail()
+{
+    printf '%s\n' "$0: $*" >&2
+    exit 1
+}
+
+valid_domain()
+{
+    candidate=$1
+
+    [ -n "$candidate" ] && [ "${#candidate}" -le 253 ] || return 1
+    case "$candidate" in
+        -*|.*|*.|*..*|*/*|*\\*|*[!A-Za-z0-9.-]*) return 1 ;;
+    esac
+
+    remainder=$candidate
+    while :; do
+        case "$remainder" in
+            *.*)
+                label=${remainder%%.*}
+                remainder=${remainder#*.}
+                ;;
+            *)
+                label=$remainder
+                remainder=
+                ;;
+        esac
+
+        [ -n "$label" ] && [ "${#label}" -le 63 ] || return 1
+        case "$label" in
+            -*|*-) return 1 ;;
+        esac
+        [ -n "$remainder" ] || break
+    done
+}
+
+[ "$#" -eq 1 ] || fail "expected exactly one domain argument"
+domain=$1
+valid_domain "$domain" || fail "invalid domain '$domain'"
+
+[ -d "$dkimdir" ] || fail "DKIM directory '$dkimdir' does not exist"
+[ -d "$trashbase" ] || fail "DKIM trash directory '$trashbase' does not exist"
+[ -w "$dkimdir" ] || fail "DKIM directory '$dkimdir' is not writable"
+[ -w "$trashbase" ] || fail "DKIM trash directory '$trashbase' is not writable"
+
+timestamp=$(date '+%Y%m%dT%H%M%S') || fail "could not generate a timestamp"
+trashdir="${trashbase%/}/${timestamp}_$$_${domain}"
+found=false
+status=0
+
+umask 077
+for keyfile in "${dkimdir%/}/${domain}".*; do
+    if [ ! -e "$keyfile" ] && [ ! -L "$keyfile" ]; then
+        continue
+    fi
+    found=true
+
+    if [ -L "$keyfile" ] || [ ! -f "$keyfile" ]; then
+        printf '%s\n' "$0: refusing non-regular DKIM entry '$keyfile'" >&2
+        status=1
+        continue
+    fi
+
+    if [ ! -d "$trashdir" ] && ! mkdir "$trashdir"; then
+        fail "could not create DKIM recovery directory '$trashdir'"
+    fi
+    if ! mv "$keyfile" "$trashdir/"; then
+        printf '%s\n' "$0: could not move '$keyfile' to '$trashdir'" >&2
+        status=1
+    fi
+done
+
+if [ "$found" = false ]; then
+    printf '%s\n' "$0: no DKIM files exist for '$domain'; nothing to do."
+    exit 0
+fi
+
+if [ "$status" -ne 0 ]; then
+    fail "one or more DKIM files could not be moved"
+fi
+
+printf '%s\n' "$0: moved DKIM files for '$domain' to '$trashdir'."
+exit 0

--- a/DOCUMENTS/RSPAMD-DKIM-HOOKS.md
+++ b/DOCUMENTS/RSPAMD-DKIM-HOOKS.md
@@ -1,0 +1,126 @@
+# Optional Rspamd DKIM hooks
+
+PostfixAdmin can invoke scripts after creating or deleting a domain. The
+scripts in this guide add optional per-domain Rspamd DKIM key management while
+keeping the generic Maildir hooks independent of Rspamd.
+
+These examples intentionally separate privileges:
+
+* the virtual-mail user owns and moves Maildirs;
+* the Rspamd service user owns and moves DKIM keys;
+* neither account receives permission to run commands as root.
+
+The example paths and account names must be reviewed for each operating
+system. In particular, `_rspamd`, `/var/db/rspamd` and `/usr/bin/sudo` are not
+portable defaults.
+
+## Included scripts
+
+`ADDITIONS/postfixadmin-rspamd-dkim-postcreation.sh`
+: Generates a private key and DNS record without overwriting existing files.
+  Run it as the Rspamd service user.
+
+`ADDITIONS/postfixadmin-rspamd-dkim-postdeletion.sh`
+: Moves every selector file for a domain into an Rspamd-owned recovery
+  directory. Run it as the Rspamd service user.
+
+`ADDITIONS/postfixadmin-domain-postdeletion-with-rspamd.sh`
+: Runs the generic Maildir deletion hook as the current virtual-mail user and
+  delegates DKIM cleanup to the Rspamd helper.
+
+All deletion operations are idempotent. Missing Maildirs or DKIM files are
+successful no-ops, which allows an interrupted domain hook to be retried.
+
+## Installation
+
+The scripts executed through sudo must be installed outside the web root in a
+root-owned directory that is not writable by the web server, virtual-mail or
+Rspamd accounts. For example:
+
+```text
+/usr/local/libexec/postfixadmin/
+```
+
+Create the runtime directories once as an administrator. Example commands for
+a system whose Rspamd account is `_rspamd` are:
+
+```console
+install -d -o _rspamd -g _rspamd -m 0700 /var/db/rspamd/dkim
+install -d -o _rspamd -g _rspamd -m 0700 /var/db/rspamd/deleted-dkim
+install -d -o vmail -g vmail -m 0700 /var/vmail/deleted-maildirs
+```
+
+Review the constants at the beginning of every script. A `/var/vmail` layout,
+for example, requires changing `basedir` in the generic Maildir scripts. On a
+system where sudo is `/usr/local/bin/sudo`, update `sudo_path` in the composite
+hook.
+
+The creation helper stores the private key as mode `0600` and the DNS record
+as mode `0644`. It writes temporary files in the DKIM directory and publishes
+them without replacing an existing key. The `.txt` file contains the standard
+zone-record output produced by `rspamadm dkim_keygen`.
+
+## PostfixAdmin configuration
+
+For an installation using Apache, `vmail` and `_rspamd`, the relevant
+`config.local.php` settings can look like:
+
+```php
+$CONF['domain_postcreation_script'] =
+    '/usr/bin/sudo -n -u _rspamd -- /usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postcreation.sh';
+
+$CONF['domain_postdeletion_script'] =
+    '/usr/bin/sudo -n -u vmail -- /usr/local/libexec/postfixadmin/postfixadmin-domain-postdeletion-with-rspamd.sh';
+
+$CONF['mailbox_postdeletion_script'] =
+    '/usr/bin/sudo -n -u vmail -- /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postdeletion.sh';
+```
+
+The `-n` option makes a sudo configuration error fail immediately instead of
+waiting for an interactive password prompt.
+
+An installation without Rspamd should configure the generic
+`postfixadmin-domain-postdeletion.sh` directly and does not need any of the
+Rspamd helpers.
+
+## Sudoers example
+
+Use `visudo` to edit and validate the rules. Restrict both the target account
+and executable path:
+
+```sudoers
+apache ALL=(_rspamd) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postcreation.sh
+apache ALL=(vmail) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-domain-postdeletion-with-rspamd.sh
+apache ALL=(vmail) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postdeletion.sh
+vmail ALL=(_rspamd) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postdeletion.sh
+```
+
+Do not use `(ALL)` as the run-as account and never grant a service account
+permission to run a general-purpose command such as `/usr/bin/mv`. A rule that
+names a command without arguments permits arbitrary arguments, so every helper
+must retain its own strict validation even when sudoers also constrains the
+command.
+
+After installation, verify ownership and permissions on every script and all
+parent directories. A script writable by `apache`, `vmail` or `_rspamd` must
+not be referenced by sudoers.
+
+## Recovery and operations
+
+Maildirs and DKIM keys use separate recovery locations because they have
+different owners and sensitivity:
+
+```text
+/var/vmail/deleted-maildirs/
+/var/db/rspamd/deleted-dkim/
+```
+
+The composite hook attempts both operations even if one fails, then returns a
+failure status if either helper reported a real error. PostfixAdmin can report
+that failure, and an administrator can safely rerun the hook after correcting
+permissions or storage problems.
+
+Before enabling the hooks in production, test creation, deletion, repeated
+deletion and restoration with a non-production domain. Also confirm the local
+`rspamadm dkim_keygen` output and publish the generated DNS record before
+enabling DKIM signing for the domain.

--- a/DOCUMENTS/RSPAMD-DKIM-HOOKS.md
+++ b/DOCUMENTS/RSPAMD-DKIM-HOOKS.md
@@ -95,6 +95,22 @@ apache ALL=(vmail) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbo
 vmail ALL=(_rspamd) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postdeletion.sh
 ```
 
+These Rspamd rules are part of the same sudoers policy as the generic hook
+rules; they are not an independent replacement for every base permission. For
+an installation that enables the Rspamd composite hook:
+
+* retain the generic mailbox-creation or mailbox-deletion rules for each hook
+  still enabled in `config.local.php`;
+* replace the web-server rule for the generic domain-deletion script with the
+  rule for `postfixadmin-domain-postdeletion-with-rspamd.sh`;
+* add the web-server rule for DKIM creation and the narrowly scoped
+  `vmail`-to-Rspamd rule for DKIM deletion;
+* retain a separate Dovecot-targeted rule if the mailbox-password hook is
+  enabled.
+
+Do not keep both direct and composite domain-deletion rules unless both are
+deliberately used by separate administrative workflows.
+
 Do not use `(ALL)` as the run-as account and never grant a service account
 permission to run a general-purpose command such as `/usr/bin/mv`. A rule that
 names a command without arguments permits arbitrary arguments, so every helper


### PR DESCRIPTION
## What changed

- Adds optional Rspamd DKIM post-creation and post-deletion hook examples to the `postfixadmin_4.0` branch.
- Adds a narrow composite domain-deletion wrapper so the mail domain and its DKIM material can be archived together.
- Documents the related `config.local.php` and least-privilege `sudoers` configuration.
- Clarifies that the `sudoers` rules apply across all enabled base and Rspamd hooks.

## Why

This carries the optional Rspamd integration previously merged into master to the maintained 4.x branch, following the invitation in #1080. The examples remain disabled unless an administrator explicitly configures them.

## Impact

No default behavior changes. Administrators using Rspamd gain documented, hardened examples that avoid broad `sudo mv` permissions and validate hook input before touching filesystem paths.

## Validation

- `sh -n` for all three added scripts
- ShellCheck-compatible style checks
- `git diff --check origin/postfixadmin_4.0..HEAD`
- Patch series `19` then `20` verified with GNU `patch -p1 --dry-run`
- Applied patch tree compared exactly with the branch commits
