### PR TITLE
Clarify sudoers rules across optional hook sets

### DIFF
--- a/ADDITIONS/README.md
+++ b/ADDITIONS/README.md
@@ -66,6 +66,26 @@ grant the web server permission to run only the exact script as that account;
 never grant access to a generic `mv` command. Install privileged hooks in a
 root-owned directory that is not writable by the web server or mail users.
 
+### Sudoers applies to every enabled hook
+
+Sudoers is not specific to the optional Rspamd integration. Every hook enabled
+in `config.local.php` that is invoked through sudo needs its own rule with the
+exact target account and installed script path. For example, after replacing
+the account names and paths to match the local system:
+
+```sudoers
+apache ALL=(courier) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postcreation.sh
+apache ALL=(courier) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postdeletion.sh
+apache ALL=(courier) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-domain-postdeletion.sh
+apache ALL=(dovecot) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbox-postpassword.sh
+```
+
+Only add rules for hooks that are actually configured. If the optional Rspamd
+hooks are installed, their rules extend this base policy. The composite Rspamd
+domain-deletion hook replaces the direct domain-deletion rule; unrelated
+mailbox and Dovecot rules remain in effect. See
+`DOCUMENTS/RSPAMD-DKIM-HOOKS.md` for the complete mapping.
+
 The scripts validate the argument contracts documented in `config.inc.php`.
 Deletion is idempotent: an already absent Maildir is reported as a successful
 no-op so an interrupted hook can be retried safely.

--- a/DOCUMENTS/RSPAMD-DKIM-HOOKS.md
+++ b/DOCUMENTS/RSPAMD-DKIM-HOOKS.md
@@ -95,6 +95,22 @@ apache ALL=(vmail) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-mailbo
 vmail ALL=(_rspamd) NOPASSWD: /usr/local/libexec/postfixadmin/postfixadmin-rspamd-dkim-postdeletion.sh
 ```
 
+These Rspamd rules are part of the same sudoers policy as the generic hook
+rules; they are not an independent replacement for every base permission. For
+an installation that enables the Rspamd composite hook:
+
+* retain the generic mailbox-creation or mailbox-deletion rules for each hook
+  still enabled in `config.local.php`;
+* replace the web-server rule for the generic domain-deletion script with the
+  rule for `postfixadmin-domain-postdeletion-with-rspamd.sh`;
+* add the web-server rule for DKIM creation and the narrowly scoped
+  `vmail`-to-Rspamd rule for DKIM deletion;
+* retain a separate Dovecot-targeted rule if the mailbox-password hook is
+  enabled.
+
+Do not keep both direct and composite domain-deletion rules unless both are
+deliberately used by separate administrative workflows.
+
 Do not use `(ALL)` as the run-as account and never grant a service account
 permission to run a general-purpose command such as `/usr/bin/mv`. A rule that
 names a command without arguments permits arbitrary arguments, so every helper


### PR DESCRIPTION
## What changed

- Clarifies that the documented `sudoers` policy applies to every enabled PostfixAdmin hook, not only to the optional Rspamd integration.
- Explains which generic rules remain in place and when the composite Rspamd domain-deletion rule replaces the direct domain-deletion rule.

## Why

The Rspamd examples could be read as a complete replacement for the base hook permissions. The new wording makes the relationship between both sets explicit and keeps least-privilege guidance intact.

## Impact

Documentation only. Existing installations are unaffected.

Follow-up to #1079.

## Validation

- `git diff --check origin/master..HEAD`
- Generated patch verified with GNU `patch -p1 --dry-run`
- Applied patch tree compared exactly with the branch commit
