### PR TITLE
Preserve anonymous login sessions across repeated GETs

### DIFF
--- a/public/login.php
+++ b/public/login.php
@@ -98,7 +98,9 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         error_log("PostfixAdmin admin login failed (username: $fUsername, ip_address: {$_SERVER['REMOTE_ADDR']})");
         flash_error($PALANG['pLogin_failed']);
     }
-} else {
+} elseif (isset($_SESSION['sessid'])) {
+    // Preserve anonymous sessions so multiple login forms keep their CSRF tokens.
+    // An existing authenticated session should still be cleared before login.
     session_unset();
     session_destroy();
     session_start();


### PR DESCRIPTION
## Summary

- keep anonymous login sessions intact across repeated `GET /login.php` requests;
- preserve the existing behavior that clears an authenticated session before showing the login form;
- avoid emitting two divergent session cookies on the initial cookieless request;
- allow the existing multi-token `CsrfToken` implementation to keep parallel or prefetched login forms valid.

This addresses the `master` part of #1084. It deliberately does not close the issue yet because the `postfixadmin_4.0` branch needs a separate follow-up.

## PostfixAdmin 4.x follow-up

The 4.x correction will be prepared separately and requires two coordinated changes:

1. avoid destroying and restarting an anonymous session while rendering the login form;
2. stop replacing the single `PFA_token` on every GET, or backport the multi-token behavior from `master`.

That follow-up will be submitted separately so the branch-specific session and token behavior can be reviewed and tested independently.

## Validation

- PHP 8.4 syntax check passes for `public/login.php`.
- The initial cookieless GET emits one `postfixadmin_session` cookie instead of two divergent cookies.
- Two GET requests in the same anonymous session generate distinct CSRF tokens.
- The first token remains valid when submitted after the second GET; the request reaches authentication instead of the expired-session handler.

