### PR TITLE
Avoid restarting anonymous login sessions on 4.x

### DIFF
--- a/public/login.php
+++ b/public/login.php
@@ -101,7 +101,9 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         error_log("PostfixAdmin admin login failed (username: $fUsername, ip_address: {$_SERVER['REMOTE_ADDR']})");
         flash_error($PALANG['pLogin_failed']);
     }
-} else {
+} elseif (isset($_SESSION['sessid'])) {
+    // Do not restart anonymous sessions while rendering the login form.
+    // An existing authenticated session should still be cleared before login.
     session_unset();
     session_destroy();
     session_start();


### PR DESCRIPTION
## Summary

- keep anonymous sessions intact while rendering `GET /login.php`;
- avoid the second session lifecycle and the two divergent session cookies emitted on an initial cookieless request;
- preserve the existing behavior that clears an authenticated session before showing the login form.

This is the first of two branch-specific changes for the `postfixadmin_4.0` part of #1084. It intentionally leaves the legacy single-token behavior unchanged so the session lifecycle and token policy can be reviewed independently.

## Follow-up

The second part is available as #1087. It addresses the remaining 4.x behavior: `PFA_token` is replaced on every GET, so another login-page request can invalidate an earlier form.

PR #1087 is stacked on this PR. Until this first part is merged, GitHub will show both commits there; afterward its diff will reduce to the token-policy change only.

## Validation

- PHP 8.4 syntax check passes for `public/login.php`.
- The initial cookieless GET emits one `postfixadmin_session` cookie instead of two divergent cookies.
- A second GET in the same anonymous session emits no replacement session cookie.
- The test confirms that the legacy token is still replaced and the earlier token still receives HTTP 419, documenting that part 2 remains necessary.
