### PR TITLE
Keep 4.x login CSRF token stable across repeated GETs

### DIFF
--- a/public/login.php
+++ b/public/login.php
@@ -109,7 +109,10 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
     session_start();
 }
 
-$_SESSION['PFA_token'] = md5(uniqid("pfa" . rand(), true));
+if (empty($_SESSION['PFA_token'])) {
+    // Keep the login token stable across repeated GETs in this session.
+    $_SESSION['PFA_token'] = md5(uniqid("pfa" . rand(), true));
+}
 
 $smarty->assign('language_selector', language_selector(), false);
 $smarty->assign('smarty_template', 'login');

--- a/public/login.php
+++ b/public/login.php
@@ -101,7 +101,9 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         error_log("PostfixAdmin admin login failed (username: $fUsername, ip_address: {$_SERVER['REMOTE_ADDR']})");
         flash_error($PALANG['pLogin_failed']);
     }
-} else {
+} elseif (isset($_SESSION['sessid'])) {
+    // Do not restart anonymous sessions while rendering the login form.
+    // An existing authenticated session should still be cleared before login.
     session_unset();
     session_destroy();
     session_start();


### PR DESCRIPTION
## Dependency

This is the second 4.x part of #1084 and is stacked on #1086. Until #1086 is merged, GitHub will show both commits in this PR; afterward this PR will reduce to the token-policy change only.

## Summary

- generate the legacy `PFA_token` only when the anonymous session does not already contain one;
- keep the login token stable across repeated, prefetched, or parallel GET requests;
- allow a form rendered by the first GET to remain valid after a second GET in the same session.

Together with #1086, this completes the `postfixadmin_4.0` correction for #1084: the first PR fixes the anonymous session lifecycle, while this PR fixes the single-token replacement behavior.

## Validation

- PHP 8.4 syntax check passes for `public/login.php`.
- The initial cookieless GET emits one `postfixadmin_session` cookie.
- A second GET in the same anonymous session emits no replacement session cookie.
- Both GET requests render the same valid `PFA_token`.
- Submitting the first form after the second GET reaches authentication with HTTP 200 instead of the expired-session HTTP 419 response.

