### PR TITLE
Reconcile 3.3 MySQL upgrades on 4.x

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -16,7 +16,7 @@
  */
 
 
-$min_db_version = 1851;  # update (at least) before a release with the latest function number in upgrade.php
+$min_db_version = 1852;  # update (at least) before a release with the latest function number in upgrade.php
 
 
 /**

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2412,3 +2412,34 @@ function upgrade_1851_mysql()
         )
     ");
 }
+
+/**
+ * Reconcile MySQL schemas upgraded through the PostfixAdmin 3.3 branch.
+ *
+ * PostfixAdmin 3.3 used upgrade_1847_mysql() to widen quota2.username to
+ * varchar(255). A later upgrade to 4.x therefore skips the more complete
+ * upgrade_1846_mysql() in this branch because the recorded database version
+ * is already 1847. The widened quota2 column is used as the marker for that
+ * upgrade path; a direct 4.x upgrade leaves it at varchar(100).
+ *
+ * See https://github.com/postfixadmin/postfixadmin/issues/971
+ */
+function upgrade_1852_mysql()
+{
+    $quota2 = table_by_key('quota2');
+    $column = db_query_one(
+        "SELECT CHARACTER_MAXIMUM_LENGTH AS character_maximum_length
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = :table
+          AND COLUMN_NAME = 'username'",
+        ['table' => trim($quota2, '`')]
+    );
+
+    $column_length = (int) (array_values($column ?? [])[0] ?? 0);
+    if ($column_length !== 255) {
+        return;
+    }
+
+    upgrade_1846_mysql();
+}

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -61,6 +61,23 @@ function _mysql_field_exists($table, $field)
     return !empty($r);
 }
 
+function _mysql_foreign_key_exists($table, $constraint)
+{
+    $sql = "
+        SELECT CONSTRAINT_NAME
+        FROM information_schema.TABLE_CONSTRAINTS
+        WHERE CONSTRAINT_SCHEMA = DATABASE()
+          AND TABLE_NAME = :table
+          AND CONSTRAINT_NAME = :constraint
+          AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    ";
+    $r = db_query_one($sql, [
+        'table' => trim($table, '`'),
+        'constraint' => $constraint,
+    ]);
+    return !empty($r);
+}
+
 function _sqlite_field_exists($table, $field)
 {
     $sql = "PRAGMA table_info($table)";
@@ -2127,9 +2144,10 @@ function upgrade_1846_mysql()
 
     db_query("ALTER TABLE $quota MODIFY username varchar(255) COLLATE latin1_general_ci NOT NULL");
     db_query("ALTER TABLE $quota MODIFY path varchar(100) COLLATE latin1_general_ci NOT NULL");
-    db_query("ALTER TABLE $quota2 MODIFY username varchar(100) COLLATE latin1_general_ci NOT NULL");
 
-    db_query("ALTER TABLE $vacation_notification DROP FOREIGN KEY vacation_notification_pkey");
+    if (_mysql_foreign_key_exists($vacation_notification, 'vacation_notification_pkey')) {
+        db_query("ALTER TABLE $vacation_notification DROP FOREIGN KEY vacation_notification_pkey");
+    }
 
     db_query("ALTER TABLE $vacation MODIFY domain varchar(255)  COLLATE latin1_general_ci NOT NULL");
     db_query("ALTER TABLE $vacation MODIFY email varchar(255)  COLLATE latin1_general_ci NOT NULL");
@@ -2147,10 +2165,16 @@ function upgrade_1846_mysql()
     db_query("ALTER TABLE $vacation_notification MODIFY notified VARCHAR(255) COLLATE latin1_general_ci NOT NULL DEFAULT ''");
 
 
-    db_query("ALTER TABLE $vacation_notification ADD CONSTRAINT vacation_notification_pkey FOREIGN KEY (`on_vacation`) REFERENCES $vacation(email) ON DELETE CASCADE");
+    if (!_mysql_foreign_key_exists($vacation_notification, 'vacation_notification_pkey')) {
+        db_query("ALTER TABLE $vacation_notification ADD CONSTRAINT vacation_notification_pkey FOREIGN KEY (`on_vacation`) REFERENCES $vacation(email) ON DELETE CASCADE");
+    }
 
     db_query("ALTER TABLE $domain_admins MODIFY `domain` varchar(255) COLLATE latin1_general_ci NOT NULL");
     db_query("ALTER TABLE $domain_admins MODIFY username varchar(255) COLLATE latin1_general_ci NOT NULL");
+
+    // Keep the 3.3-path marker until every other reconciliation statement has
+    // succeeded, so an interrupted upgrade_1852_mysql() remains retryable.
+    db_query("ALTER TABLE $quota2 MODIFY username varchar(100) COLLATE latin1_general_ci NOT NULL");
 }
 
 function upgrade_1847()

--- a/tests/DatabaseUpgradeTest.php
+++ b/tests/DatabaseUpgradeTest.php
@@ -1,0 +1,123 @@
+<?php
+
+class DatabaseUpgradeTest extends \PHPUnit\Framework\TestCase
+{
+    private $orphan;
+    private $quota2;
+    private $vacation;
+    private $vacation_notification;
+
+    public function setUp(): void
+    {
+        if (!db_mysql()) {
+            $this->markTestSkipped('MySQL/MariaDB-specific migration test');
+        }
+
+        $this->orphan = 'upgrade-retry-' . uniqid() . '@example.invalid';
+        $this->quota2 = table_by_key('quota2');
+        $this->vacation = table_by_key('vacation');
+        $this->vacation_notification = table_by_key('vacation_notification');
+
+        $this->removeOrphan();
+        $this->ensureForeignKeyExists();
+    }
+
+    public function tearDown(): void
+    {
+        if (!db_mysql()) {
+            return;
+        }
+
+        $this->removeOrphan();
+        $this->ensureForeignKeyExists();
+        db_query("ALTER TABLE $this->quota2 MODIFY username varchar(100) COLLATE latin1_general_ci NOT NULL");
+    }
+
+    public function testReconcilesSchemaWhenForeignKeyExists(): void
+    {
+        db_query("ALTER TABLE $this->quota2 MODIFY username varchar(255) COLLATE latin1_general_ci NOT NULL");
+
+        upgrade_1852_mysql();
+
+        $this->assertTrue(
+            _mysql_foreign_key_exists($this->vacation_notification, 'vacation_notification_pkey')
+        );
+        $this->assertSame(100, $this->quota2UsernameLength());
+    }
+
+    public function testLeavesAlreadyCorrectSchemaUntouched(): void
+    {
+        $before = db_query_one("SHOW CREATE TABLE $this->vacation_notification");
+
+        upgrade_1852_mysql();
+
+        $this->assertSame($before, db_query_one("SHOW CREATE TABLE $this->vacation_notification"));
+        $this->assertSame(100, $this->quota2UsernameLength());
+    }
+
+    public function testRetriesReconciliationAfterForeignKeyFailure(): void
+    {
+        db_query("ALTER TABLE $this->vacation_notification DROP FOREIGN KEY vacation_notification_pkey");
+        db_query("ALTER TABLE $this->quota2 MODIFY username varchar(255) COLLATE latin1_general_ci NOT NULL");
+        db_query(
+            "INSERT INTO $this->vacation_notification (on_vacation, notified) VALUES (:on_vacation, :notified)",
+            [
+                'on_vacation' => $this->orphan,
+                'notified' => $this->orphan,
+            ]
+        );
+
+        try {
+            upgrade_1852_mysql();
+            $this->fail('The orphaned notification should prevent the foreign key from being restored');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('vacation_notification_pkey', $e->getMessage());
+        }
+
+        $this->assertFalse(
+            _mysql_foreign_key_exists($this->vacation_notification, 'vacation_notification_pkey')
+        );
+        $this->assertSame(255, $this->quota2UsernameLength());
+
+        $this->removeOrphan();
+        upgrade_1852_mysql();
+
+        $this->assertTrue(
+            _mysql_foreign_key_exists($this->vacation_notification, 'vacation_notification_pkey')
+        );
+        $this->assertSame(100, $this->quota2UsernameLength());
+    }
+
+    private function ensureForeignKeyExists(): void
+    {
+        if (!_mysql_foreign_key_exists($this->vacation_notification, 'vacation_notification_pkey')) {
+            db_query(
+                "ALTER TABLE $this->vacation_notification
+                ADD CONSTRAINT vacation_notification_pkey
+                FOREIGN KEY (`on_vacation`) REFERENCES $this->vacation(email) ON DELETE CASCADE"
+            );
+        }
+    }
+
+    private function removeOrphan(): void
+    {
+        db_query(
+            "DELETE FROM $this->vacation_notification WHERE on_vacation = :on_vacation",
+            ['on_vacation' => $this->orphan]
+        );
+    }
+
+    private function quota2UsernameLength(): int
+    {
+        $column = db_query_one(
+            "SELECT CHARACTER_MAXIMUM_LENGTH AS character_maximum_length
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = :table
+              AND COLUMN_NAME = 'username'",
+            ['table' => trim($this->quota2, '`')]
+        );
+
+        return (int) (array_values($column ?? [])[0] ?? 0);
+    }
+}


### PR DESCRIPTION
## Summary

- add `upgrade_1852_mysql()` to reconcile MySQL/MariaDB schemas that previously passed through the PostfixAdmin 3.3 upgrade path
- use `quota2.username = varchar(255)` as the marker for that path and replay the complete `upgrade_1846_mysql()` only when needed
- bump the minimum database version to 1852 for the next 4.x release

## Root cause

The 3.3 branch contains a partial `upgrade_1846_mysql()` and then records database version 1847 after widening `quota2.username`. When that database is later upgraded to 4.x, the more complete 4.x implementation of migration 1846 is skipped because the recorded version is already higher.

For a direct 4.x installation, `quota2.username` is already `varchar(100)`. In that case the new migration does not alter the schema and only advances the recorded database version.

Addresses #971.

## Validation

- PHP 8.4 syntax and parallel lint checks
- PHP-CS-Fixer dry run
- MariaDB 10.4 integration test reproducing the affected schema at database version 1851
- verified `quota2.username` normalization from `varchar(255)` to `varchar(100)`
- verified all affected column and table collations match a clean 4.x reference schema
- verified `vacation_notification_pkey` remains present
- verified the already-correct `varchar(100)` path is a schema no-op

