### PR TITLE
Reconcile 3.3 MySQL upgrades on master

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -16,7 +16,7 @@
  */
 
 
-$min_db_version = 1851;  # update (at least) before a release with the latest function number in upgrade.php
+$min_db_version = 1855;  # update (at least) before a release with the latest function number in upgrade.php
 
 
 /**

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -2251,3 +2251,34 @@ function upgrade_1854()
     # add description after 'target_domain' field in alias_domain table
     _db_add_field('alias_domain', 'description', "varchar(255) {UTF-8} NOT NULL DEFAULT ''", 'target_domain');
 }
+
+/**
+ * Reconcile MySQL schemas upgraded through the PostfixAdmin 3.3 branch.
+ *
+ * PostfixAdmin 3.3 used upgrade_1847_mysql() to widen quota2.username to
+ * varchar(255). A later upgrade to master therefore skips the more complete
+ * upgrade_1846_mysql() in this branch because the recorded database version
+ * is already 1847. The widened quota2 column is used as the marker for that
+ * upgrade path; a direct master upgrade leaves it at varchar(100).
+ *
+ * See https://github.com/postfixadmin/postfixadmin/issues/971
+ */
+function upgrade_1855_mysql()
+{
+    $quota2 = table_by_key('quota2');
+    $column = db_query_one(
+        "SELECT CHARACTER_MAXIMUM_LENGTH AS character_maximum_length
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = :table
+          AND COLUMN_NAME = 'username'",
+        ['table' => trim($quota2, '`')]
+    );
+
+    $column_length = (int) (array_values($column ?? [])[0] ?? 0);
+    if ($column_length !== 255) {
+        return;
+    }
+
+    upgrade_1846_mysql();
+}


### PR DESCRIPTION
## Summary

- add `upgrade_1855_mysql()` to reconcile MySQL/MariaDB schemas that previously passed through the PostfixAdmin 3.3 upgrade path
- use `quota2.username = varchar(255)` as the marker for that path and replay the complete `upgrade_1846_mysql()` only when needed
- bump the minimum database version to 1855

## Root cause

The 3.3 branch contains a partial `upgrade_1846_mysql()` and then records database version 1847 after widening `quota2.username`. When that database is later upgraded to master, the more complete implementation of migration 1846 is skipped because the recorded version is already higher.

For a database upgraded directly by master, `quota2.username` is already `varchar(100)`. In that case the new migration does not alter the schema and only advances the recorded database version.

Addresses #971.

## Validation

- PHP 8.4 syntax and parallel lint checks
- PHP-CS-Fixer dry run
- MariaDB 10.4 integration test reproducing the affected schema at database version 1854
- verified `quota2.username` normalization from `varchar(255)` to `varchar(100)`
- verified all affected column and table collations match a clean master reference schema
- verified `vacation_notification_pkey` remains present

