### PR TITLE
Add reusable _pagination.tpl partial, use it in viewlog (#1064)

### DIFF
--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -227,6 +227,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Дата';
 $PALANG['pViewlog_action'] = 'Действие';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Данни';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -225,6 +225,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acció';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Dades';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -226,6 +226,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = '时间';
 $PALANG['pViewlog_action'] = '操作';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = '内容';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -236,6 +236,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Časová značka';
 $PALANG['pViewlog_action'] = 'Akce';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Poznámka';
 $PALANG['pViewlog_action_create_domain'] = 'vytvoření domény';
 $PALANG['pViewlog_action_delete_domain'] = 'smazání domény';

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -233,6 +233,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tidsstempel';
 $PALANG['pViewlog_action'] = 'Handling';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Data';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -230,6 +230,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Zeitpunkt';
 $PALANG['pViewlog_action'] = 'Aktion';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Daten';
 
 $PALANG['pViewlog_action_create_domain'] = 'Domain erstellen';

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -284,6 +284,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Timestamp';
 $PALANG['pViewlog_action'] = 'Action';
+$PALANG['pViewlog_pagination'] = 'Log pages';
 $PALANG['pViewlog_data'] = 'Data';
 
 $PALANG['pViewlog_action_add_totp_exception'] = 'Add TOTP exception';

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -227,6 +227,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Fecha/Hora';
 $PALANG['pViewlog_action'] = 'Acción';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Datos';
 $PALANG['pViewlog_action_create_domain'] = 'crear dominio';
 $PALANG['pViewlog_action_delete_domain'] = 'borrar dominio';

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -226,6 +226,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Ajatempel';
 $PALANG['pViewlog_action'] = 'Toiming';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Andmed';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -224,6 +224,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/ordua';
 $PALANG['pViewlog_action'] = 'Ekintza';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Datuak';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -226,6 +226,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Aikaleima';
 $PALANG['pViewlog_action'] = 'Tapahtuma';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Tiedot';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -226,6 +226,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tíðarstempul';
 $PALANG['pViewlog_action'] = 'Hending';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Dáta';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -230,6 +230,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Date/Heure';
 $PALANG['pViewlog_action'] = 'Action';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Information';
 $PALANG['pViewlog_action_create_domain'] = 'créer le domaine';
 $PALANG['pViewlog_action_delete_domain'] = 'supprimer le domaine';

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -225,6 +225,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acción';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Datos';
 $PALANG['pViewlog_action_create_domain'] = 'crear domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'borrar domain'; # XXX

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -225,6 +225,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Vrijeme';
 $PALANG['pViewlog_action'] = 'Akcija';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Podaci';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -230,6 +230,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Idõbélyeg';
 $PALANG['pViewlog_action'] = 'Akció';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Adat';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -226,6 +226,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tími';
 $PALANG['pViewlog_action'] = 'aðgerð';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'gögn';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -227,6 +227,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Orario';
 $PALANG['pViewlog_action'] = 'Azione';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Dati';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -230,6 +230,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'タイムスタンプ';
 $PALANG['pViewlog_action'] = 'アクション';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'データ';
 $PALANG['pViewlog_action_create_domain'] = 'ドメインを作成';
 $PALANG['pViewlog_action_delete_domain'] = 'ドメインを削除';

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -227,6 +227,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Laikas';
 $PALANG['pViewlog_action'] = 'Veiksmas';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Duomenys';
 $PALANG['pViewlog_action_create_domain'] = 'sukurta sritis';
 $PALANG['pViewlog_action_delete_domain'] = 'panaikinta sritis';

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -226,6 +226,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Маркер (Timestamp)';
 $PALANG['pViewlog_action'] = 'Операција';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Датум';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -227,6 +227,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Klokkeslett';
 $PALANG['pViewlog_action'] = 'Handling';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Data';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -229,6 +229,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tijd';
 $PALANG['pViewlog_action'] = 'Actie';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Aanpassing';
 $PALANG['pViewlog_action_create_domain'] = 'domein toegevoegd';
 $PALANG['pViewlog_action_delete_domain'] = 'domein verwijderd';

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -225,6 +225,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Klokkeslett';
 $PALANG['pViewlog_action'] = 'Handling';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Data';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -229,6 +229,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data';
 $PALANG['pViewlog_action'] = 'Działanie';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Dane';
 $PALANG['pViewlog_action_create_domain'] = 'utwórz domenę';
 $PALANG['pViewlog_action_delete_domain'] = 'skasuj domenę';

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -232,6 +232,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Ação';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Descrição';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/pt-pt.lang
+++ b/languages/pt-pt.lang
@@ -232,6 +232,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data/Hora';
 $PALANG['pViewlog_action'] = 'Acção';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Descrição';
 $PALANG['pViewlog_action_create_domain'] = 'criar domínio'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'remover domínio'; # XXX

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -230,6 +230,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Data si ora';
 $PALANG['pViewlog_action'] = 'Operatie';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Detalii';
 
 $PALANG['pViewlog_action_create_domain'] = 'creare domeniu';

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -233,6 +233,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Время создания/модификации';
 $PALANG['pViewlog_action'] = 'Действие';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Данные';
 
 $PALANG['pViewlog_action_create_domain'] = 'создание домена';

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -227,6 +227,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Časová značka';
 $PALANG['pViewlog_action'] = 'Akcia';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Podrobnosti';
 $PALANG['pViewlog_action_create_domain'] = 'vytvorenie domény';
 $PALANG['pViewlog_action_delete_domain'] = 'zrušenie domény';

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -226,6 +226,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Čas';
 $PALANG['pViewlog_action'] = 'Operacija';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Podatki';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -231,6 +231,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Tidpunkt';
 $PALANG['pViewlog_action'] = 'Åtgärd';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Data';
 
 $PALANG['pViewlog_action_create_domain'] = 'skapa domän';

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -226,6 +226,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Timestamp'; # XXX
 $PALANG['pViewlog_action'] = 'Hareket';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Veri';
 $PALANG['pViewlog_action_create_domain'] = 'domain oluştur';
 $PALANG['pViewlog_action_delete_domain'] = 'domain sil';

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -228,6 +228,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = '時間';
 $PALANG['pViewlog_action'] = '操作';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = '內容';
 $PALANG['pViewlog_action_create_domain'] = 'create domain'; # XXX
 $PALANG['pViewlog_action_delete_domain'] = 'delete domain'; # XXX

--- a/languages/ua.lang
+++ b/languages/ua.lang
@@ -232,6 +232,7 @@ $PALANG['pViewlog_all_domains'] = 'All domains';
 $PALANG['pViewlog_per_page'] = 'Per page:';
 $PALANG['pViewlog_timestamp'] = 'Час створення/модифікації';
 $PALANG['pViewlog_action'] = 'Дія';
+$PALANG['pViewlog_pagination'] = 'Log pages'; # XXX
 $PALANG['pViewlog_data'] = 'Данні';
 
 $PALANG['pViewlog_action_create_domain'] = 'створення домену';

--- a/public/viewlog.php
+++ b/public/viewlog.php
@@ -139,7 +139,7 @@ if ($error != 1) {
     foreach ($result as $r) {
         $number_of_logs = $r['number_of_logs'];
     }
-    $number_of_pages = ceil($number_of_logs / $page_size);
+    $number_of_pages = (int) ceil($number_of_logs / $page_size);
 
     # An empty result set (no matching log entries) has 0 pages; page 1 should
     # then be accepted (the template simply shows no log rows) rather than throwing.
@@ -147,7 +147,7 @@ if ($error != 1) {
         throw new InvalidArgumentException('Unknown page number');
     }
 
-    $page_window = pagination_window($page_number, (int)$number_of_pages, 5);
+    $page_window = pagination_window($page_number, $number_of_pages, 5);
 
     if ($page_number == 1) {
         $offset = 0;
@@ -180,20 +180,38 @@ foreach ($tLog as $k => $v) {
 //get url
 $url = explode("?", (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]")[0];
 
+# Build the pagination items for the shared _pagination.tpl partial. Each entry
+# is a plain page link (real href, so it works without JavaScript); disabled
+# arrows and the current page render as non-clickable spans.
+$domain_param = $show_all ? $all_domains_value : $fDomain;
+$pagination = array();
+if ($number_of_pages > 1) {
+    $base = $url . '?fDomain=' . urlencode($domain_param) . '&amp;page_size=' . $page_size . '&amp;page=';
+    $on_first = ($page_number <= 1);
+    $on_last  = ($page_number >= $number_of_pages);
+
+    $pagination[] = array('label' => '&laquo;',  'url' => $base . 1,                 'disabled' => $on_first, 'aria' => 'First');
+    $pagination[] = array('label' => '&lsaquo;', 'url' => $base . ($page_number - 1), 'disabled' => $on_first, 'aria' => 'Previous');
+    foreach ($page_window as $p) {
+        if ($p === null) {
+            $pagination[] = array('ellipsis' => true);
+        } else {
+            $pagination[] = array('label' => $p, 'url' => $base . $p, 'active' => ($p == $page_number));
+        }
+    }
+    $pagination[] = array('label' => '&rsaquo;', 'url' => $base . ($page_number + 1), 'disabled' => $on_last, 'aria' => 'Next');
+    $pagination[] = array('label' => '&raquo;',  'url' => $base . $number_of_pages,   'disabled' => $on_last, 'aria' => 'Last');
+}
+
 $smarty->assign('domain_list', $list_domains);
 $smarty->assign('domain_selected', $fDomain);
 $smarty->assign('tLog', $tLog, false);
 $smarty->assign('fDomain', $fDomain);
 $smarty->assign('show_all', $show_all);
 $smarty->assign('all_domains_value', $all_domains_value);
-$smarty->assign('domain_param', $show_all ? $all_domains_value : $fDomain);
 $smarty->assign('page_size', $page_size);
 $smarty->assign('page_size_options', $page_size_options);
-$smarty->assign('page_window', $page_window);
-
-$smarty->assign('number_of_pages', $number_of_pages);
-$smarty->assign('page_number', $page_number);
-$smarty->assign('url', $url);
+$smarty->assign('pagination', $pagination);
 
 $smarty->assign('smarty_template', 'viewlog');
 $smarty->display('index.tpl');

--- a/templates/_pagination.tpl
+++ b/templates/_pagination.tpl
@@ -1,0 +1,29 @@
+{*
+ * Reusable Bootstrap 5 pagination.
+ *
+ * $pagination       - array of items; each item is an array with keys:
+ *                       label    - text/entity to display
+ *                       url      - href (used unless disabled/active/ellipsis)
+ *                       active   - bool, marks the current page
+ *                       disabled - bool, rendered as a non-clickable span
+ *                       ellipsis - bool, rendered as a "..." gap
+ *                       aria     - optional aria-label (for nav arrows)
+ * $pagination_label - optional aria-label for the <nav> (defaults to "Pagination")
+ *}
+{if $pagination}
+    <nav aria-label="{$pagination_label|default:'Pagination'}">
+        <ul class="pagination justify-content-end mb-0">
+            {foreach from=$pagination item=pi}
+                {if $pi.ellipsis|default:false}
+                    <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                {elseif $pi.disabled|default:false}
+                    <li class="page-item disabled"><span class="page-link" aria-hidden="true">{$pi.label}</span></li>
+                {elseif $pi.active|default:false}
+                    <li class="page-item active"><span class="page-link">{$pi.label}</span></li>
+                {else}
+                    <li class="page-item"><a class="page-link" href="{$pi.url}"{if $pi.aria|default:''} aria-label="{$pi.aria}"{/if}>{$pi.label}</a></li>
+                {/if}
+            {/foreach}
+        </ul>
+    </nav>
+{/if}

--- a/templates/_pagination.tpl
+++ b/templates/_pagination.tpl
@@ -15,11 +15,11 @@
         <ul class="pagination justify-content-end mb-0">
             {foreach from=$pagination item=pi}
                 {if $pi.ellipsis|default:false}
-                    <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                    <li class="page-item disabled"><span class="page-link" aria-hidden="true">&hellip;</span></li>
                 {elseif $pi.disabled|default:false}
                     <li class="page-item disabled"><span class="page-link" aria-hidden="true">{$pi.label}</span></li>
                 {elseif $pi.active|default:false}
-                    <li class="page-item active"><span class="page-link">{$pi.label}</span></li>
+                    <li class="page-item active"><span class="page-link" aria-current="page">{$pi.label}</span></li>
                 {else}
                     <li class="page-item"><a class="page-link" href="{$pi.url}"{if $pi.aria|default:''} aria-label="{$pi.aria}"{/if}>{$pi.label}</a></li>
                 {/if}

--- a/templates/viewlog.tpl
+++ b/templates/viewlog.tpl
@@ -47,43 +47,10 @@
             {/foreach}
         </table>
 
-        {if $number_of_pages > 1}
+        {if $pagination}
             <div class="card-footer">
-                <nav aria-label="{$PALANG.pViewlog_action}">
-                    <ul class="pagination justify-content-end mb-0">
-                        {if $page_number <= 1}
-                            <li class="page-item disabled"><span class="page-link" aria-hidden="true">&laquo;</span></li>
-                            <li class="page-item disabled"><span class="page-link" aria-hidden="true">&lsaquo;</span></li>
-                        {else}
-                            <li class="page-item"><a class="page-link" href="#" onclick="go2page(1); return false;" aria-label="First">&laquo;</a></li>
-                            <li class="page-item"><a class="page-link" href="#" onclick="go2page({$page_number-1}); return false;" aria-label="Previous">&lsaquo;</a></li>
-                        {/if}
-                        {foreach from=$page_window item=p}
-                            {if $p}
-                                <li class="page-item{if $p == $page_number} active{/if}">
-                                    <a class="page-link" href="#" onclick="go2page({$p}); return false;">{$p}</a>
-                                </li>
-                            {else}
-                                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
-                            {/if}
-                        {/foreach}
-                        {if $page_number >= $number_of_pages}
-                            <li class="page-item disabled"><span class="page-link" aria-hidden="true">&rsaquo;</span></li>
-                            <li class="page-item disabled"><span class="page-link" aria-hidden="true">&raquo;</span></li>
-                        {else}
-                            <li class="page-item"><a class="page-link" href="#" onclick="go2page({$page_number+1}); return false;" aria-label="Next">&rsaquo;</a></li>
-                            <li class="page-item"><a class="page-link" href="#" onclick="go2page({$number_of_pages}); return false;" aria-label="Last">&raquo;</a></li>
-                        {/if}
-                    </ul>
-                </nav>
+                {include file="_pagination.tpl"}
             </div>
         {/if}
     {/if}
 </div>
-
-<script>
-        function go2page(page){
-                page = Math.max(1, Math.min(page, {$number_of_pages}));
-                window.location.href = '{$url}?page='+page+'&fDomain={$domain_param|escape:"url"}&page_size={$page_size}';
-        }
-</script>

--- a/templates/viewlog.tpl
+++ b/templates/viewlog.tpl
@@ -49,7 +49,7 @@
 
         {if $pagination}
             <div class="card-footer">
-                {include file="_pagination.tpl"}
+                {include file="_pagination.tpl" pagination_label=$PALANG.pViewlog_pagination}
             </div>
         {/if}
     {/if}


### PR DESCRIPTION
First step of #1064 (the step @TrapoSAMA suggested): extract a reusable pagination partial and migrate viewlog to it, leaving the larger `cNav_bar` refactor for follow-up PRs.

## What

- **New `templates/_pagination.tpl`** — a shared Bootstrap 5 `.pagination` component. It renders from a `$pagination` array of items, each `{label, url, active, disabled, ellipsis, aria}`. Disabled arrows and the current page render as non-clickable `<span>`s (accessible); ellipses render as gaps.
- **`viewlog.php`** builds those items (first/prev, ±5 window, next/last) with **real `href`s** and assigns `$pagination`.
- **`viewlog.tpl`** replaces its inline pager markup with `{include file="_pagination.tpl"}`.

## Why it's a small net win already

- The pager now uses real links instead of the `go2page()` JavaScript — works without JS, and the page links are right-clickable / open-in-new-tab. The inline `<script>` is gone.
- No behaviour change to which pages are shown (still uses the existing `pagination_window()` helper and its tests).

## Follow-ups (separate PRs, per #1064)

- Migrate `list-virtual.php`'s `cNav_bar` to the partial (the big one — it also carries the search-threading/`append_to_url` logic, so it needs care).
- Migrate the generic `list.php` page-browser.

## Testing

- Full suite green (120 tests, 1289 assertions) on the SQLite test DB; `pagination_window()` tests unchanged.
- `psalm` (exit 0), `php-cs-fixer` (dry-run), and template `<div>` balance all clean.
- Manual QA of the viewlog pager (arrows, ellipses, disabled states, page-size + domain params carried in the links) recommended on a populated log.
