### PR TITLE
Add a read-only database integrity check

### DIFF
--- a/model/DatabaseIntegrityChecker.php
+++ b/model/DatabaseIntegrityChecker.php
@@ -1,0 +1,108 @@
+<?php
+
+class DatabaseIntegrityChecker
+{
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function check(int $sample_limit = 20): array
+    {
+        $sample_limit = max(1, min(100, $sample_limit));
+        $results = [];
+
+        foreach ($this->relations() as $relation) {
+            $child_table = table_by_key($relation['child_table']);
+            $parent_table = table_by_key($relation['parent_table']);
+            $child_column = $relation['child_column'];
+            $parent_column = $relation['parent_column'];
+
+            $join = " FROM $child_table child_record" .
+                " LEFT JOIN $parent_table parent_record" .
+                " ON child_record.$child_column = parent_record.$parent_column";
+            $where = " WHERE parent_record.$parent_column IS NULL" . $relation['extra_where'];
+
+            $count = db_query_one("SELECT COUNT(*) AS orphan_count$join$where", $relation['params']);
+            $orphan_count = intval($count['orphan_count'] ?? 0);
+            $sample_values = [];
+
+            if ($orphan_count > 0) {
+                $rows = db_query_all(
+                    "SELECT DISTINCT child_record.$child_column AS orphan_value" .
+                    "$join$where ORDER BY child_record.$child_column LIMIT $sample_limit",
+                    $relation['params']
+                );
+                $sample_values = array_column($rows, 'orphan_value');
+            }
+
+            $results[] = array_merge($relation, [
+                'orphan_count' => $orphan_count,
+                'sample_values' => $sample_values,
+            ]);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function relations(): array
+    {
+        return [
+            [
+                'child_table' => 'fetchmail',
+                'child_column' => 'mailbox',
+                'parent_table' => 'mailbox',
+                'parent_column' => 'username',
+                'extra_where' => '',
+                'params' => [],
+                'recommendation' => 'Review whether each fetchmail entry should be removed or assigned to an existing mailbox.',
+            ],
+            [
+                'child_table' => 'quota',
+                'child_column' => 'username',
+                'parent_table' => 'mailbox',
+                'parent_column' => 'username',
+                'extra_where' => '',
+                'params' => [],
+                'recommendation' => 'Review the mailbox state and use the configured quota backend tooling before changing quota data.',
+            ],
+            [
+                'child_table' => 'quota2',
+                'child_column' => 'username',
+                'parent_table' => 'mailbox',
+                'parent_column' => 'username',
+                'extra_where' => '',
+                'params' => [],
+                'recommendation' => 'Review the mailbox state and use the configured quota backend tooling before changing quota data.',
+            ],
+            [
+                'child_table' => 'vacation',
+                'child_column' => 'email',
+                'parent_table' => 'mailbox',
+                'parent_column' => 'username',
+                'extra_where' => '',
+                'params' => [],
+                'recommendation' => 'Review whether each vacation entry should be removed or belongs to an existing mailbox.',
+            ],
+            [
+                'child_table' => 'domain_admins',
+                'child_column' => 'domain',
+                'parent_table' => 'domain',
+                'parent_column' => 'domain',
+                'extra_where' => ' AND child_record.domain <> ?',
+                'params' => ['ALL'],
+                'recommendation' => 'Review whether each domain assignment should be removed or linked to an existing domain.',
+            ],
+            [
+                'child_table' => 'domain_admins',
+                'child_column' => 'username',
+                'parent_table' => 'admin',
+                'parent_column' => 'username',
+                'extra_where' => '',
+                'params' => [],
+                'recommendation' => 'Review whether each domain assignment should be removed or linked to an existing administrator.',
+            ],
+        ];
+    }
+}

--- a/public/setup.php
+++ b/public/setup.php
@@ -21,7 +21,9 @@ require_once('common.php');
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
     <div class="container-fluid">
-        <a class="navbar-brand" href='main.php'><img id="login_header_logo" src="images/postbox.png" alt="Logo"/></a>
+        <a class="navbar-brand" href='main.php'><img id="login_header_logo" src="images/postbox.png" alt="Logo"/>
+            PostfixAdmin - setup
+        </a>
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbar"
                 aria-expanded="false" aria-controls="navbar">
             <span class="navbar-toggler-icon"></span>
@@ -80,7 +82,7 @@ $tick = ' ✅ ';
 ?>
 
 
-<div class="container">
+<main class="container" style="padding-top: 100px">
     <div class="row">
         <h1 class="h1">Configure and Setup Postfixadmin</h1>
 
@@ -104,16 +106,16 @@ $tick = ' ✅ ';
                     } else {
                         echo $todo . " You need to have a setup_password hash configured in a <code>config.local.php</code> file";
                     }
-?>
+                    ?>
                 </li>
                 <li>
                     <?php
-if ($authenticated) {
-    echo $tick . " You are logged in with the setup_password, some environment and hosting checks are displayed below.";
-} else {
-    echo $todo . " You need to authenticate using the setup_password before you can perform some environment and hosting checks.";
-}
-?>
+                    if ($authenticated) {
+                        echo $tick . " You are logged in with the setup_password, some environment and hosting checks are displayed below.";
+                    } else {
+                        echo $todo . " You need to authenticate using the setup_password before you can perform some environment and hosting checks.";
+                    }
+                    ?>
                 </li>
             </ul>
 
@@ -177,39 +179,39 @@ if ($authenticated) {
                         echo '<p class="text-danger"><strong>Your setup_password is in an obsolete format. As of PostfixAdmin 3.3 it needs regenerating.</strong>';
                     }
 
-            if (!$configSetupDone) { ?>
+                    if (!$configSetupDone) { ?>
 
                     <?php
 
-            $form_error = '';
-                $result = '';
+                    $form_error = '';
+                    $result = '';
 
-                if (safepost('form') === "setuppw") {
-                    $errors = [];
+                    if (safepost('form') === "setuppw") {
+                        $errors = [];
 
-                    # "setup password" form submitted
+                        # "setup password" form submitted
 
-                    if (safepost('setup_password', 'abc') != safepost('setup_password2')) {
-                        $errors['setup_password'] = "The two passwords differ!";
-                        $form_error = 'has-error';
-                    } else {
-                        $msgs = validate_password(safepost('setup_password'));
-
-                        if (empty($msgs)) {
-                            // form has been submitted; both fields filled in, so generate a new setup password.
-                            $hash = password_hash(safepost('setup_password'), PASSWORD_DEFAULT);
-
-                            $result = '<p>If you want to use the password you entered as setup password, edit your config file (config.local.php) and set</p>';
-                            $result .= "<code>\$CONF['setup_password'] = '$hash';</code><p>After updating your configuration you should be able to login with the &quot;Login with setup_password&quot; form.</p>";
-                        } else {
+                        if (safepost('setup_password', 'abc') != safepost('setup_password2')) {
+                            $errors['setup_password'] = "The two passwords differ!";
                             $form_error = 'has-error';
-                            $errors['setup_password'] = implode(', ', $msgs);
+                        } else {
+                            $msgs = validate_password(safepost('setup_password'));
+
+                            if (empty($msgs)) {
+                                // form has been submitted; both fields filled in, so generate a new setup password.
+                                $hash = password_hash(safepost('setup_password'), PASSWORD_DEFAULT);
+
+                                $result = '<p>If you want to use the password you entered as setup password, edit your config file (config.local.php) and set</p>';
+                                $result .= "<code>\$CONF['setup_password'] = '$hash';</code><p>After updating your configuration you should be able to login with the &quot;Login with setup_password&quot; form.</p>";
+                            } else {
+                                $form_error = 'has-error';
+                                $errors['setup_password'] = implode(', ', $msgs);
+                            }
                         }
                     }
-                }
 
 
-                ?>
+                    ?>
 
                 <form name="setuppw" method="post" class="form-horizontal" action="setup.php">
                     <input type="hidden" name="form" value="setuppw"/>
@@ -252,7 +254,7 @@ if ($authenticated) {
                 </form>
                 <?= $result ?>
                 <?php
-            }  // end if(!$authenticated)?>
+                }  // end if(!$authenticated)?>
             </div>
         <?php } ?>
     </div>
@@ -265,48 +267,48 @@ if ($authenticated) {
             <?php
             $check = do_software_environment_check();
 
-if ($authenticated) {
+            if ($authenticated) {
 
 
-    if (!empty($check['info'])) {
-        echo "<h3>Information</h3><ul>";
-        foreach ($check['info'] as $msg) {
-            echo "<li>{$tick} {$msg}</li>";
-        }
-        echo "</ul>";
-    }
+                if (!empty($check['info'])) {
+                    echo "<h3>Information</h3><ul>";
+                    foreach ($check['info'] as $msg) {
+                        echo "<li>{$tick} {$msg}</li>";
+                    }
+                    echo "</ul>";
+                }
 
-    if (!empty($check['warn'])) {
-        echo "<h3>Warnings</h3><ul>";
-        foreach ($check['warn'] as $msg) {
-            echo "<li class='text-warning'>⚠ {$msg}</li>";
-        }
-        echo "</ul>";
-    }
-    if (!empty($check['error'])) {
-        echo "<h3>Errors (MUST be fixed)</h3><ul>";
-        foreach ($check['error'] as $msg) {
-            echo "<li class='text-danger'>⛔{$msg}</li>";
-        }
-        echo "</ul>";
-    }
+                if (!empty($check['warn'])) {
+                    echo "<h3>Warnings</h3><ul>";
+                    foreach ($check['warn'] as $msg) {
+                        echo "<li class='text-warning'>⚠ {$msg}</li>";
+                    }
+                    echo "</ul>";
+                }
+                if (!empty($check['error'])) {
+                    echo "<h3>Errors (MUST be fixed)</h3><ul>";
+                    foreach ($check['error'] as $msg) {
+                        echo "<li class='text-danger'>⛔{$msg}</li>";
+                    }
+                    echo "</ul>";
+                }
 
 
-} else {
-    if (!empty($check['error'])) {
-        echo '<p class="text-danger">Hosting Environment errors found. Login to see details.</p>';
-    }
+            } else {
+                if (!empty($check['error'])) {
+                    echo '<p class="text-danger">Hosting Environment errors found. Login to see details.</p>';
+                }
 
-    if (!empty($check['warn'])) {
-        echo '<p class="text-warning">Hosting Environment warnings found. Login to see details.</p>';
-    }
+                if (!empty($check['warn'])) {
+                    echo '<p class="text-warning">Hosting Environment warnings found. Login to see details.</p>';
+                }
 
-    if (empty($check['warn']) && empty($check['error'])) {
-        echo "<p> $tick No problems detected.</p>";
-    }
-}
+                if (empty($check['warn']) && empty($check['error'])) {
+                    echo "<p> $tick No problems detected.</p>";
+                }
+            }
 
-?>
+            ?>
 
         </div>
     </div>
@@ -317,43 +319,54 @@ if ($authenticated) {
 
             <ul>
                 <?php
-    $db = false;
-try {
-    $db = db_connect();
-} catch (\Exception $e) {
-    $error_log = ini_get('error_log');
-    if (empty($error_log)) {
-        $error_log = 'maybe /var/log/apache2/error.log';
-    }
-    echo "<li class='text-danger'>Something went wrong while trying to connect to the database. A message should be logged - check PHP's error_log ($error_log)</li>";
-    error_log("Couldn't perform PostfixAdmin database update - failed to connect to db? " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
-}
+                $db = false;
+                try {
+                    $db = db_connect();
+                } catch (\Exception $e) {
+                    $error_log = ini_get('error_log');
+                    if (empty($error_log)) {
+                        $error_log = 'maybe /var/log/apache2/error.log';
+                    }
+                    echo "<li class='text-danger'>Something went wrong while trying to connect to the database. A message should be logged - check PHP's error_log ($error_log)</li>";
+                    error_log("Couldn't perform PostfixAdmin database update - failed to connect to db? " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
+                }
 
-if ($db) {
-    echo "<li>$tick Database - connection works</li>";
-    try {
-        ob_start();
-        $ret = require_once(dirname(__FILE__) . '/upgrade.php');
-        $output = ob_get_clean();
-        if ($ret) {
-            echo "<li>$tick Database update check - $output </li>";
-        }
-    } catch (\Exception $e) {
-        if ($authenticated) {
-            echo "<li class='h3 text-danger'>Exception message: {$e->getMessage()} - check logs!</li>";
-        }
-        echo "<li class='h3 text-danger'>Something went wrong while trying to apply database updates, a message should be logged - check PHP's error_log (" . ini_get('error_log') . ')</li>';
-        error_log("Couldn't perform PostfixAdmin database update via upgrade.php - " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
-    }
+                if ($db) {
+                    echo "<li>$tick Database - connection works</li>";
+                    try {
+                        ob_start();
+                        $ret = require_once(dirname(__FILE__) . '/upgrade.php');
+                        $output = ob_get_clean();
+                        if ($ret) {
+                            echo "<li>$tick Database update check - $output </li>";
+                        }
+                    } catch (\Exception $e) {
+                        if ($authenticated) {
+                            echo "<li class='h3 text-danger'>Exception message: {$e->getMessage()} - check logs!</li>";
+                        }
+                        echo "<li class='h3 text-danger'>Something went wrong while trying to apply database updates, a message should be logged - check PHP's error_log (" . ini_get('error_log') . ')</li>';
+                        error_log("Couldn't perform PostfixAdmin database update via upgrade.php - " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
+                    }
 
-    if ($authenticated) {
-        ?>
-                <li class="list-unstyled mt-4">
-                    <h3 class="h3">Database integrity</h3>
-                    <p>
-                        Check for records that reference missing mailboxes, domains, or administrators.
-                        This read-only check does not modify the database.
-                    </p>
+
+                } else {
+                    echo "<li class='text-danger'>Could not connect to database to perform updates; check PHP error log.</li>";
+                }
+                ?>
+            </ul>
+
+            <?php
+            if ($authenticated) {
+                ?>
+                <h3 class="h3">Database integrity</h3>
+
+                <p>
+                    Check for records that reference missing mailboxes, domains, or administrators.
+                    This read-only check does not modify the database.
+                </p>
+                <?php
+                if (safepost('submit') !== 'check_integrity') {
+                    ?>
                     <form name="check_database_integrity" class="form-inline" method="post">
                         <div class="form-group mb-2">
                             <label for="integrity_setup_password">Setup password</label>
@@ -361,72 +374,70 @@ if ($db) {
                                    name="setup_password" minlength="5"
                                    id="integrity_setup_password" value=""/>
                         </div>
-                        <button class="btn btn-secondary" type="submit" name="submit" value="check_integrity">
+                        <button class="btn btn-secondary" type="submit" name="submit"
+                                value="check_integrity">
                             Check database integrity
                         </button>
                     </form>
                     <?php
-                    if (safepost('submit') === 'check_integrity') {
-                        try {
-                            $integrity_results = (new DatabaseIntegrityChecker())->check();
-                            echo render_database_integrity_results($integrity_results);
-                        } catch (\Exception $e) {
-                            echo "<p class='mt-3 text-danger'>The database integrity check failed; check PHP's error log.</p>";
-                            error_log("Couldn't perform PostfixAdmin database integrity check - " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
-                        }
+                }
+
+                if (safepost('submit') === 'check_integrity') {
+                    try {
+                        $integrity_results = (new DatabaseIntegrityChecker())->check();
+                        echo render_database_integrity_results($integrity_results);
+                    } catch (\Exception $e) {
+                        echo "<p class='mt-3 text-danger'>The database integrity check failed; check PHP's error log.</p>";
+                        error_log("Couldn't perform PostfixAdmin database integrity check - " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
                     }
-        ?>
-                </li>
-                <?php
-    }
-} else {
-    echo "<li class='text-danger'>Could not connect to database to perform updates; check PHP error log.</li>";
-}
-?>
-            </ul>
+                }
+            }
+            ?>
+
+
         </div>
     </div>
 
 
     <?php
     if ($authenticated) {
-        $setupMessage = '';
+    $setupMessage = '';
 
-        if (safepost("submit") === "createadmin") {
-            ?>
-    <div class='row'>
-        <div class='col-12'>
-            <?php
-                    # "create admin" form submitted, make sure the correct setup password was specified.
+    if (safepost("submit") === "createadmin") {
+    ?>
+    < class='row'>
+    <div class='col-12'>
+        <?php
+        # "create admin" form submitted, make sure the correct setup password was specified.
 
-                    // XXX need to ensure domains table includes an 'ALL' entry.
-                    $table_domain = table_by_key('domain');
-            $rows = db_query_all("SELECT * FROM $table_domain WHERE domain = 'ALL'");
-            if (empty($rows)) {
-                // all other fields should default through the schema.
-                db_insert('domain', array('domain' => 'ALL', 'description' => '', 'transport' => ''));
-            }
+        // XXX need to ensure domains table includes an 'ALL' entry.
+        $table_domain = table_by_key('domain');
+        $rows = db_query_all("SELECT * FROM $table_domain WHERE domain = 'ALL'");
+        if (empty($rows)) {
+            // all other fields should default through the schema.
+            db_insert('domain', array('domain' => 'ALL', 'description' => '', 'transport' => ''));
+        }
 
-            $values = array(
-                    'username' => safepost('username'),
-                    'password' => safepost('password'),
-                    'password2' => safepost('password2'),
-                    'superadmin' => 1,
-                    'domains' => array(),
-                    'active' => 1,
-            );
+        $values = array(
+                'username' => safepost('username'),
+                'password' => safepost('password'),
+                'password2' => safepost('password2'),
+                'superadmin' => 1,
+                'domains' => array(),
+                'active' => 1,
+        );
 
-            list($error, $setupMessage, $errors) = create_admin($values);
+        list($error, $setupMessage, $errors) = create_admin($values);
 
-            if ($error == 1) {
-                error_log("failed to add admin - " . json_encode([$error, $setupMessage, $errors]));
-                echo "<p class='text-danger'>Admin addition failed; check field error messages or server logs.</p>";
-            } else {
-                // all good!.
-                $setupMessage .= "<p>You are done with your basic setup. <b>You can now <a href='login.php'>login to PostfixAdmin</a> using the account you just created.</b></p>";
-            }
+        if ($error == 1) {
+            error_log("failed to add admin - " . json_encode([$error, $setupMessage, $errors]));
+            echo "<p class='text-danger'>Admin addition failed; check field error messages or server logs.</p>";
+        } else {
+            // all good!.
+            $setupMessage .= "<p>You are done with your basic setup. <b>You can now <a href='login.php'>login to PostfixAdmin</a> using the account you just created.</b></p>";
+        }
 
-            echo "</div>
+        echo "</div>
 </div>";
         }
 
@@ -436,111 +447,111 @@ if ($db) {
 
         if (!empty($admins)) { ?>
 
-                <div class="row">
-                    <div class="col-12">
+            <div class="row">
+                <div class="col-12">
 
-                        <h2 class="h2">Super admins</h2>
-                        <p>The following 'super-admin' accounts have already been added to the database.</p>
-                        <ul>
-                            <?php
+                    <h2 class="h2">Super admins</h2>
+                    <p>The following 'super-admin' accounts have already been added to the database.</p>
+                    <ul>
+                        <?php
                         foreach ($admins as $row) {
                             echo "<li>{$row['username']}</li>";
                         }
-            ?>
-                        </ul>
+                        ?>
+                    </ul>
+                </div>
+            </div>
+        <?php } ?>
+
+        <div class="row">
+            <div class="col-12">
+                <h2>Add Superadmin Account</h2>
+
+                <form name="create_admin" class="form-horizontal" method="post">
+                    <div class="form-group">
+                        <label for="setup_password" class="col-sm-4 control-label">Setup password</label>
+                        <div class="col-sm-4">
+                            <input class="form-control" type="password" required="required"
+                                   name="setup_password"
+                                   minlength=5
+                                   value=""/>
+
+                        </div>
                     </div>
-                </div>
-            <?php } ?>
 
-            <div class="row">
-                <div class="col-12">
-                    <h2>Add Superadmin Account</h2>
 
-                    <form name="create_admin" class="form-horizontal" method="post">
-                        <div class="form-group">
-                            <label for="setup_password" class="col-sm-4 control-label">Setup password</label>
-                            <div class="col-sm-4">
-                                <input class="form-control" type="password" required="required"
-                                       name="setup_password"
-                                       minlength=5
-                                       value=""/>
+                    <div class="form-group">
+                        <label for="username" class="col-sm-4 control-label"><?= $PALANG['admin'] ?></label>
+                        <div class="col-sm-4">
+                            <input class="form-control" type="text" required="required" name="username"
+                                   minlength=5
+                                   id="username"
+                                   value=""/>
 
-                            </div>
+                            <?= _error_field($errors, 'username'); ?>
+
                         </div>
+                    </div>
 
 
-                        <div class="form-group">
-                            <label for="username" class="col-sm-4 control-label"><?= $PALANG['admin'] ?></label>
-                            <div class="col-sm-4">
-                                <input class="form-control" type="text" required="required" name="username"
-                                       minlength=5
-                                       id="username"
-                                       value=""/>
-
-                                <?= _error_field($errors, 'username'); ?>
-
-                            </div>
+                    <div class="form-group">
+                        <label for="password" class="col-sm-4 control-label"><?= $PALANG['password'] ?></label>
+                        <div class="col-sm-4">
+                            <input class="form-control" type="password" required=required
+                                   name="password" minlength=5
+                                   id="password" autocomplete="new-password"
+                                   value=""/>
+                            <?= _error_field($errors, 'password'); ?>
                         </div>
+                    </div>
 
+                    <div class="form-group">
+                        <label for="password2"
+                               class="col-sm-4 control-label"><?= $PALANG['password_again'] ?></label>
+                        <div class="col-sm-4">
+                            <input class="form-control" type="password" required=required
+                                   name="password2" minlength=5
+                                   id="password2" autocomplete="new-password"
+                                   value=""/>
 
-                        <div class="form-group">
-                            <label for="password" class="col-sm-4 control-label"><?= $PALANG['password'] ?></label>
-                            <div class="col-sm-4">
-                                <input class="form-control" type="password" required=required
-                                       name="password" minlength=5
-                                       id="password" autocomplete="new-password"
-                                       value=""/>
-                                <?= _error_field($errors, 'password'); ?>
-                            </div>
+                            <?= _error_field($errors, 'password2'); ?>
+
                         </div>
+                    </div>
 
-                        <div class="form-group">
-                            <label for="password2"
-                                   class="col-sm-4 control-label"><?= $PALANG['password_again'] ?></label>
-                            <div class="col-sm-4">
-                                <input class="form-control" type="password" required=required
-                                       name="password2" minlength=5
-                                       id="password2" autocomplete="new-password"
-                                       value=""/>
 
-                                <?= _error_field($errors, 'password2'); ?>
-
-                            </div>
+                    <div class="form-group">
+                        <div class="offset-sm-4 col-sm-4">
+                            <button class="btn btn-primary" type="submit" name="submit"
+                                    value="createadmin"><?= $PALANG['pAdminCreate_admin_button'] ?>
+                            </button>
                         </div>
+                    </div>
 
-
-                        <div class="form-group">
-                            <div class="offset-sm-4 col-sm-4">
-                                <button class="btn btn-primary" type="submit" name="submit"
-                                        value="createadmin"><?= $PALANG['pAdminCreate_admin_button'] ?>
-                                </button>
-                            </div>
-                        </div>
-
-                    </form>
-                </div>
+                </form>
             </div>
-
-            <div class="row">
-                <div class="col-12">
-                    <p class="text-success"><?= $setupMessage ?></p>
-                </div>
-            </div>
-            <?php
-    }
-
-?>
         </div>
+
+        <div class="row">
+            <div class="col-12">
+                <p class="text-success"><?= $setupMessage ?></p>
+            </div>
+        </div>
+        <?php
+        }
+
+        ?>
     </div>
-    <footer class="footer mt-5">
-        <div class="container text-center">
-            <a target="_blank" rel="noopener"
-               href="https://github.com/postfixadmin/postfixadmin/blob/master/DOCUMENTS/">Documentation</a>
-            //
-            <a target="_blank" rel="noopener"
-               href="https://github.com/postfixadmin/postfixadmin/">Postfix Admin</a>
-        </div>
-    </footer>
+</main>
+<footer class="footer mt-5">
+    <div class="container text-center">
+        <a target="_blank" rel="noopener"
+           href="https://github.com/postfixadmin/postfixadmin/blob/master/DOCUMENTS/">Documentation</a>
+        //
+        <a target="_blank" rel="noopener"
+           href="https://github.com/postfixadmin/postfixadmin/">Postfix Admin</a>
+    </div>
+</footer>
 
 </body>
 </html>
@@ -602,9 +613,9 @@ function render_database_integrity_results(array $results): string
 
     foreach ($problems as $problem) {
         $relation = $problem['child_table'] . '.' . $problem['child_column'] .
-            ' &rarr; ' . $problem['parent_table'] . '.' . $problem['parent_column'];
+                ' &rarr; ' . $problem['parent_table'] . '.' . $problem['parent_column'];
         $sample_values = array_map(function ($value): string {
-            return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            return htmlspecialchars((string)$value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         }, $problem['sample_values']);
 
         $output .= '<tr>';
@@ -744,10 +755,10 @@ function do_software_environment_check()
 
             if (is_writeable($error_log_file)) {
                 $err = "Possibly helpful error_log messages - " . htmlspecialchars(
-                    implode("",
-                        array_slice(file($error_log_file), -4, 3)  // last three lines, might fail miserably if error_log is large.
-                    )
-                );
+                                implode("",
+                                        array_slice(file($error_log_file), -4, 3)  // last three lines, might fail miserably if error_log is large.
+                                )
+                        );
 
                 $error[] = nl2br($err);
             }

--- a/public/setup.php
+++ b/public/setup.php
@@ -106,16 +106,16 @@ $tick = ' ✅ ';
                     } else {
                         echo $todo . " You need to have a setup_password hash configured in a <code>config.local.php</code> file";
                     }
-                    ?>
+?>
                 </li>
                 <li>
                     <?php
-                    if ($authenticated) {
-                        echo $tick . " You are logged in with the setup_password, some environment and hosting checks are displayed below.";
-                    } else {
-                        echo $todo . " You need to authenticate using the setup_password before you can perform some environment and hosting checks.";
-                    }
-                    ?>
+if ($authenticated) {
+    echo $tick . " You are logged in with the setup_password, some environment and hosting checks are displayed below.";
+} else {
+    echo $todo . " You need to authenticate using the setup_password before you can perform some environment and hosting checks.";
+}
+?>
                 </li>
             </ul>
 
@@ -179,39 +179,39 @@ $tick = ' ✅ ';
                         echo '<p class="text-danger"><strong>Your setup_password is in an obsolete format. As of PostfixAdmin 3.3 it needs regenerating.</strong>';
                     }
 
-                    if (!$configSetupDone) { ?>
+            if (!$configSetupDone) { ?>
 
                     <?php
 
-                    $form_error = '';
-                    $result = '';
+            $form_error = '';
+                $result = '';
 
-                    if (safepost('form') === "setuppw") {
-                        $errors = [];
+                if (safepost('form') === "setuppw") {
+                    $errors = [];
 
-                        # "setup password" form submitted
+                    # "setup password" form submitted
 
-                        if (safepost('setup_password', 'abc') != safepost('setup_password2')) {
-                            $errors['setup_password'] = "The two passwords differ!";
-                            $form_error = 'has-error';
+                    if (safepost('setup_password', 'abc') != safepost('setup_password2')) {
+                        $errors['setup_password'] = "The two passwords differ!";
+                        $form_error = 'has-error';
+                    } else {
+                        $msgs = validate_password(safepost('setup_password'));
+
+                        if (empty($msgs)) {
+                            // form has been submitted; both fields filled in, so generate a new setup password.
+                            $hash = password_hash(safepost('setup_password'), PASSWORD_DEFAULT);
+
+                            $result = '<p>If you want to use the password you entered as setup password, edit your config file (config.local.php) and set</p>';
+                            $result .= "<code>\$CONF['setup_password'] = '$hash';</code><p>After updating your configuration you should be able to login with the &quot;Login with setup_password&quot; form.</p>";
                         } else {
-                            $msgs = validate_password(safepost('setup_password'));
-
-                            if (empty($msgs)) {
-                                // form has been submitted; both fields filled in, so generate a new setup password.
-                                $hash = password_hash(safepost('setup_password'), PASSWORD_DEFAULT);
-
-                                $result = '<p>If you want to use the password you entered as setup password, edit your config file (config.local.php) and set</p>';
-                                $result .= "<code>\$CONF['setup_password'] = '$hash';</code><p>After updating your configuration you should be able to login with the &quot;Login with setup_password&quot; form.</p>";
-                            } else {
-                                $form_error = 'has-error';
-                                $errors['setup_password'] = implode(', ', $msgs);
-                            }
+                            $form_error = 'has-error';
+                            $errors['setup_password'] = implode(', ', $msgs);
                         }
                     }
+                }
 
 
-                    ?>
+                ?>
 
                 <form name="setuppw" method="post" class="form-horizontal" action="setup.php">
                     <input type="hidden" name="form" value="setuppw"/>
@@ -254,7 +254,7 @@ $tick = ' ✅ ';
                 </form>
                 <?= $result ?>
                 <?php
-                }  // end if(!$authenticated)?>
+            }  // end if(!$authenticated)?>
             </div>
         <?php } ?>
     </div>
@@ -267,48 +267,48 @@ $tick = ' ✅ ';
             <?php
             $check = do_software_environment_check();
 
-            if ($authenticated) {
+if ($authenticated) {
 
 
-                if (!empty($check['info'])) {
-                    echo "<h3>Information</h3><ul>";
-                    foreach ($check['info'] as $msg) {
-                        echo "<li>{$tick} {$msg}</li>";
-                    }
-                    echo "</ul>";
-                }
+    if (!empty($check['info'])) {
+        echo "<h3>Information</h3><ul>";
+        foreach ($check['info'] as $msg) {
+            echo "<li>{$tick} {$msg}</li>";
+        }
+        echo "</ul>";
+    }
 
-                if (!empty($check['warn'])) {
-                    echo "<h3>Warnings</h3><ul>";
-                    foreach ($check['warn'] as $msg) {
-                        echo "<li class='text-warning'>⚠ {$msg}</li>";
-                    }
-                    echo "</ul>";
-                }
-                if (!empty($check['error'])) {
-                    echo "<h3>Errors (MUST be fixed)</h3><ul>";
-                    foreach ($check['error'] as $msg) {
-                        echo "<li class='text-danger'>⛔{$msg}</li>";
-                    }
-                    echo "</ul>";
-                }
+    if (!empty($check['warn'])) {
+        echo "<h3>Warnings</h3><ul>";
+        foreach ($check['warn'] as $msg) {
+            echo "<li class='text-warning'>⚠ {$msg}</li>";
+        }
+        echo "</ul>";
+    }
+    if (!empty($check['error'])) {
+        echo "<h3>Errors (MUST be fixed)</h3><ul>";
+        foreach ($check['error'] as $msg) {
+            echo "<li class='text-danger'>⛔{$msg}</li>";
+        }
+        echo "</ul>";
+    }
 
 
-            } else {
-                if (!empty($check['error'])) {
-                    echo '<p class="text-danger">Hosting Environment errors found. Login to see details.</p>';
-                }
+} else {
+    if (!empty($check['error'])) {
+        echo '<p class="text-danger">Hosting Environment errors found. Login to see details.</p>';
+    }
 
-                if (!empty($check['warn'])) {
-                    echo '<p class="text-warning">Hosting Environment warnings found. Login to see details.</p>';
-                }
+    if (!empty($check['warn'])) {
+        echo '<p class="text-warning">Hosting Environment warnings found. Login to see details.</p>';
+    }
 
-                if (empty($check['warn']) && empty($check['error'])) {
-                    echo "<p> $tick No problems detected.</p>";
-                }
-            }
+    if (empty($check['warn']) && empty($check['error'])) {
+        echo "<p> $tick No problems detected.</p>";
+    }
+}
 
-            ?>
+?>
 
         </div>
     </div>
@@ -319,40 +319,40 @@ $tick = ' ✅ ';
 
             <ul>
                 <?php
-                $db = false;
-                try {
-                    $db = db_connect();
-                } catch (\Exception $e) {
-                    $error_log = ini_get('error_log');
-                    if (empty($error_log)) {
-                        $error_log = 'maybe /var/log/apache2/error.log';
-                    }
-                    echo "<li class='text-danger'>Something went wrong while trying to connect to the database. A message should be logged - check PHP's error_log ($error_log)</li>";
-                    error_log("Couldn't perform PostfixAdmin database update - failed to connect to db? " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
-                }
+    $db = false;
+try {
+    $db = db_connect();
+} catch (\Exception $e) {
+    $error_log = ini_get('error_log');
+    if (empty($error_log)) {
+        $error_log = 'maybe /var/log/apache2/error.log';
+    }
+    echo "<li class='text-danger'>Something went wrong while trying to connect to the database. A message should be logged - check PHP's error_log ($error_log)</li>";
+    error_log("Couldn't perform PostfixAdmin database update - failed to connect to db? " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
+}
 
-                if ($db) {
-                    echo "<li>$tick Database - connection works</li>";
-                    try {
-                        ob_start();
-                        $ret = require_once(dirname(__FILE__) . '/upgrade.php');
-                        $output = ob_get_clean();
-                        if ($ret) {
-                            echo "<li>$tick Database update check - $output </li>";
-                        }
-                    } catch (\Exception $e) {
-                        if ($authenticated) {
-                            echo "<li class='h3 text-danger'>Exception message: {$e->getMessage()} - check logs!</li>";
-                        }
-                        echo "<li class='h3 text-danger'>Something went wrong while trying to apply database updates, a message should be logged - check PHP's error_log (" . ini_get('error_log') . ')</li>';
-                        error_log("Couldn't perform PostfixAdmin database update via upgrade.php - " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
-                    }
+if ($db) {
+    echo "<li>$tick Database - connection works</li>";
+    try {
+        ob_start();
+        $ret = require_once(dirname(__FILE__) . '/upgrade.php');
+        $output = ob_get_clean();
+        if ($ret) {
+            echo "<li>$tick Database update check - $output </li>";
+        }
+    } catch (\Exception $e) {
+        if ($authenticated) {
+            echo "<li class='h3 text-danger'>Exception message: {$e->getMessage()} - check logs!</li>";
+        }
+        echo "<li class='h3 text-danger'>Something went wrong while trying to apply database updates, a message should be logged - check PHP's error_log (" . ini_get('error_log') . ')</li>';
+        error_log("Couldn't perform PostfixAdmin database update via upgrade.php - " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
+    }
 
 
-                } else {
-                    echo "<li class='text-danger'>Could not connect to database to perform updates; check PHP error log.</li>";
-                }
-                ?>
+} else {
+    echo "<li class='text-danger'>Could not connect to database to perform updates; check PHP error log.</li>";
+}
+?>
             </ul>
 
             <?php
@@ -392,7 +392,7 @@ $tick = ' ✅ ';
                     }
                 }
             }
-            ?>
+?>
 
 
         </div>
@@ -401,43 +401,43 @@ $tick = ' ✅ ';
 
     <?php
     if ($authenticated) {
-    $setupMessage = '';
+        $setupMessage = '';
 
-    if (safepost("submit") === "createadmin") {
-    ?>
+        if (safepost("submit") === "createadmin") {
+            ?>
     < class='row'>
     <div class='col-12'>
         <?php
-        # "create admin" form submitted, make sure the correct setup password was specified.
+                # "create admin" form submitted, make sure the correct setup password was specified.
 
-        // XXX need to ensure domains table includes an 'ALL' entry.
-        $table_domain = table_by_key('domain');
-        $rows = db_query_all("SELECT * FROM $table_domain WHERE domain = 'ALL'");
-        if (empty($rows)) {
-            // all other fields should default through the schema.
-            db_insert('domain', array('domain' => 'ALL', 'description' => '', 'transport' => ''));
-        }
+                // XXX need to ensure domains table includes an 'ALL' entry.
+                $table_domain = table_by_key('domain');
+            $rows = db_query_all("SELECT * FROM $table_domain WHERE domain = 'ALL'");
+            if (empty($rows)) {
+                // all other fields should default through the schema.
+                db_insert('domain', array('domain' => 'ALL', 'description' => '', 'transport' => ''));
+            }
 
-        $values = array(
-                'username' => safepost('username'),
-                'password' => safepost('password'),
-                'password2' => safepost('password2'),
-                'superadmin' => 1,
-                'domains' => array(),
-                'active' => 1,
-        );
+            $values = array(
+                    'username' => safepost('username'),
+                    'password' => safepost('password'),
+                    'password2' => safepost('password2'),
+                    'superadmin' => 1,
+                    'domains' => array(),
+                    'active' => 1,
+            );
 
-        list($error, $setupMessage, $errors) = create_admin($values);
+            list($error, $setupMessage, $errors) = create_admin($values);
 
-        if ($error == 1) {
-            error_log("failed to add admin - " . json_encode([$error, $setupMessage, $errors]));
-            echo "<p class='text-danger'>Admin addition failed; check field error messages or server logs.</p>";
-        } else {
-            // all good!.
-            $setupMessage .= "<p>You are done with your basic setup. <b>You can now <a href='login.php'>login to PostfixAdmin</a> using the account you just created.</b></p>";
-        }
+            if ($error == 1) {
+                error_log("failed to add admin - " . json_encode([$error, $setupMessage, $errors]));
+                echo "<p class='text-danger'>Admin addition failed; check field error messages or server logs.</p>";
+            } else {
+                // all good!.
+                $setupMessage .= "<p>You are done with your basic setup. <b>You can now <a href='login.php'>login to PostfixAdmin</a> using the account you just created.</b></p>";
+            }
 
-        echo "</div>
+            echo "</div>
 </div>";
         }
 
@@ -457,7 +457,7 @@ $tick = ' ✅ ';
                         foreach ($admins as $row) {
                             echo "<li>{$row['username']}</li>";
                         }
-                        ?>
+            ?>
                     </ul>
                 </div>
             </div>
@@ -538,9 +538,9 @@ $tick = ' ✅ ';
             </div>
         </div>
         <?php
-        }
+    }
 
-        ?>
+?>
     </div>
 </main>
 <footer class="footer mt-5">
@@ -755,10 +755,10 @@ function do_software_environment_check()
 
             if (is_writeable($error_log_file)) {
                 $err = "Possibly helpful error_log messages - " . htmlspecialchars(
-                                implode("",
-                                        array_slice(file($error_log_file), -4, 3)  // last three lines, might fail miserably if error_log is large.
-                                )
-                        );
+                    implode("",
+                        array_slice(file($error_log_file), -4, 3)  // last three lines, might fail miserably if error_log is large.
+                    )
+                );
 
                 $error[] = nl2br($err);
             }

--- a/public/setup.php
+++ b/public/setup.php
@@ -345,6 +345,40 @@ if ($db) {
         echo "<li class='h3 text-danger'>Something went wrong while trying to apply database updates, a message should be logged - check PHP's error_log (" . ini_get('error_log') . ')</li>';
         error_log("Couldn't perform PostfixAdmin database update via upgrade.php - " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
     }
+
+    if ($authenticated) {
+        ?>
+                <li class="list-unstyled mt-4">
+                    <h3 class="h3">Database integrity</h3>
+                    <p>
+                        Check for records that reference missing mailboxes, domains, or administrators.
+                        This read-only check does not modify the database.
+                    </p>
+                    <form name="check_database_integrity" class="form-inline" method="post">
+                        <div class="form-group mb-2">
+                            <label for="integrity_setup_password">Setup password</label>
+                            <input class="form-control" type="password" required="required"
+                                   name="setup_password" minlength="5"
+                                   id="integrity_setup_password" value=""/>
+                        </div>
+                        <button class="btn btn-secondary" type="submit" name="submit" value="check_integrity">
+                            Check database integrity
+                        </button>
+                    </form>
+                    <?php
+                    if (safepost('submit') === 'check_integrity') {
+                        try {
+                            $integrity_results = (new DatabaseIntegrityChecker())->check();
+                            echo render_database_integrity_results($integrity_results);
+                        } catch (\Exception $e) {
+                            echo "<p class='mt-3 text-danger'>The database integrity check failed; check PHP's error log.</p>";
+                            error_log("Couldn't perform PostfixAdmin database integrity check - " . $e->getMessage() . " Trace: " . $e->getTraceAsString());
+                        }
+                    }
+        ?>
+                </li>
+                <?php
+    }
 } else {
     echo "<li class='text-danger'>Could not connect to database to perform updates; check PHP error log.</li>";
 }
@@ -546,6 +580,46 @@ function create_admin($values)
             $handler->infomsg['success'],
             array(),
     );
+}
+
+/**
+ * @param array<int, array<string, mixed>> $results
+ */
+function render_database_integrity_results(array $results): string
+{
+    $problems = array_filter($results, function (array $result): bool {
+        return $result['orphan_count'] > 0;
+    });
+
+    if (empty($problems)) {
+        return '<p class="mt-3 text-success">No orphaned records found.</p>';
+    }
+
+    $output = '<div class="mt-3">';
+    $output .= '<p class="text-warning"><strong>Orphaned records found.</strong> Review the records and make a database backup before correcting them manually.</p>';
+    $output .= '<div class="table-responsive"><table class="table table-sm table-bordered">';
+    $output .= '<thead><tr><th>Relation</th><th>Rows</th><th>Sample identifiers</th><th>Recommendation</th></tr></thead><tbody>';
+
+    foreach ($problems as $problem) {
+        $relation = $problem['child_table'] . '.' . $problem['child_column'] .
+            ' &rarr; ' . $problem['parent_table'] . '.' . $problem['parent_column'];
+        $sample_values = array_map(function ($value): string {
+            return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }, $problem['sample_values']);
+
+        $output .= '<tr>';
+        $output .= '<td><code>' . $relation . '</code></td>';
+        $output .= '<td>' . intval($problem['orphan_count']) . '</td>';
+        $output .= '<td><code>' . implode('</code><br><code>', $sample_values) . '</code></td>';
+        $output .= '<td>' . htmlspecialchars($problem['recommendation'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</td>';
+        $output .= '</tr>';
+    }
+
+    $output .= '</tbody></table></div>';
+    $output .= '<p class="text-muted">Up to 20 distinct identifiers are shown for each relation. No data was changed.</p>';
+    $output .= '</div>';
+
+    return $output;
 }
 
 /**

--- a/public/setup.php
+++ b/public/setup.php
@@ -405,7 +405,7 @@ if ($db) {
 
         if (safepost("submit") === "createadmin") {
             ?>
-    < class='row'>
+    <div class='row'>
     <div class='col-12'>
         <?php
                 # "create admin" form submitted, make sure the correct setup password was specified.

--- a/tests/DatabaseIntegrityCheckerTest.php
+++ b/tests/DatabaseIntegrityCheckerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+class DatabaseIntegrityCheckerTest extends \PHPUnit\Framework\TestCase
+{
+    private string $orphan_mailbox;
+    private string $valid_mailbox;
+    private string $domain;
+    private string $admin;
+
+    public function setUp(): void
+    {
+        $suffix = uniqid();
+        $this->domain = "integrity-$suffix.example";
+        $this->valid_mailbox = "valid@$this->domain";
+        $this->orphan_mailbox = "orphan-$suffix@example.invalid";
+        $this->admin = "integrity-admin-$suffix";
+
+        db_insert('domain', [
+            'domain' => $this->domain,
+            'description' => 'integrity test',
+            'transport' => '',
+        ]);
+        db_insert('mailbox', [
+            'username' => $this->valid_mailbox,
+            'password' => 'test',
+            'name' => 'Integrity test',
+            'maildir' => $this->domain . '/valid/',
+            'local_part' => 'valid',
+            'domain' => $this->domain,
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        db_delete('quota2', 'username', $this->valid_mailbox);
+        db_delete('quota2', 'username', $this->orphan_mailbox);
+        db_delete('domain_admins', 'username', $this->admin);
+        db_delete('mailbox', 'username', $this->valid_mailbox);
+        db_delete('domain', 'domain', $this->domain);
+    }
+
+    public function testReportsOrphanedRowsWithoutChangingData(): void
+    {
+        db_insert('quota2', [
+            'username' => $this->valid_mailbox,
+            'bytes' => 10,
+            'messages' => 1,
+        ], []);
+        db_insert('quota2', [
+            'username' => $this->orphan_mailbox,
+            'bytes' => 20,
+            'messages' => 2,
+        ], []);
+
+        $results = (new DatabaseIntegrityChecker())->check(100);
+        $quota2 = $this->findResult($results, 'quota2', 'username');
+
+        $this->assertGreaterThanOrEqual(1, $quota2['orphan_count']);
+        $this->assertContains($this->orphan_mailbox, $quota2['sample_values']);
+        $this->assertNotContains($this->valid_mailbox, $quota2['sample_values']);
+
+        $row = db_query_one(
+            'SELECT bytes, messages FROM ' . table_by_key('quota2') . ' WHERE username = ?',
+            [$this->orphan_mailbox]
+        );
+        $this->assertSame(20, intval($row['bytes']));
+        $this->assertSame(2, intval($row['messages']));
+    }
+
+    public function testIgnoresAllAsSpecialDomainAssignment(): void
+    {
+        db_insert('domain_admins', [
+            'username' => $this->admin,
+            'domain' => 'ALL',
+            'active' => 1,
+        ], ['created']);
+
+        $results = (new DatabaseIntegrityChecker())->check(100);
+        $domains = $this->findResult($results, 'domain_admins', 'domain');
+        $admins = $this->findResult($results, 'domain_admins', 'username');
+
+        $this->assertNotContains('ALL', $domains['sample_values']);
+        $this->assertContains($this->admin, $admins['sample_values']);
+    }
+
+    public function testChecksAllRelationsProposedByIssue972(): void
+    {
+        $results = (new DatabaseIntegrityChecker())->check();
+        $relations = array_map(function (array $result): string {
+            return $result['child_table'] . '.' . $result['child_column'] .
+                '->' . $result['parent_table'] . '.' . $result['parent_column'];
+        }, $results);
+
+        $this->assertSame([
+            'fetchmail.mailbox->mailbox.username',
+            'quota.username->mailbox.username',
+            'quota2.username->mailbox.username',
+            'vacation.email->mailbox.username',
+            'domain_admins.domain->domain.domain',
+            'domain_admins.username->admin.username',
+        ], $relations);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $results
+     * @return array<string, mixed>
+     */
+    private function findResult(array $results, string $table, string $column): array
+    {
+        foreach ($results as $result) {
+            if ($result['child_table'] === $table && $result['child_column'] === $column) {
+                return $result;
+            }
+        }
+
+        $this->fail("Missing integrity result for $table.$column");
+    }
+}

--- a/tests/DatabaseIntegrityCheckerTest.php
+++ b/tests/DatabaseIntegrityCheckerTest.php
@@ -6,6 +6,7 @@ class DatabaseIntegrityCheckerTest extends \PHPUnit\Framework\TestCase
     private string $valid_mailbox;
     private string $domain;
     private string $admin;
+    private bool $created_all_domain = false;
 
     public function setUp(): void
     {
@@ -35,6 +36,9 @@ class DatabaseIntegrityCheckerTest extends \PHPUnit\Framework\TestCase
         db_delete('quota2', 'username', $this->valid_mailbox);
         db_delete('quota2', 'username', $this->orphan_mailbox);
         db_delete('domain_admins', 'username', $this->admin);
+        if ($this->created_all_domain) {
+            db_delete('domain', 'domain', 'ALL');
+        }
         db_delete('mailbox', 'username', $this->valid_mailbox);
         db_delete('domain', 'domain', $this->domain);
     }
@@ -69,6 +73,19 @@ class DatabaseIntegrityCheckerTest extends \PHPUnit\Framework\TestCase
 
     public function testIgnoresAllAsSpecialDomainAssignment(): void
     {
+        $all_domain = db_query_one(
+            'SELECT domain FROM ' . table_by_key('domain') . ' WHERE domain = ?',
+            ['ALL']
+        );
+        if (db_pgsql() && $all_domain === null) {
+            db_insert('domain', [
+                'domain' => 'ALL',
+                'description' => 'special domain assignment',
+                'transport' => '',
+            ]);
+            $this->created_all_domain = true;
+        }
+
         db_insert('domain_admins', [
             'username' => $this->admin,
             'domain' => 'ALL',


### PR DESCRIPTION
## Summary

- add an authenticated **Check database integrity** action to `setup.php`
- detect orphaned rows for the six relationships discussed in #972
- keep the check read-only and repeatable, with row counts, limited sample identifiers, and manual remediation guidance
- exclude the special `domain_admins.domain = 'ALL'` assignment
- add SQLite-backed tests for detection, non-destructive behavior, and the special-domain case

## Why

This partially addresses #972 without deleting user data or adding foreign keys yet. It gives administrators a safe way to identify inconsistencies left by partial migrations, interrupted operations, manual SQL changes, or external database writers before deciding how to correct them.

The scope follows the approach discussed in https://github.com/postfixadmin/postfixadmin/issues/972#issuecomment-5052913570.

## Impact

- no schema-version change
- no automatic cleanup
- no foreign keys added
- supports configured table names through `table_by_key()`
- uses portable queries for MySQL/MariaDB, PostgreSQL, and SQLite

## Validation

- `DatabaseIntegrityCheckerTest.php`: 3 tests, 9 assertions
- PHPStan level 0 on the changed implementation, UI, and tests
- PHP lint and PHP-CS-Fixer checks on all changed PHP files

All targeted checks were run with the project PHP 8.4 runtime.
