### PR TITLE
Make 3.3 schema reconciliation retry-safe

### DIFF
--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -61,6 +61,23 @@ function _mysql_field_exists($table, $field)
     return !empty($r);
 }
 
+function _mysql_foreign_key_exists($table, $constraint)
+{
+    $sql = "
+        SELECT CONSTRAINT_NAME
+        FROM information_schema.TABLE_CONSTRAINTS
+        WHERE CONSTRAINT_SCHEMA = DATABASE()
+          AND TABLE_NAME = :table
+          AND CONSTRAINT_NAME = :constraint
+          AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    ";
+    $r = db_query_one($sql, [
+        'table' => trim($table, '`'),
+        'constraint' => $constraint,
+    ]);
+    return !empty($r);
+}
+
 function _sqlite_field_exists($table, $field)
 {
     $sql = "PRAGMA table_info($table)";
@@ -1898,9 +1915,10 @@ function upgrade_1846_mysql()
 
     db_query("ALTER TABLE $quota MODIFY username varchar(255) COLLATE latin1_general_ci NOT NULL");
     db_query("ALTER TABLE $quota MODIFY path varchar(100) COLLATE latin1_general_ci NOT NULL");
-    db_query("ALTER TABLE $quota2 MODIFY username varchar(100) COLLATE latin1_general_ci NOT NULL");
 
-    db_query("ALTER TABLE $vacation_notification DROP FOREIGN KEY vacation_notification_pkey");
+    if (_mysql_foreign_key_exists($vacation_notification, 'vacation_notification_pkey')) {
+        db_query("ALTER TABLE $vacation_notification DROP FOREIGN KEY vacation_notification_pkey");
+    }
 
     db_query("ALTER TABLE $vacation MODIFY domain varchar(255)  COLLATE latin1_general_ci NOT NULL");
     db_query("ALTER TABLE $vacation MODIFY email varchar(255)  COLLATE latin1_general_ci NOT NULL");
@@ -1918,10 +1936,16 @@ function upgrade_1846_mysql()
     db_query("ALTER TABLE $vacation_notification MODIFY notified VARCHAR(255) COLLATE latin1_general_ci NOT NULL DEFAULT ''");
 
 
-    db_query("ALTER TABLE $vacation_notification ADD CONSTRAINT vacation_notification_pkey FOREIGN KEY (`on_vacation`) REFERENCES $vacation(email) ON DELETE CASCADE");
+    if (!_mysql_foreign_key_exists($vacation_notification, 'vacation_notification_pkey')) {
+        db_query("ALTER TABLE $vacation_notification ADD CONSTRAINT vacation_notification_pkey FOREIGN KEY (`on_vacation`) REFERENCES $vacation(email) ON DELETE CASCADE");
+    }
 
     db_query("ALTER TABLE $domain_admins MODIFY `domain` varchar(255) COLLATE latin1_general_ci NOT NULL");
     db_query("ALTER TABLE $domain_admins MODIFY username varchar(255) COLLATE latin1_general_ci NOT NULL");
+
+    // Keep the 3.3-path marker until every other reconciliation statement has
+    // succeeded, so an interrupted upgrade_1855_mysql() remains retryable.
+    db_query("ALTER TABLE $quota2 MODIFY username varchar(100) COLLATE latin1_general_ci NOT NULL");
 }
 
 function upgrade_1847()

--- a/tests/DatabaseUpgradeTest.php
+++ b/tests/DatabaseUpgradeTest.php
@@ -1,0 +1,123 @@
+<?php
+
+class DatabaseUpgradeTest extends \PHPUnit\Framework\TestCase
+{
+    private $orphan;
+    private $quota2;
+    private $vacation;
+    private $vacation_notification;
+
+    public function setUp(): void
+    {
+        if (!db_mysql()) {
+            $this->markTestSkipped('MySQL/MariaDB-specific migration test');
+        }
+
+        $this->orphan = 'upgrade-retry-' . uniqid() . '@example.invalid';
+        $this->quota2 = table_by_key('quota2');
+        $this->vacation = table_by_key('vacation');
+        $this->vacation_notification = table_by_key('vacation_notification');
+
+        $this->removeOrphan();
+        $this->ensureForeignKeyExists();
+    }
+
+    public function tearDown(): void
+    {
+        if (!db_mysql()) {
+            return;
+        }
+
+        $this->removeOrphan();
+        $this->ensureForeignKeyExists();
+        db_query("ALTER TABLE $this->quota2 MODIFY username varchar(100) COLLATE latin1_general_ci NOT NULL");
+    }
+
+    public function testReconcilesSchemaWhenForeignKeyExists(): void
+    {
+        db_query("ALTER TABLE $this->quota2 MODIFY username varchar(255) COLLATE latin1_general_ci NOT NULL");
+
+        upgrade_1855_mysql();
+
+        $this->assertTrue(
+            _mysql_foreign_key_exists($this->vacation_notification, 'vacation_notification_pkey')
+        );
+        $this->assertSame(100, $this->quota2UsernameLength());
+    }
+
+    public function testLeavesAlreadyCorrectSchemaUntouched(): void
+    {
+        $before = db_query_one("SHOW CREATE TABLE $this->vacation_notification");
+
+        upgrade_1855_mysql();
+
+        $this->assertSame($before, db_query_one("SHOW CREATE TABLE $this->vacation_notification"));
+        $this->assertSame(100, $this->quota2UsernameLength());
+    }
+
+    public function testRetriesReconciliationAfterForeignKeyFailure(): void
+    {
+        db_query("ALTER TABLE $this->vacation_notification DROP FOREIGN KEY vacation_notification_pkey");
+        db_query("ALTER TABLE $this->quota2 MODIFY username varchar(255) COLLATE latin1_general_ci NOT NULL");
+        db_query(
+            "INSERT INTO $this->vacation_notification (on_vacation, notified) VALUES (:on_vacation, :notified)",
+            [
+                'on_vacation' => $this->orphan,
+                'notified' => $this->orphan,
+            ]
+        );
+
+        try {
+            upgrade_1855_mysql();
+            $this->fail('The orphaned notification should prevent the foreign key from being restored');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('vacation_notification_pkey', $e->getMessage());
+        }
+
+        $this->assertFalse(
+            _mysql_foreign_key_exists($this->vacation_notification, 'vacation_notification_pkey')
+        );
+        $this->assertSame(255, $this->quota2UsernameLength());
+
+        $this->removeOrphan();
+        upgrade_1855_mysql();
+
+        $this->assertTrue(
+            _mysql_foreign_key_exists($this->vacation_notification, 'vacation_notification_pkey')
+        );
+        $this->assertSame(100, $this->quota2UsernameLength());
+    }
+
+    private function ensureForeignKeyExists(): void
+    {
+        if (!_mysql_foreign_key_exists($this->vacation_notification, 'vacation_notification_pkey')) {
+            db_query(
+                "ALTER TABLE $this->vacation_notification
+                ADD CONSTRAINT vacation_notification_pkey
+                FOREIGN KEY (`on_vacation`) REFERENCES $this->vacation(email) ON DELETE CASCADE"
+            );
+        }
+    }
+
+    private function removeOrphan(): void
+    {
+        db_query(
+            "DELETE FROM $this->vacation_notification WHERE on_vacation = :on_vacation",
+            ['on_vacation' => $this->orphan]
+        );
+    }
+
+    private function quota2UsernameLength(): int
+    {
+        $column = db_query_one(
+            "SELECT CHARACTER_MAXIMUM_LENGTH AS character_maximum_length
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = :table
+              AND COLUMN_NAME = 'username'",
+            ['table' => trim($this->quota2, '`')]
+        );
+
+        return (int) (array_values($column ?? [])[0] ?? 0);
+    }
+}


### PR DESCRIPTION
﻿## Summary

- guard the historical `vacation_notification_pkey` drop and recreation with explicit `information_schema` checks
- keep the 3.3-path `quota2.username = varchar(255)` marker until every other reconciliation statement has succeeded
- add MySQL/MariaDB integration coverage for the normal path, the already-correct no-op path, a partial foreign-key failure, and a successful retry

## Root cause

PR #1089 replays `upgrade_1846_mysql()` when it detects a schema that passed through the PostfixAdmin 3.3 upgrade path. That migration dropped and recreated `vacation_notification_pkey` without checking its current state. MySQL/MariaDB DDL can remain committed when a later statement fails, so a retry could encounter a missing constraint.

The replay also normalized `quota2.username` before the remaining statements completed. If a later statement failed, the marker could disappear and the next invocation could treat the incomplete reconciliation as a no-op.

This change makes the foreign-key operations safe to repeat and moves marker normalization to the final statement.

The issue was identified in review of the corresponding 4.x PR: https://github.com/postfixadmin/postfixadmin/pull/1088#issuecomment-5094644535

Follow-up to #1089. Addresses the retry-safety aspect of #971.

## Validation

- PHP 8.4 syntax and parallel lint checks
- PHP-CS-Fixer dry run
- MariaDB integration test: 3 tests, 9 assertions
- forced foreign-key restoration failure confirms the marker remains `varchar(255)`
- removing the orphan and rerunning confirms the FK is restored and the marker becomes `varchar(100)`
- full local suite was also exercised; remaining failures are the existing Windows/XAMPP environment cases for Unix command execution, DNS discovery, GD, and URL path escaping
