### PR TITLE
Distinguish mailbox and domain quota validation errors

### DIFF
--- a/languages/bg.lang
+++ b/languages/bg.lang
@@ -186,6 +186,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Обема, който сте дали е твърде голям!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Този домейн не е ваш: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Не мога да модифицирам пощенската кутия!';
 

--- a/languages/ca.lang
+++ b/languages/ca.lang
@@ -184,6 +184,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'La quota especificada és massa alta!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Aquest domini no et pertany: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Imposible canviar la contrasenya!';
 

--- a/languages/cn.lang
+++ b/languages/cn.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = '你输入的容量限制超出范围!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = '你没有该域的管理权限: ';
 $PALANG['pEdit_mailbox_result_error'] = '不能编辑该邮箱!';
 

--- a/languages/cs.lang
+++ b/languages/cs.lang
@@ -193,6 +193,7 @@ $PALANG['mb_max'] = 'MB (maximálně: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (maximálně: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (maximálně: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Zadané místo je příliš velké!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Tato doména není vaše: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Nepodařilo se upravit schránku!';
 

--- a/languages/da.lang
+++ b/languages/da.lang
@@ -190,6 +190,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Den ønskede kvota er for høj!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Dette domæne er ikke dit: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Kan ikke ændre adgangskoden!';
 

--- a/languages/de.lang
+++ b/languages/de.lang
@@ -193,6 +193,7 @@ $PALANG['mb_max'] = 'MB (max: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (max: unbegrenzt)';
 $PALANG['mb_max_disabled'] = 'MB (max: deaktiviert)';
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Das angegebene Quota ist zu hoch!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Diese Domain gehört nicht Ihnen: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Mailbox kann nicht geändert werden!';
 

--- a/languages/en.lang
+++ b/languages/en.lang
@@ -200,6 +200,7 @@ $PALANG['mb_max'] = 'MB (max: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)';
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)';
 $PALANG['pEdit_mailbox_quota_text_error'] = 'The quota that you specified is too high!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.';
 $PALANG['pEdit_mailbox_domain_error'] = 'This domain is not yours: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Unable to modify the mailbox!';
 

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (max: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (max: ilimitado)';
 $PALANG['mb_max_disabled'] = 'MB (max: desactivado)';
 $PALANG['pEdit_mailbox_quota_text_error'] = '¡La cuota especificada es demasiado alta!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'El dominio no tiene suficiente cuota disponible para este buzón.';
 $PALANG['pEdit_mailbox_domain_error'] = 'Este dominio no le pertenece: ';
 $PALANG['pEdit_mailbox_result_error'] = '¡Imposible cambiar la contraseña!';
 

--- a/languages/et.lang
+++ b/languages/et.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Sisestatud kettaruumi piirang on liiga kõrge!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Puuduvad õigused. Domeen: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Postkasti muutmine ebaõnnestus!';
 

--- a/languages/eu.lang
+++ b/languages/eu.lang
@@ -183,6 +183,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Zehazturiko kuota altuegia da!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Ez zara domeinu honen jabe: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Ezinezkoa pasahitza aldatzea!';
 

--- a/languages/fi.lang
+++ b/languages/fi.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Antamasi kiintiö on liian korkea!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Tämä domaini ei ole sinun: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Postilaatikon muokkaus ei onnistunut!';
 

--- a/languages/fo.lang
+++ b/languages/fo.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Kvotan tú skrivaði er ov høg!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Hetta navnaøki er ikki títt: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Fái ikki broytt loyniorðið!';
 

--- a/languages/fr.lang
+++ b/languages/fr.lang
@@ -188,6 +188,7 @@ $PALANG['mb_max'] = 'Mo (max: %s)';
 $PALANG['mb_max_unlimited'] = 'Mo (max : illimité)';
 $PALANG['mb_max_disabled'] = 'Mo (max : désactivé)';
 $PALANG['pEdit_mailbox_quota_text_error'] = 'La limite fournie est trop élevée !';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Ce domaine n\'est pas le votre: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Impossible de modifier le compte courriel !';
 

--- a/languages/gl.lang
+++ b/languages/gl.lang
@@ -183,6 +183,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'A cota especificada é demasiado alta!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Este dominio non lle pertence: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Imposible mudar o contrasinal!';
 

--- a/languages/hr.lang
+++ b/languages/hr.lang
@@ -184,6 +184,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Uneena kvota je prevelika!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Izbrana domena nije pod vaim nadzorom: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Potanski ormarić nije bilo moguče promjeniti!';
 

--- a/languages/hu.lang
+++ b/languages/hu.lang
@@ -187,6 +187,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'A megadott quota érték túl magas!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Ehhez a domainhez nincs jogosultságod: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Nemsikerült megváltoztatni a jelszót!';
 

--- a/languages/is.lang
+++ b/languages/is.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Kvótinn sem þú skilgreindir er of hár fyrir heimildina þína!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Þetta lén er ekki á þínum vegum: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Get ekki breytt lykilorðinu!';
 

--- a/languages/it.lang
+++ b/languages/it.lang
@@ -186,6 +186,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'La quota che hai specificato è troppo alta!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Questo dominio non è tuo: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Impossibile cambiare la password!';
 

--- a/languages/ja.lang
+++ b/languages/ja.lang
@@ -187,6 +187,7 @@ $PALANG['mb_max'] = 'MB (最大: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (最大: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (最大: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = '指定された容量制限が大きすぎます。';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'このドメインは管理外です: ';
 $PALANG['pEdit_mailbox_result_error'] = '更新できませんでした！';
 

--- a/languages/lt.lang
+++ b/languages/lt.lang
@@ -186,6 +186,7 @@ $PALANG['mb_max'] = 'MB (max: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Įvesta per didelė kvota!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Ne jūsų sritis: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Pašto dėžutės pakeisti nepavyko!';
 

--- a/languages/mk.lang
+++ b/languages/mk.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Внесената квота е превисока!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Овој домен не е ваш: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Не можам да го променан сандачето!';
 

--- a/languages/nb.lang
+++ b/languages/nb.lang
@@ -186,6 +186,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Kvoten du har angitt er for høy!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Dette domenet tilhører deg ikke: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Kunne ikke endre e-postkontoen!';
 

--- a/languages/nl.lang
+++ b/languages/nl.lang
@@ -187,6 +187,7 @@ $PALANG['mb_max'] = 'MB (max: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (max: ongelimiteerd)';
 $PALANG['mb_max_disabled'] = 'MB (max: uitgeschakeld)';
 $PALANG['pEdit_mailbox_quota_text_error'] = 'De quota die opgaf is te hoog.';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Dit domein is niet van nu: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Mislukt om het wachtwoord te wijzigen.';
 

--- a/languages/nn.lang
+++ b/languages/nn.lang
@@ -184,6 +184,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Kvoten er for høy!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Dette domenet er ikke ditt: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Klarte ikke å skifte passord';
 

--- a/languages/pl.lang
+++ b/languages/pl.lang
@@ -187,6 +187,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Podany udział jest za wysoki!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Ta domena nie należy do Ciebie: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Nie można zmienić parametrów!';
 

--- a/languages/pt-br.lang
+++ b/languages/pt-br.lang
@@ -189,6 +189,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'A cota de espaço especificada é muito alta!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Domínio não lhe pertence: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Não foi possível editar a conta de email!';
 

--- a/languages/pt-pt.lang
+++ b/languages/pt-pt.lang
@@ -189,6 +189,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'A cota de espaço especificada é muito alta!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'O Domínio não lhe pertence: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Não foi possível editar a conta de email!';
 

--- a/languages/ro.lang
+++ b/languages/ro.lang
@@ -187,6 +187,7 @@ $PALANG['mb_max'] = 'MB (max: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Marimea specificata este prea mare!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Acest domeniu nu este al dvs: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Nu se poate actualiza casuta de mail!';
 

--- a/languages/ru.lang
+++ b/languages/ru.lang
@@ -190,6 +190,7 @@ $PALANG['mb_max'] = 'МБ (максимум: %s)';
 $PALANG['mb_max_unlimited'] = 'МБ (максимум: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'МБ (максимум: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Квота, выставленная вами, слишком велика!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Указанный домен не принадлежит вам: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Невозможно изменить пароль!';
 

--- a/languages/sk.lang
+++ b/languages/sk.lang
@@ -186,6 +186,7 @@ $PALANG['mb_max'] = 'MB (max: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)';
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)';
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Zadané miesto je príliš veľké!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Táto doména nie je vaša: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Nepodarilo sa upraviť schránku!';
 

--- a/languages/sl.lang
+++ b/languages/sl.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Vnešena kvota je prevelika!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Izbrana domena ni pod vašim nadzorom: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Predala ni bilo mogoče spremeniti!';
 

--- a/languages/sv.lang
+++ b/languages/sv.lang
@@ -188,6 +188,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Kvotagränsen du angett är för stor!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Detta är inte din domän: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Kan inte ändra lösenordet!';
 

--- a/languages/tr.lang
+++ b/languages/tr.lang
@@ -185,6 +185,7 @@ $PALANG['mb_max'] = 'MB (maks: %s)';
 $PALANG['mb_max_unlimited'] = 'MB (maks: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (maks: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Verdiğiniz kota çok yüksek!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Bu domain dizin değil: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Şifre değiştirilemedi!';
 

--- a/languages/tw.lang
+++ b/languages/tw.lang
@@ -186,6 +186,7 @@ $PALANG['mb_max'] = 'MB (max: %s)'; # XXX
 $PALANG['mb_max_unlimited'] = 'MB (max: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'MB (max: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = '你輸入的容量限制超出範圍!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = '你沒有該網域的管理權限: ';
 $PALANG['pEdit_mailbox_result_error'] = '不能編輯該郵箱!';
 

--- a/languages/ua.lang
+++ b/languages/ua.lang
@@ -188,6 +188,7 @@ $PALANG['mb_max'] = 'МБ (максимум: %s)';
 $PALANG['mb_max_unlimited'] = 'МБ (максимум: unlimited)'; # XXX
 $PALANG['mb_max_disabled'] = 'МБ (максимум: disabled)'; # XXX
 $PALANG['pEdit_mailbox_quota_text_error'] = 'Квота, виставлена Вами, занадто велика!';
+$PALANG['pEdit_mailbox_domain_quota_text_error'] = 'The domain does not have enough quota available for this mailbox.'; # XXX
 $PALANG['pEdit_mailbox_domain_error'] = 'Зазначений домен не належить Вам: ';
 $PALANG['pEdit_mailbox_result_error'] = 'Неможливо змінити пароль!';
 

--- a/model/MailboxHandler.php
+++ b/model/MailboxHandler.php
@@ -11,6 +11,7 @@ class MailboxHandler extends PFAHandler
     protected string $id_field = 'username';
     protected ?string $domain_field = 'domain';
     protected array $searchfields = ['username'];
+    protected string $quota_error = 'pEdit_mailbox_quota_text_error';
 
     # init $this->struct, $this->db_table and $this->id_field
     protected function initStruct()
@@ -435,7 +436,7 @@ class MailboxHandler extends PFAHandler
     protected function _validate_quota($field, $val)
     {
         if (!$this->check_quota($val)) {
-            $this->errormsg[$field] = Config::lang('pEdit_mailbox_quota_text_error');
+            $this->errormsg[$field] = Config::lang($this->quota_error);
             return false;
         }
         return true;
@@ -550,6 +551,8 @@ class MailboxHandler extends PFAHandler
      */
     protected function check_quota($quota)
     {
+        $this->quota_error = 'pEdit_mailbox_quota_text_error';
+
         if (!Config::bool('quota')) {
             return true; # enforcing quotas is disabled - just allow it
         }
@@ -571,12 +574,12 @@ class MailboxHandler extends PFAHandler
             return false; # mailbox bigger than maxquota restriction (and maxquota != unlimited) -> not allowed, no more checks needed
         }
 
-        # TODO: detailed error message ("domain quota exceeded", "mailbox quota too big" etc.) via flash_error? Or "available quota: xxx MB"?
         if (!Config::bool('domain_quota')) {
             return true; # enforcing domain_quota is disabled - just allow it
         } elseif ($limit['quota'] <= 0) { # TODO: CHECK - 0 (unlimited) is fine, not sure about <= -1 (disabled)...
             $rval = true;
         } elseif ($quota == 0) { # trying to create an unlimited mailbox, but domain quota is set
+            $this->quota_error = 'pEdit_mailbox_domain_quota_text_error';
             return false;
         } else {
             $table_mailbox = table_by_key('mailbox');
@@ -586,6 +589,7 @@ class MailboxHandler extends PFAHandler
 
             $cur_quota_total = (int)divide_quota($rows[0]['sum']); # convert to MB
             if (($quota + $cur_quota_total) > $limit['quota']) {
+                $this->quota_error = 'pEdit_mailbox_domain_quota_text_error';
                 $rval = false;
             } else {
                 $rval = true;

--- a/tests/MailboxHandlerTest.php
+++ b/tests/MailboxHandlerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+class MailboxQuotaTestHandler extends MailboxHandler
+{
+    public function validateQuota(string $username, int $quota): bool
+    {
+        $this->id = $username;
+        return $this->_validate_quota('quota', $quota);
+    }
+}
+
 class MailboxHandlerTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown(): void
@@ -31,6 +40,48 @@ class MailboxHandlerTest extends \PHPUnit\Framework\TestCase
         $results = $x->result();
 
         $this->assertEmpty($results);
+    }
+
+    public function testQuotaValidationDistinguishesMailboxAndDomainLimits()
+    {
+        Config::write('quota', 'YES');
+        Config::write('domain_quota', 'YES');
+
+        db_insert('domain', [
+            'domain' => 'quota.example',
+            'description' => 'Quota test',
+            'aliases' => 10,
+            'mailboxes' => 10,
+            'maxquota' => 100,
+            'quota' => 100,
+            'transport' => 'virtual',
+            'backupmx' => 0,
+            'active' => 1,
+        ]);
+        db_insert('mailbox', [
+            'username' => 'existing@quota.example',
+            'password' => 'test',
+            'name' => 'Existing mailbox',
+            'maildir' => 'quota.example/existing/',
+            'quota' => 100 * (int)Config::read_string('quota_multiplier'),
+            'local_part' => 'existing',
+            'domain' => 'quota.example',
+            'active' => 1,
+        ]);
+
+        $domainQuota = new MailboxQuotaTestHandler();
+        $this->assertFalse($domainQuota->validateQuota('new@quota.example', 1));
+        $this->assertSame(
+            'The domain does not have enough quota available for this mailbox.',
+            $domainQuota->errormsg['quota']
+        );
+
+        $mailboxQuota = new MailboxQuotaTestHandler();
+        $this->assertFalse($mailboxQuota->validateQuota('large@quota.example', 101));
+        $this->assertSame(
+            'The quota that you specified is too high!',
+            $mailboxQuota->errormsg['quota']
+        );
     }
 
 


### PR DESCRIPTION
## Summary

- distinguish the per-mailbox maximum quota error from insufficient remaining domain quota
- add the domain-quota error message to every language catalog
- add focused coverage for both quota failure causes

## Root cause

Mailbox quota validation used the same generic translation for both the mailbox maximum and the domain-wide quota limit, so administrators could not tell why a valid per-mailbox value was rejected.

## Scope

This pull request now contains only the quota validation change and its required language key. General Spanish translation corrections are tracked separately in #1100.

## Validation

- PHP 8.4 lint
- `git diff --check`
- PHP-CS-Fixer
- `MailboxHandlerTest`: 4 tests, 56 assertions
- GNU `patch -p1 --dry-run`
- authenticated XAMPP checks for mailbox quota and browser console errors
