### PR TITLE
Remove obsolete password expiration SQL

### DIFF
--- a/password_expiration.sql
+++ b/password_expiration.sql
@@ -1,3 +1,0 @@
-ALTER TABLE mailbox ADD COLUMN password_expiry TIMESTAMP DEFAULT now() not null;
-UPDATE mailbox set password_expiry = now() + interval 90 day;
-ALTER TABLE domain ADD COLUMN password_expiry int DEFAULT 0;


### PR DESCRIPTION
## Summary

- remove the obsolete standalone `password_expiration.sql` file from the 4.x branch
- keep the supported password-expiration schema migration unchanged

## Rationale

Password expiration has been part of PostfixAdmin's database upgrade path since `upgrade_1842()`, which predates the 3.3 release. The current password-expiration documentation also states that no additional database changes are required.

Keeping the standalone SQL file is misleading because it bypasses configured table names, only uses MySQL/MariaDB syntax, is not safe to rerun, and unconditionally sets existing mailbox passwords to expire after 90 days.

Users upgrading from older 3.x versions remain covered by `public/upgrade.php`. Existing installations where the columns are already present are handled by `_db_add_field()`'s field-existence check.

## Cross-branch

The equivalent cleanup for `master` is tracked in #1098.

## Validation

- confirmed `upgrade_1842()` remains present
- confirmed there are no repository references to `password_expiration.sql`
- `git diff --check`
