### PR TITLE
Improve form focus and TOTP input semantics

### DIFF
--- a/public/css/bootstrap.css
+++ b/public/css/bootstrap.css
@@ -160,3 +160,10 @@ div#login{ max-width: 35em; }
 .virtual-list-scroll > #admin_table { min-width: 720px; margin-bottom: 0; }
 .virtual-search form { margin-bottom: .25rem; }
 .virtual-search .form-control { margin-left: auto; max-width: 18rem; }
+
+/* Use a consistent, soft focus treatment for data-entry controls. */
+.form-control:focus,
+.form-select:focus {
+  border-color: #0d6efd;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 .5rem rgba(13, 110, 253, .6);
+}

--- a/templates/login-mfa.tpl
+++ b/templates/login-mfa.tpl
@@ -8,7 +8,7 @@
             <div class="mb-3 {if $pTOPT_code_text}is-invalid{/if}">
                 <label class="col-md-4 col-sm-4" for="fTOTP_code">{$PALANG.pTOTP_code}:</label>
                 <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control"
-                                                      type="password" name="fTOTP_code" size="6"
+                                                      type="text" name="fTOTP_code" size="6"
                                                       inputmode="numeric" autocomplete="one-time-code" autofocus/></div>
                 <span class="form-text">{$pTOPT_code_text}</span>
 

--- a/templates/login-mfa.tpl
+++ b/templates/login-mfa.tpl
@@ -7,8 +7,9 @@
 
             <div class="mb-3 {if $pTOPT_code_text}is-invalid{/if}">
                 <label class="col-md-4 col-sm-4" for="fTOTP_code">{$PALANG.pTOTP_code}:</label>
-                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" autocomplete="off"
-                                                      type="text" name="fTOTP_code" size="6" autofocus/></div>
+                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control"
+                                                      type="password" name="fTOTP_code" size="6"
+                                                      inputmode="numeric" autocomplete="one-time-code" autofocus/></div>
                 <span class="form-text">{$pTOPT_code_text}</span>
 
             </div>

--- a/templates/password-change.tpl
+++ b/templates/password-change.tpl
@@ -33,7 +33,7 @@
         <label for="fTOTP_code">
             {$PALANG.pTOTP_confirm}:
         </label>
-        <input id="fTOTP_code" class="flat" type="password" name="fTOTP_code"
+        <input id="fTOTP_code" class="flat" type="text" name="fTOTP_code"
                inputmode="numeric" autocomplete="one-time-code" />
     </div>
     {/if}

--- a/templates/password-change.tpl
+++ b/templates/password-change.tpl
@@ -33,7 +33,8 @@
         <label for="fTOTP_code">
             {$PALANG.pTOTP_confirm}:
         </label>
-        <input class="flat" type="text" name="fTOTP_code" autocomplete="one-time-code" />
+        <input id="fTOTP_code" class="flat" type="password" name="fTOTP_code"
+               inputmode="numeric" autocomplete="one-time-code" />
     </div>
     {/if}
 

--- a/templates/totp.tpl
+++ b/templates/totp.tpl
@@ -25,7 +25,7 @@
             </div>
             <div class="mb-3 {if $pTOTP_code_text}is-invalid{/if}">
                 <label class="col-md-2" for="fTOTP_code">{$PALANG.pTOTP_code}:</label>
-                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="password"
+                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="text"
                                                       name="fTOTP_code" size="6" inputmode="numeric"
                                                       autocomplete="one-time-code"/>
                     <span class="text-warning">{$pTOTP_code_text}</span> <!-- error text -->

--- a/templates/totp.tpl
+++ b/templates/totp.tpl
@@ -25,8 +25,9 @@
             </div>
             <div class="mb-3 {if $pTOTP_code_text}is-invalid{/if}">
                 <label class="col-md-2" for="fTOTP_code">{$PALANG.pTOTP_code}:</label>
-                <div class="col-md-6 col-sm-8"><input id="TOTP_code" class="form-control" type="text" name="fTOTP_code"
-                                                      size="6"/>
+                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="password"
+                                                      name="fTOTP_code" size="6" inputmode="numeric"
+                                                      autocomplete="one-time-code"/>
                     <span class="text-warning">{$pTOTP_code_text}</span> <!-- error text -->
                     <span class="form-text">{$PALANG.pTOTP_code_text}</span>
                 </div>


### PR DESCRIPTION
## Summary

- use a softer, consistent primary-blue focus treatment for standard data-entry controls
- identify TOTP inputs as one-time codes and request numeric keyboards on supported devices
- keep TOTP digits visible while they are entered
- fix the TOTP setup input ID so its label points to the actual control

## Impact

The focus rule applies to `.form-control` and `.form-select`. Buttons, links,
checkboxes, and theme controls retain their existing focus styles. TOTP
validation and server-side behavior are unchanged.

## Validation

- `git diff --check`
- verified the focused diff contains only the shared stylesheet and three TOTP templates
- verified every `fTOTP_code` input uses `type="text"`, `inputmode="numeric"`, and `autocomplete="one-time-code"`

Authenticated browser validation was not run because the isolated browser
session did not have a PostfixAdmin login.
