### PR TITLE
Improve TOTP code input semantics

### DIFF
--- a/templates/login-mfa.tpl
+++ b/templates/login-mfa.tpl
@@ -5,7 +5,7 @@
             <input class="flat" type="hidden" name="token" value="{$smarty.session.PFA_token|escape:"url"}"/>
             <div class="form-group {if $pTOPT_code_text}has-error{/if}">
                 <label class="col-md-4 col-sm-4 control-label" for="fTOTP_code">{$PALANG.pTOTP_code}:</label>
-                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="password"
+                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="text"
                                                       name="fTOTP_code" size="6" inputmode="numeric"
                                                       autocomplete="one-time-code" autofocus /></div>
                 <span class="help-block">{$pTOPT_code_text}</span>

--- a/templates/login-mfa.tpl
+++ b/templates/login-mfa.tpl
@@ -5,7 +5,9 @@
             <input class="flat" type="hidden" name="token" value="{$smarty.session.PFA_token|escape:"url"}"/>
             <div class="form-group {if $pTOPT_code_text}has-error{/if}">
                 <label class="col-md-4 col-sm-4 control-label" for="fTOTP_code">{$PALANG.pTOTP_code}:</label>
-                <div class="col-md-6 col-sm-8"><input id="TOTP_code" class="form-control" autocomplete="off" type="text" name="fTOTP_code" size="6" autofocus /></div>
+                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="password"
+                                                      name="fTOTP_code" size="6" inputmode="numeric"
+                                                      autocomplete="one-time-code" autofocus /></div>
                 <span class="help-block">{$pTOPT_code_text}</span>
             </div>
         </div>

--- a/templates/password-change.tpl
+++ b/templates/password-change.tpl
@@ -44,7 +44,7 @@
         <label for="fTOTP_code">
             {$PALANG.pTOTP_confirm}:
         </label>
-        <input id="fTOTP_code" class="flat" type="password" name="fTOTP_code"
+        <input id="fTOTP_code" class="flat" type="text" name="fTOTP_code"
                inputmode="numeric" autocomplete="one-time-code" />
     </div>
     {/if}

--- a/templates/password-change.tpl
+++ b/templates/password-change.tpl
@@ -44,7 +44,8 @@
         <label for="fTOTP_code">
             {$PALANG.pTOTP_confirm}:
         </label>
-        <input class="flat" type="text" name="fTOTP_code" autocomplete="one-time-code" />
+        <input id="fTOTP_code" class="flat" type="password" name="fTOTP_code"
+               inputmode="numeric" autocomplete="one-time-code" />
     </div>
     {/if}
 

--- a/templates/totp.tpl
+++ b/templates/totp.tpl
@@ -23,8 +23,9 @@
             </div>
             <div class="form-group {if $pTOTP_code_text}has-error{/if}">
                 <label class="col-md-2 col-sm-2 control-label" for="fTOTP_code">{$PALANG.pTOTP_code}:</label>
-                <div class="col-md-6 col-sm-8"><input id="TOTP_code" class="form-control" type="text" name="fTOTP_code"
-                                                      size="6"/>
+                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="password"
+                                                      name="fTOTP_code" size="6" inputmode="numeric"
+                                                      autocomplete="one-time-code"/>
                     <span class="text-warning">{$pTOTP_code_text}</span> <!-- error text -->
                     <span class="help-block">{$PALANG.pTOTP_code_text}</span>
                 </div>

--- a/templates/totp.tpl
+++ b/templates/totp.tpl
@@ -23,7 +23,7 @@
             </div>
             <div class="form-group {if $pTOTP_code_text}has-error{/if}">
                 <label class="col-md-2 col-sm-2 control-label" for="fTOTP_code">{$PALANG.pTOTP_code}:</label>
-                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="password"
+                <div class="col-md-6 col-sm-8"><input id="fTOTP_code" class="form-control" type="text"
                                                       name="fTOTP_code" size="6" inputmode="numeric"
                                                       autocomplete="one-time-code"/>
                     <span class="text-warning">{$pTOTP_code_text}</span> <!-- error text -->


### PR DESCRIPTION
## Summary

- identify TOTP inputs as one-time codes and request numeric keyboards on supported devices
- keep TOTP digits visible while they are entered
- fix the TOTP input IDs so their labels point to the actual controls

## Impact

This change is limited to the three TOTP templates. TOTP validation, session
handling, forms unrelated to TOTP, and application styling remain unchanged.

## Validation

- `git diff --check`
- verified the focused diff contains only the three TOTP templates
- verified every `fTOTP_code` input uses `type="text"`, `inputmode="numeric"`, and `autocomplete="one-time-code"`

Authenticated browser validation was not run because the isolated browser
session did not have a PostfixAdmin login.
