### PR TITLE
Clarify password expiration units on 4.x

### DIFF
--- a/languages/en.lang
+++ b/languages/en.lang
@@ -520,8 +520,8 @@ $PALANG['pFetchmail_desc_returned_text']    = 'Text message from last polling';
 
 $PALANG['dateformat_pgsql'] = 'YYYY-mm-dd'; # translators: rearrange to your local date format, but make sure it's a valid PostgreSQL date format
 $PALANG['dateformat_mysql'] = '%Y-%m-%d';   # translators: rearrange to your local date format, but make sure it's a valid MySQL date format
-$PALANG['password_expiration'] = 'Pass expires';
-$PALANG['password_expiration_desc'] = 'Date when password will expire';
+$PALANG['password_expiration'] = 'Password expiration (days)';
+$PALANG['password_expiration_desc'] = 'Number of days before the password expires';
 
 $PALANG['To_Mailbox']                       = 'Mailbox'; # XXX
 $PALANG['To_Forward_Only']                  = 'Forward Only'; # XXX

--- a/languages/es.lang
+++ b/languages/es.lang
@@ -439,8 +439,8 @@ $PALANG['pFetchmail_desc_date']             = 'Fecha del último sondeo/cambio e
 $PALANG['pFetchmail_desc_returned_text']    = 'Mensaje del último sondeo';
 $PALANG['dateformat_pgsql'] = 'YYYY-mm-dd'; # translators: rearrange to your local date format, but make sure it's a valid PostgreSQL date format # XXX
 $PALANG['dateformat_mysql'] = '%Y-%m-%d';   # translators: rearrange to your local date format, but make sure it's a valid MySQL date format # XXX
-$PALANG['password_expiration'] = 'Expiración de contraseña';
-$PALANG['password_expiration_desc'] = 'Fecha en que expirará la contraseña';
+$PALANG['password_expiration'] = 'Expiración de contraseña (días)';
+$PALANG['password_expiration_desc'] = 'Número de días antes de que expire la contraseña';
 $PALANG['To_Mailbox']                       = 'Buzón'; # XXX # XXX
 $PALANG['To_Forward_Only']                  = 'Solo Reenvío'; # XXX # XXX
 


### PR DESCRIPTION
## Summary

- clarify that the domain password-expiration value is measured in days
- update the English and Spanish labels and descriptions

## Rationale

The domain setting stores a duration in days, but the current labels can render values such as `365` without a unit, and the descriptions incorrectly describe the value as a date. The updated text makes the meaning explicit in both the domain form and the domain-list tooltip.

## Cross-branch

This is the `postfixadmin_4.0` counterpart of the focused `master` pull request.

## Validation

- PHP 8.4 lint for `languages/en.lang` and `languages/es.lang`
- `git diff --check`
