### PR TITLE
Document optional Dovecot mail deletion logging

### DIFF
--- a/DOCUMENTS/DOVECOT-2.4.md
+++ b/DOCUMENTS/DOVECOT-2.4.md
@@ -229,15 +229,23 @@ The related migration script is provided in
 test with dry-run first, back up mail storage and the database, and review
 paths, ownership and Dovecot permissions before running with `--real`.
 
-## Operational mail deletion logging
+## Optional operational mail deletion logging
 
-The example configuration enables the `mail_log` and `notify` plugins for IMAP
-and records the events and message fields needed to investigate reported mail
-deletions:
+The example configuration includes optional `mail_log` and `notify` settings
+for investigating reported mail deletions. They are commented out by default
+because the recorded message metadata can be sensitive. To enable them,
+uncomment both plugin entries and the event and field settings:
 
 ```conf
-mail_log_events = delete undelete expunge mailbox_delete
-mail_log_fields = uid box msgid size from subject
+#mail_log_events = delete undelete expunge mailbox_delete
+#mail_log_fields = uid box msgid size from subject
+
+protocol imap {
+  mail_plugins {
+    #mail_log = yes
+    #notify = yes
+  }
+}
 ```
 
 This provides an operational audit trail for messages marked as deleted,
@@ -251,9 +259,9 @@ fields, and the requirement to enable `notify` alongside `mail_log` are describe
 in the official [mail-log plugin documentation](https://doc.dovecot.org/2.4.1/core/plugins/mail_log.html).
 
 These settings only record operations performed after they are enabled; they
-cannot reconstruct earlier deletions. Because `from` and `subject` may contain
-sensitive information, protect and retain the resulting logs according to the
-site's privacy and log-retention policy.
+cannot reconstruct earlier deletions. Before enabling them, decide whether
+logging `from` and `subject` is necessary, and protect and retain the resulting
+logs according to the site's privacy and log-retention policy.
 
 ## Optional quota warning delivery
 

--- a/DOCUMENTS/DOVECOT-2.4.md
+++ b/DOCUMENTS/DOVECOT-2.4.md
@@ -229,6 +229,32 @@ The related migration script is provided in
 test with dry-run first, back up mail storage and the database, and review
 paths, ownership and Dovecot permissions before running with `--real`.
 
+## Operational mail deletion logging
+
+The example configuration enables the `mail_log` and `notify` plugins for IMAP
+and records the events and message fields needed to investigate reported mail
+deletions:
+
+```conf
+mail_log_events = delete undelete expunge mailbox_delete
+mail_log_fields = uid box msgid size from subject
+```
+
+This provides an operational audit trail for messages marked as deleted,
+unmarked, expunged, or removed as part of a mailbox deletion. In particular,
+an `expunge` event identifies a message that was actually removed, while `box`,
+`uid` and `msgid` help identify where and which message was affected. Dovecot's
+[debugging documentation](https://doc.dovecot.org/2.4.1/core/admin/debug.html)
+recommends the mail-log plugin when investigating reports of lost mail so the
+logs can show which actions caused messages to be deleted. The supported events,
+fields, and the requirement to enable `notify` alongside `mail_log` are described
+in the official [mail-log plugin documentation](https://doc.dovecot.org/2.4.1/core/plugins/mail_log.html).
+
+These settings only record operations performed after they are enabled; they
+cannot reconstruct earlier deletions. Because `from` and `subject` may contain
+sensitive information, protect and retain the resulting logs according to the
+site's privacy and log-retention policy.
+
 ## Optional quota warning delivery
 
 The full configuration example uses Dovecot quota warnings:

--- a/DOCUMENTS/examples/dovecot-2.4-local.conf
+++ b/DOCUMENTS/examples/dovecot-2.4-local.conf
@@ -181,6 +181,11 @@ mail_plugins {
   fts_flatcurve = yes
 }
 
+# Record message and mailbox deletion activity for operational troubleshooting.
+# The mail_log and notify plugins are enabled for IMAP below.
+mail_log_events = delete undelete expunge mailbox_delete
+mail_log_fields = uid box msgid size from subject
+
 acl_driver = vfile
 
 acl_sharing_map {

--- a/DOCUMENTS/examples/dovecot-2.4-local.conf
+++ b/DOCUMENTS/examples/dovecot-2.4-local.conf
@@ -181,10 +181,10 @@ mail_plugins {
   fts_flatcurve = yes
 }
 
-# Record message and mailbox deletion activity for operational troubleshooting.
-# The mail_log and notify plugins are enabled for IMAP below.
-mail_log_events = delete undelete expunge mailbox_delete
-mail_log_fields = uid box msgid size from subject
+# Optional detailed message and mailbox deletion logging. Uncomment these
+# settings and the mail_log/notify IMAP plugins below to enable it.
+#mail_log_events = delete undelete expunge mailbox_delete
+#mail_log_fields = uid box msgid size from subject
 
 acl_driver = vfile
 
@@ -199,8 +199,9 @@ protocol imap {
     imap_quota = yes
     imap_acl = yes
     imap_sieve = yes
-    mail_log = yes
-    notify = yes
+    # Enable together with mail_log_events and mail_log_fields above.
+    #mail_log = yes
+    #notify = yes
     fts = yes
     fts_flatcurve = yes
   }


### PR DESCRIPTION
## Summary

- include optional `mail_log_events` and `mail_log_fields` settings in the Dovecot 2.4 example
- keep detailed logging and the required `mail_log`/`notify` plugins commented out by default
- explain how administrators can explicitly enable the complete set
- link to the official Dovecot documentation
- document the prospective nature and privacy implications of sender and subject fields

## Why

Detailed deletion logging can help investigate future reports of missing mail,
but sender and subject metadata may be sensitive. The example documents the
capability without enabling it by default.

## Validation

- `git diff --check`
- verified all related settings remain commented out in the example
- verified the events and fields against the official Dovecot 2.4.1 documentation

`doveconf -n` was not run because Dovecot is unavailable on the Windows host.
