### PR TITLE
4.x: accept valid doveadm results with stderr warnings

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1058,12 +1058,14 @@ function _pacrypt_dovecot($pw, $pw_db = '', $username = '')
     fclose($pipes[0]);
 
     $stderr_output = stream_get_contents($pipes[2]);
+    $password = stream_get_contents($pipes[1]);
 
-    // Read hash from pipe stdout
-    $password = fread($pipes[1], 200);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $exit_status = proc_close($pipe);
 
-    if (!empty($stderr_output) || empty($password)) {
-        error_log("Failed to read password from $dovecotpw ... stderr: $stderr_output, password: $password ");
+    if ($exit_status !== 0 || empty($password)) {
+        error_log("Failed to read password from $dovecotpw ... exit status: $exit_status, stderr: $stderr_output, password: $password ");
         throw new Exception("$dovecotpw failed, see error log for details");
     }
 
@@ -1080,9 +1082,9 @@ function _pacrypt_dovecot($pw, $pw_db = '', $username = '')
         }
     }
 
-    fclose($pipes[1]);
-    fclose($pipes[2]);
-    proc_close($pipe);
+    if (!empty($stderr_output)) {
+        error_log("$dovecotpw wrote to stderr but returned a valid result: $stderr_output");
+    }
 
     if ((!empty($pw_db)) && (substr($pw_db, 0, 1) != '{')) {
         # for backward compability with "old" dovecot passwords that don't have the {method} prefix

--- a/tests/PacryptTest.php
+++ b/tests/PacryptTest.php
@@ -55,6 +55,100 @@ class PacryptTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected_hash, _pacrypt_dovecot('test', '', $username));
     }
 
+    public function testPacryptDovecotAcceptsValidHashWithStderr()
+    {
+        global $CONF;
+
+        $previous_encrypt = $CONF['encrypt'];
+        $previous_dovecotpw = $CONF['dovecotpw'];
+        $CONF['encrypt'] = 'dovecot:FIXTUREWARN';
+        $CONF['dovecotpw'] = $this->fakeDoveadmCommand();
+
+        try {
+            $this->assertEquals('{FIXTUREWARN}fixture-hash', _pacrypt_dovecot('test'));
+        } finally {
+            $CONF['encrypt'] = $previous_encrypt;
+            $CONF['dovecotpw'] = $previous_dovecotpw;
+        }
+    }
+
+    public function testPacryptDovecotAcceptsVerifiedPasswordWithStderr()
+    {
+        global $CONF;
+
+        $previous_encrypt = $CONF['encrypt'];
+        $previous_dovecotpw = $CONF['dovecotpw'];
+        $CONF['encrypt'] = 'dovecot:FIXTUREWARN';
+        $CONF['dovecotpw'] = $this->fakeDoveadmCommand();
+        $stored_password = '{FIXTUREWARN}fixture-hash';
+
+        try {
+            $this->assertEquals($stored_password, _pacrypt_dovecot('test', $stored_password));
+        } finally {
+            $CONF['encrypt'] = $previous_encrypt;
+            $CONF['dovecotpw'] = $previous_dovecotpw;
+        }
+    }
+
+    public function testPacryptDovecotRejectsNonZeroExitStatusWithValidHash()
+    {
+        global $CONF;
+
+        $previous_encrypt = $CONF['encrypt'];
+        $previous_dovecotpw = $CONF['dovecotpw'];
+        $CONF['encrypt'] = 'dovecot:FIXTUREFAIL';
+        $CONF['dovecotpw'] = $this->fakeDoveadmCommand();
+
+        try {
+            $this->expectException(Exception::class);
+            _pacrypt_dovecot('test');
+        } finally {
+            $CONF['encrypt'] = $previous_encrypt;
+            $CONF['dovecotpw'] = $previous_dovecotpw;
+        }
+    }
+
+    public function testPacryptDovecotRejectsEmptyOutput()
+    {
+        global $CONF;
+
+        $previous_encrypt = $CONF['encrypt'];
+        $previous_dovecotpw = $CONF['dovecotpw'];
+        $CONF['encrypt'] = 'dovecot:FIXTUREEMPTY';
+        $CONF['dovecotpw'] = $this->fakeDoveadmCommand();
+
+        try {
+            $this->expectException(Exception::class);
+            _pacrypt_dovecot('test');
+        } finally {
+            $CONF['encrypt'] = $previous_encrypt;
+            $CONF['dovecotpw'] = $previous_dovecotpw;
+        }
+    }
+
+    public function testPacryptDovecotRejectsInvalidHash()
+    {
+        global $CONF;
+
+        $previous_encrypt = $CONF['encrypt'];
+        $previous_dovecotpw = $CONF['dovecotpw'];
+        $CONF['encrypt'] = 'dovecot:FIXTUREINVALID';
+        $CONF['dovecotpw'] = $this->fakeDoveadmCommand();
+
+        try {
+            $this->expectException(Exception::class);
+            _pacrypt_dovecot('test');
+        } finally {
+            $CONF['encrypt'] = $previous_encrypt;
+            $CONF['dovecotpw'] = $previous_dovecotpw;
+        }
+    }
+
+    private function fakeDoveadmCommand(): string
+    {
+        return escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg(__DIR__ . '/fixtures/fake-doveadm.php');
+    }
+
 
     public function testPhpCrypt()
     {

--- a/tests/fixtures/fake-doveadm.php
+++ b/tests/fixtures/fake-doveadm.php
@@ -1,0 +1,26 @@
+<?php
+
+$method_index = array_search('-s', $argv, true);
+$method = $method_index === false ? '' : ($argv[$method_index + 1] ?? '');
+$test_index = array_search('-t', $argv, true);
+$stored_password = $test_index === false ? '' : ($argv[$test_index + 1] ?? '');
+
+stream_get_contents(STDIN);
+
+if ($method === 'FIXTUREEMPTY') {
+    exit(0);
+}
+
+if ($method === 'FIXTUREINVALID') {
+    echo "not a password hash\n";
+    exit(0);
+}
+
+$password = empty($stored_password) ? "{{$method}}fixture-hash" : "$stored_password (verified)";
+echo "$password\n";
+
+if ($method === 'FIXTUREWARN') {
+    fwrite(STDERR, "fixture warning\n");
+}
+
+exit($method === 'FIXTUREFAIL' ? 1 : 0);


### PR DESCRIPTION
## Summary

- port the `doveadm pw` stderr and exit-status handling from #1121 to `postfixadmin_4.0`
- preserve PHP 7.4-compatible syntax and the branch-specific password flow
- add the same portable regression coverage for password generation and verification

Addresses #1119.

## Validation

- PHP 8.4 lint on all changed PHP files
- `PacryptTest` with PHPUnit 9: 16 tests, 147 assertions; the real `doveadm` integration test is skipped on Windows
- local Psalm 4 cannot start on PHP 8.4 because its bundled Amp dependency emits a PHP 8.4 deprecation
- fork GitHubBuild run 32540966181 passed lint and the complete PHP 7.4-8.5 matrix