### PR TITLE
Document optional strict MX policy service

### DIFF
--- a/ADDITIONS/README.md
+++ b/ADDITIONS/README.md
@@ -109,3 +109,10 @@ and recovery guidance.
 ## Cyrus Quota Usage
 
 See https://github.com/o-m-d/cyrus-quotausage-to-pfa
+
+## Optional strict MX policy service
+
+[postfix-strict-mx-policy](https://github.com/TrapoSAMA/postfix-strict-mx-policy)
+is a standalone Postfix policy service that rejects recipient domains without
+an explicit MX record. This is intentionally stricter than standard SMTP
+implicit-MX delivery; see the project documentation before enabling it.


### PR DESCRIPTION
## Summary

Add a short documentation pointer from `ADDITIONS/README.md` to the standalone [postfix-strict-mx-policy](https://github.com/TrapoSAMA/postfix-strict-mx-policy) project.

The policy service implementation, tests, CI, installation instructions, and license now live exclusively in that independent repository. This PR contains no executable code and makes no runtime changes to PostfixAdmin.

The text also calls out that requiring an explicit MX record is intentionally stricter than standard SMTP implicit-MX delivery, so administrators can make an informed choice before enabling it.

## Validation

- `git diff --check`: passed.
- Standalone project CI: passed on Python 3.8 and 3.13.

No PHP runtime, database engine, schema, authorization flow, or PostfixAdmin configuration is affected.