### PR TITLE
Use shared pagination in generic lists

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -2086,6 +2086,71 @@ function viewlog_domain_condition(bool $show_all, bool $is_global_admin, string 
 }
 
 /**
+ * Build normalized pagination items for an alphabetical page browser.
+ *
+ * @param array<int, string> $pages
+ * @param array<string, mixed> $query_params
+ * @param array{first?: string, previous?: string, next?: string} $aria_labels
+ * @return array<int, array<string, bool|int|string>>
+ */
+function page_browser_pagination(
+    array $pages,
+    int $offset,
+    int $page_size,
+    array $query_params,
+    string $anchor,
+    array $aria_labels = []
+): array {
+    if (count($pages) === 0) {
+        return [];
+    }
+    if ($page_size < 1) {
+        throw new InvalidArgumentException('Page size must be greater than zero');
+    }
+
+    $current_page = intdiv(max(0, $offset), $page_size);
+    $last_page = count($pages) - 1;
+
+    $url_for_page = static function (int $page) use ($query_params, $page_size, $anchor): string {
+        $query_params['limit'] = $page * $page_size;
+        $query = http_build_query($query_params, '', '&', PHP_QUERY_RFC3986);
+        return '?' . htmlspecialchars($query, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '#' . rawurlencode($anchor);
+    };
+
+    $pagination = [
+        [
+            'label' => '&laquo;',
+            'url' => $url_for_page(0),
+            'disabled' => $current_page === 0,
+            'aria' => $aria_labels['first'] ?? '',
+        ],
+        [
+            'label' => '&lsaquo;',
+            'url' => $url_for_page(max(0, $current_page - 1)),
+            'disabled' => $current_page === 0,
+            'aria' => $aria_labels['previous'] ?? '',
+        ],
+    ];
+
+    foreach ($pages as $page => $label) {
+        $pagination[] = [
+            'label' => $label,
+            'url' => $url_for_page($page),
+            'active' => $page === $current_page,
+        ];
+    }
+
+    $pagination[] = [
+        'label' => '&rsaquo;',
+        'url' => $url_for_page(min($last_page, $current_page + 1)),
+        'disabled' => $current_page >= $last_page,
+        'aria' => $aria_labels['next'] ?? '',
+    ];
+
+    return $pagination;
+}
+
+/**
  * Compute the page numbers to display in a windowed pager.
  *
  * Always includes page 1 and the last page, plus a window of $radius pages on

--- a/public/list.php
+++ b/public/list.php
@@ -89,10 +89,44 @@ if (array_key_exists('reset_search', $_GET)) {
 $_SESSION["search_$table"] = $search;
 $_SESSION["searchmode_$table"] = $searchmode;
 
-if (count($search)) {
-    $handler->getList($search, $searchmode);
+$condition = count($search) ? $search : '';
+$pagination = [];
+
+if (safeget('output') == 'csv') {
+    // CSV exports keep the historical behavior and contain the complete list.
+    $handler->getList($condition, $searchmode);
 } else {
-    $handler->getList('');
+    $page_size = (int)$CONF['page_size'];
+    $pagebrowser = $handler->getPagebrowser($condition, $searchmode);
+    $last_offset = max(0, (count($pagebrowser) - 1) * $page_size);
+    $offset = max(0, (int)safeget('limit', '0'));
+    $offset = min($last_offset, intdiv($offset, $page_size) * $page_size);
+
+    $handler->getList($condition, $searchmode, $page_size, $offset);
+
+    $pagination_params = ['table' => $table];
+    if ($is_superadmin && $formconf['required_role'] != 'global-admin') {
+        $pagination_params['username'] = $username;
+    }
+    if (count($search)) {
+        $pagination_params['search'] = $search;
+    }
+    if (count($searchmode)) {
+        $pagination_params['searchmode'] = $searchmode;
+    }
+
+    $pagination = page_browser_pagination(
+        $pagebrowser,
+        $offset,
+        $page_size,
+        $pagination_params,
+        'main_div',
+        [
+            'first' => $PALANG['pOverview_up_arrow'],
+            'previous' => $PALANG['pOverview_left_arrow'],
+            'next' => $PALANG['pOverview_right_arrow'],
+        ]
+    );
 }
 
 $items = $handler->result();
@@ -163,6 +197,8 @@ $smarty->assign('id_field', $handler->getId_field());
 $smarty->assign('formconf', $formconf);
 $smarty->assign('search', $search);
 $smarty->assign('searchmode', $searchmode);
+$smarty->assign('pagination', $pagination);
+$smarty->assign('pagination_label', $PALANG[$handler->getMsg()['list_header'] ?? ''] ?? 'Pagination');
 $smarty->assign('domain_selected', ''); /* stop list-virtual.tpl triggering a PHP notice */
 
 $smarty->display('index.tpl');

--- a/templates/list.tpl
+++ b/templates/list.tpl
@@ -34,6 +34,11 @@
     {/if}
 
     <div class="card-body">
+        {if isset($pagination) && $pagination}
+            <div class="mb-3">
+                {include file="_pagination.tpl" pagination=$pagination pagination_label=$pagination_label}
+            </div>
+        {/if}
         {if $table == 'domain'}
             <div class="domain-list-scroll">
         {elseif $table == 'alias' || $table == 'aliasdomain'}
@@ -182,6 +187,11 @@
             </tbody>
         </table>
         {if $table == 'domain' || $table == 'alias' || $table == 'aliasdomain'}</div>{/if}
+        {if isset($pagination) && $pagination}
+            <div class="mt-3">
+                {include file="_pagination.tpl" pagination=$pagination pagination_label=$pagination_label}
+            </div>
+        {/if}
     </div>
 
     <div class="card-footer">

--- a/tests/ListTemplatePaginationTest.php
+++ b/tests/ListTemplatePaginationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+class ListTemplatePaginationTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRendersPaginationAboveAndBelowGenericList(): void
+    {
+        $html = $this->renderList([
+            [
+                'label' => 'aa-cz',
+                'url' => '?table=domain&amp;limit=0#main_div',
+                'active' => true,
+            ],
+            [
+                'label' => 'de-zz',
+                'url' => '?table=domain&amp;limit=10#main_div',
+            ],
+        ]);
+
+        $this->assertSame(2, substr_count($html, '<nav aria-label="Domains">'));
+        $this->assertSame(2, substr_count($html, 'aria-current="page">aa-cz'));
+        $this->assertSame(2, substr_count($html, 'href="?table=domain&amp;limit=10#main_div"'));
+    }
+
+    public function testOmitsPaginationForSinglePageList(): void
+    {
+        $html = $this->renderList([]);
+
+        $this->assertStringNotContainsString('<nav ', $html);
+    }
+
+    /**
+     * @param array<int, array<string, bool|string>> $pagination
+     */
+    private function renderList(array $pagination): string
+    {
+        $original_session = $_SESSION;
+        $original_language = Config::read_array('__LANG');
+
+        try {
+            $_SESSION = [
+                'sessid' => [
+                    'roles' => ['global-admin'],
+                    'username' => 'admin',
+                ],
+            ];
+            Config::write('__LANG', ['download_csv' => 'Download CSV']);
+
+            $smarty = PFASmarty::getInstance();
+            $smarty->assign('id_div', 'main_div');
+            $smarty->assign('admin_list', []);
+            $smarty->assign('msg', [
+                'show_simple_search' => false,
+                'list_header' => '',
+                'can_create' => false,
+            ]);
+            $smarty->assign('table', 'domain');
+            $smarty->assign('struct', []);
+            $smarty->assign('items', []);
+            $smarty->assign('id_field', 'domain');
+            $smarty->assign('formconf', ['create_button' => '']);
+            $smarty->assign('search', []);
+            $smarty->assign('searchmode', []);
+            $smarty->assign('pagination', $pagination);
+            $smarty->assign('pagination_label', 'Domains');
+            $smarty->assign('domain_selected', '');
+
+            ob_start();
+            $smarty->display('list.tpl');
+            return (string)ob_get_clean();
+        } finally {
+            $_SESSION = $original_session;
+            Config::write('__LANG', $original_language);
+        }
+    }
+}

--- a/tests/PageBrowserPaginationTest.php
+++ b/tests/PageBrowserPaginationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+class PageBrowserPaginationTest extends \PHPUnit\Framework\TestCase
+{
+    public function testEmptyPageBrowserDoesNotRenderPagination(): void
+    {
+        $this->assertSame([], page_browser_pagination([], 0, 10, [], 'main_div'));
+    }
+
+    public function testFirstPagePreservesGenericListState(): void
+    {
+        $pagination = page_browser_pagination(
+            ['aa-cz', 'de-pf', 'pg-zz'],
+            0,
+            10,
+            [
+                'table' => 'alias',
+                'username' => 'admin@example.com',
+                'search' => ['_' => 'sales & support'],
+                'searchmode' => ['_' => '='],
+            ],
+            'main_div',
+            [
+                'first' => 'First page',
+                'previous' => 'Previous page',
+                'next' => 'Next page',
+            ]
+        );
+
+        $this->assertTrue($pagination[0]['disabled']);
+        $this->assertTrue($pagination[1]['disabled']);
+        $this->assertTrue($pagination[2]['active']);
+        $this->assertSame(
+            '?table=alias&amp;username=admin%40example.com&amp;search%5B_%5D=sales%20%26%20support&amp;searchmode%5B_%5D=%3D&amp;limit=10#main_div',
+            $pagination[3]['url']
+        );
+        $this->assertSame('Next page', $pagination[5]['aria']);
+    }
+
+    public function testMiddlePageBuildsFirstPreviousAndNextLinks(): void
+    {
+        $pagination = page_browser_pagination(
+            ['aa-cz', 'de-pf', 'pg-zz'],
+            10,
+            10,
+            ['table' => 'domain'],
+            'main_div'
+        );
+
+        $this->assertFalse($pagination[0]['disabled']);
+        $this->assertSame('?table=domain&amp;limit=0#main_div', $pagination[0]['url']);
+        $this->assertSame('?table=domain&amp;limit=0#main_div', $pagination[1]['url']);
+        $this->assertTrue($pagination[3]['active']);
+        $this->assertSame('?table=domain&amp;limit=20#main_div', $pagination[5]['url']);
+        $this->assertFalse($pagination[5]['disabled']);
+    }
+
+    public function testRejectsInvalidPageSize(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        page_browser_pagination(['aa-zz'], 0, 0, [], 'main_div');
+    }
+}


### PR DESCRIPTION
## Summary

This is the third and final implementation step of #1064, after #1090 and alongside #1093.

- paginate generic handler-backed `list.php` pages through `getPagebrowser()` and the configured page size
- render the shared `_pagination.tpl` partial above and below the generic list
- preserve table, simulated-admin, search, and search-mode query state, with a stable `#main_div` target
- keep CSV exports complete and unpaginated
- add focused helper and Smarty rendering regression tests

## Coordination with #1093

#1093 remains separate because it covers `list-virtual.php`. The shared `page_browser_pagination()` helper and the `list.tpl` hooks are intentionally identical in both open branches. After either PR merges, I will rebase the other one so that it retains only its surface-specific changes.

Together, #1090, #1093, and this PR cover all three pagination surfaces tracked in #1064.

## Validation

- PHP 8.4 focused suites: 8 tests, 550 assertions
- Smarty 5 rendering: top and bottom controls, plus omission for a single page
- full parallel PHP lint: 166 files
- PHP-CS-Fixer dry run against the exact LF index: clean
- Psalm: no errors
- PHPStan level 0: no errors
- authenticated XAMPP controller/template validation against MariaDB: 20 rows on page 1, 7 on page 2, stale offsets clamped to the last page, and all 27 rows retained in CSV
- GNU `patch -p1` dry run and real application against the exact base, with no offsets, fuzz, rejects, or `.orig` files; the applied tree exactly matched the branch head
