### PR TITLE
Require reauthentication for TOTP removal

### DIFF
--- a/public/users/totp.php
+++ b/public/users/totp.php
@@ -29,6 +29,9 @@ require_once('../common.php');
 $smarty = PFASmarty::getInstance();
 $smarty->configureTheme($smarty->getRelPath());
 
+$required_role = authentication_has_role('admin') ? 'admin' : 'user';
+authentication_require_role($required_role);
+
 $username = authentication_get_username();
 $pPassword_password_current_text = "";
 $pTOTP_now = "";
@@ -74,10 +77,16 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         $pPassword_password_current_text = $PALANG['pPassword_password_current_text_error'];
     }
 
-    // Does entered code from 2FA-app match the secret
+    // An empty code means that the user wants to remove TOTP.
     if ($fTOTP_code === '') {
-        // user wishes to remove TOTP code?
-        $totppf->removeTotpFromUser($username);
+        if ($error == 0) {
+            try {
+                $totppf->changeTOTP_secret($username, null, $fPassword_current);
+                flash_info($PALANG['pTotp_stored']);
+            } catch (\Exception $e) {
+                flash_error($e->getMessage());
+            }
+        }
         $error++;
     } else {
         if (false == $totppf->checkTOTP($fTOTP_secret, $fTOTP_code)) {

--- a/tests/TotpPfTest.php
+++ b/tests/TotpPfTest.php
@@ -94,6 +94,35 @@ class TotpPfTest extends TestCase
         $this->assertFalse($totp->passwordOnlyLogin('test@example.com', 'incorrect-password'));
     }
 
+    public function testTotpRemovalRequiresCurrentPassword(): void
+    {
+        $totp = new TotpPf('mailbox', new Login('mailbox'));
+        db_execute(
+            'UPDATE mailbox SET totp_secret = :secret WHERE username = :username',
+            ['username' => 'test@example.com', 'secret' => 'existing-secret']
+        );
+
+        try {
+            $totp->changeTOTP_secret('test@example.com', null, 'incorrect-password');
+            $this->fail('Removing TOTP with an invalid password must fail');
+        } catch (\Exception $e) {
+            $this->assertSame(Config::Lang('pPassword_password_current_text_error'), $e->getMessage());
+        }
+
+        $row = db_query_one(
+            'SELECT totp_secret FROM mailbox WHERE username = :username',
+            ['username' => 'test@example.com']
+        );
+        $this->assertSame('existing-secret', $row['totp_secret']);
+
+        $this->assertTrue($totp->changeTOTP_secret('test@example.com', null, 'foobar'));
+        $row = db_query_one(
+            'SELECT totp_secret FROM mailbox WHERE username = :username',
+            ['username' => 'test@example.com']
+        );
+        $this->assertNull($row['totp_secret']);
+    }
+
     public function testDbOperations()
     {
         $x = new TotpPf('mailbox', new Login('mailbox'));


### PR DESCRIPTION
## Summary

- require a completed user or admin role before opening TOTP management
- remove TOTP through the existing password-verifying change path
- keep configured post-change hooks active when a secret is removed
- add regression coverage proving an invalid password cannot remove the stored secret

## Validation

- focused PHPUnit regression: 1 test, 4 assertions
- PHP-CS-Fixer dry run on both changed files
- PHP lint on both changed files
- `git diff --check`

This is the first focused change for #1128.