### PR TITLE
Enforce TOTP policy for XML-RPC login

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -790,6 +790,8 @@ $CONF['theme_custom_css'] = '';
 // XMLRPC Interface.
 // This should be only of use if you wish to use e.g the
 // Postfixadmin-Squirrelmail package
+// XML-RPC has no TOTP challenge flow. Mailbox accounts with a TOTP
+// secret cannot authenticate through this interface.
 //  change to boolean true to enable xmlrpc
 $CONF['xmlrpc_enabled'] = false;
 

--- a/model/TotpPf.php
+++ b/model/TotpPf.php
@@ -134,6 +134,18 @@ class TotpPf
     }
 
     /**
+     * Authenticate an interface that cannot complete a TOTP challenge.
+     */
+    public function passwordOnlyLogin(string $username, string $password): bool
+    {
+        if (!$this->login->login($username, $password)) {
+            return false;
+        }
+
+        return !$this->usesTOTP($username);
+    }
+
+    /**
      * Check if a TOTP code is valid for a user
      */
     public function checkUserTOTP(string $username, string $code): bool

--- a/public/xmlrpc.php
+++ b/public/xmlrpc.php
@@ -48,7 +48,8 @@ $server = new Zend_XmlRpc_Server();
 function login($username, $password)
 {
     $login = new Login('mailbox');
-    if ($login->login($username, $password)) {
+    $totp = new TotpPf('mailbox', $login);
+    if ($totp->passwordOnlyLogin($username, $password)) {
         session_regenerate_id();
         $_SESSION['authenticated'] = true;
         $_SESSION['sessid'] = array();

--- a/tests/TotpPfTest.php
+++ b/tests/TotpPfTest.php
@@ -76,6 +76,24 @@ class TotpPfTest extends TestCase
         $this->assertNotEmpty($currentCode);
     }
 
+    public function testPasswordOnlyLoginRejectsAccountsUsingTotp(): void
+    {
+        global $CONF;
+        Config::write('totp', 'YES');
+        $CONF['totp'] = 'YES';
+
+        $totp = new TotpPf('mailbox', new Login('mailbox'));
+        $this->assertTrue($totp->passwordOnlyLogin('test@example.com', 'foobar'));
+
+        db_execute(
+            'UPDATE mailbox SET totp_secret = :secret WHERE username = :username',
+            ['username' => 'test@example.com', 'secret' => 'existing-secret']
+        );
+
+        $this->assertFalse($totp->passwordOnlyLogin('test@example.com', 'foobar'));
+        $this->assertFalse($totp->passwordOnlyLogin('test@example.com', 'incorrect-password'));
+    }
+
     public function testDbOperations()
     {
         $x = new TotpPf('mailbox', new Login('mailbox'));


### PR DESCRIPTION
## Summary

- reject password-only XML-RPC login when the mailbox requires TOTP
- preserve XML-RPC login behavior for mailboxes without TOTP
- centralize the password-only eligibility check in `TotpPf`
- add focused regression coverage for valid, TOTP-protected, and invalid-password cases

The XML-RPC protocol has no second-factor exchange, so protected accounts fail closed.

## Validation

- focused PHPUnit regression: 1 test, 3 assertions
- PHP-CS-Fixer on all changed files
- PHP lint on the XML-RPC endpoint
- `git diff --check`

Part of #1128.