### PR TITLE
Escape viewlog output by default

### DIFF
--- a/public/viewlog.php
+++ b/public/viewlog.php
@@ -205,7 +205,7 @@ if ($number_of_pages > 1) {
 
 $smarty->assign('domain_list', $list_domains);
 $smarty->assign('domain_selected', $fDomain);
-$smarty->assign('tLog', $tLog, false);
+$smarty->assign('tLog', $tLog);
 $smarty->assign('fDomain', $fDomain);
 $smarty->assign('show_all', $show_all);
 $smarty->assign('all_domains_value', $all_domains_value);

--- a/templates/viewlog.tpl
+++ b/templates/viewlog.tpl
@@ -32,17 +32,19 @@
             <th>{$PALANG.pViewlog_action}</th>
             <th>{$PALANG.pViewlog_data}</th>
             </tr>
-            {assign var="PALANG_pViewlog_data" value=$PALANG.pViewlog_data}
-
             {foreach from=$tLog item=item}
                 {assign var=log_data value=$item.data|truncate:35:"...":true}
-                {assign var=item_data value=$item.data}
-                {$smarty.config.tr_hilightoff|replace:'>':" style=\"cursor:pointer;\" onclick=\"alert('$PALANG_pViewlog_data = $item_data')\">"}
+                {$smarty.config.tr_hilightoff}
                 <td nowrap="nowrap">{$item.timestamp}</td>
                 <td nowrap="nowrap">{$item.username}</td>
                 <td nowrap="nowrap">{$item.domain}</td>
                 <td nowrap="nowrap">{$item.action}</td>
-                <td nowrap="nowrap">{$log_data}</td>
+                <td>
+                    <details>
+                        <summary>{$log_data}</summary>
+                        <div class="text-break">{$item.data}</div>
+                    </details>
+                </td>
                 </tr>
             {/foreach}
         </table>

--- a/tests/ViewlogOutputSecurityTest.php
+++ b/tests/ViewlogOutputSecurityTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ViewlogOutputSecurityTest extends TestCase
+{
+    public function testControllerUsesDefaultOutputSanitisation(): void
+    {
+        $controller = file_get_contents(__DIR__ . '/../public/viewlog.php');
+
+        $this->assertStringContainsString("assign('tLog', \$tLog);", $controller);
+        $this->assertStringNotContainsString("assign('tLog', \$tLog, false)", $controller);
+    }
+
+    public function testTemplateDoesNotEmbedLogDataInJavascript(): void
+    {
+        $template = file_get_contents(__DIR__ . '/../templates/viewlog.tpl');
+
+        $this->assertStringNotContainsString('onclick=', $template);
+        $this->assertStringContainsString('<details>', $template);
+    }
+}


### PR DESCRIPTION
Render log records through the default output sanitization path and remove the inline JavaScript interpolation of log data.

Full log data remains available through a native details element without placing it in a script context.

Tests: focused PHPUnit checks, existing viewlog scope tests, PHP lint, PHP-CS-Fixer, and diff checks.

Refs #1128