### PR TITLE
4.x: harden password recovery requests

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -2358,4 +2358,28 @@ function getSiteUrl(array $server = []): string
     return $https . '://' . $server['HTTP_HOST'] . $uri;
 }
 
+/**
+ * Return the configured canonical URL used in password-recovery messages.
+ *
+ * Request headers are deliberately not used here because recovery links carry
+ * a credential and must not depend on an untrusted Host value.
+ */
+function getPasswordRecoverySiteUrl(): string
+{
+    $url = Config::read_string('site_url');
+    $parts = parse_url($url);
+
+    if ($url === '' || !is_array($parts) || empty($parts['host']) ||
+        !isset($parts['scheme']) || !in_array(strtolower($parts['scheme']), ['http', 'https'], true) ||
+        isset($parts['user']) || isset($parts['pass']) || isset($parts['query']) || isset($parts['fragment'])) {
+        throw new RuntimeException("A valid canonical site_url is required for password recovery");
+    }
+
+    if (substr($url, -1) !== '/') {
+        $url .= '/';
+    }
+
+    return $url;
+}
+
 /* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */

--- a/model/Login.php
+++ b/model/Login.php
@@ -63,27 +63,27 @@ class Login
      */
     public function generatePasswordRecoveryCode(string $username)
     {
-        $sql = "SELECT count(1) FROM {$this->key_table} WHERE username = :username AND active = :active";
+        $token = generate_password();
+        $token_hash = pacrypt($token);
+        $token_validity = date('Y-m-d H:i:s', strtotime('+1 hour'));
+        $cooldown = date('Y-m-d H:i:s', strtotime('+55 minutes'));
+        $now = db_sqlite() ? "datetime('now')" : 'now()';
 
-        $active = db_get_boolean(true);
+        $sql = "UPDATE {$this->key_table}
+            SET token = :token, token_validity = :token_validity, modified = $now
+            WHERE username = :username AND active = :active
+              AND (token IS NULL OR token = '' OR token_validity <= :cooldown)";
 
-        $values = [
+        $updatedRows = db_execute($sql, [
+            'token' => $token_hash,
+            'token_validity' => $token_validity,
             'username' => $username,
-            'active' => $active,
-        ];
+            'active' => db_get_boolean(true),
+            'cooldown' => $cooldown,
+        ]);
 
-        $result = db_query_one($sql, $values);
-
-        if ($result) {
-            $token = generate_password();
-            $updatedRows = db_update($this->table, 'username', $username, array(
-                'token' => pacrypt($token),
-                'token_validity' => date("Y-m-d H:i:s", strtotime('+ 1 hour')),
-            ));
-
-            if ($updatedRows == 1) {
-                return $token;
-            }
+        if ($updatedRows == 1) {
+            return $token;
         }
         return false;
     }

--- a/public/users/password-recover.php
+++ b/public/users/password-recover.php
@@ -46,7 +46,12 @@ if ($context === 'admin' && !Config::read('forgotten_admin_password_reset') ||
 
 function sendCodebyEmail($to, $username, $code)
 {
-    $url = getSiteUrl($_SERVER) . 'password-change.php?username=' . urlencode($username) . '&code=' . $code;
+    try {
+        $url = getPasswordRecoverySiteUrl() . 'password-change.php?username=' . urlencode($username) . '&code=' . $code;
+    } catch (RuntimeException $e) {
+        error_log(__FILE__ . ' - ' . $e->getMessage());
+        return false;
+    }
 
     return smtp_mail($to,
         smtp_get_admin_email(false),
@@ -99,16 +104,15 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
             error_log(__FILE__ . " - No mechanism configured for password-recovery.");
         }
 
-        if ($email_other || $phone) {
-            header("Location: password-change.php?username=" . $tUsername);
-            exit(0);
-        }
     }
 
     // throttle password reset requests to prevent brute force attack
     $elapsed_time = microtime(true) - $start_time;
-    if ($elapsed_time < 2 * pow(10, 6)) {
-        usleep((int) (2 * pow(10, 6) - $elapsed_time));
+    if ($elapsed_time < 2.0) {
+        $sleep = (int)((2.0 - $elapsed_time) * 1_000_000.0);
+        if ($sleep > 0) {
+            usleep($sleep);
+        }
     }
 
     flash_info(Config::Lang('pPassword_recovery_processed'));

--- a/tests/GetSiteUrlTest.php
+++ b/tests/GetSiteUrlTest.php
@@ -56,4 +56,33 @@ class GetSiteUrlTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('http://example.org/', getSiteUrl($server));
     }
+
+    public function testPasswordRecoveryRequiresCanonicalUrl(): void
+    {
+        $config = Config::getInstance()->getAll();
+        $config['site_url'] = null;
+        Config::getInstance()->setAll($config);
+
+        $this->expectException(RuntimeException::class);
+        getPasswordRecoverySiteUrl();
+    }
+
+    public function testPasswordRecoveryUsesConfiguredUrlOnly(): void
+    {
+        $config = Config::getInstance()->getAll();
+        $config['site_url'] = 'https://example.com/postfixadmin';
+        Config::getInstance()->setAll($config);
+
+        $this->assertSame('https://example.com/postfixadmin/', getPasswordRecoverySiteUrl());
+    }
+
+    public function testPasswordRecoveryRejectsUrlCredentials(): void
+    {
+        $config = Config::getInstance()->getAll();
+        $config['site_url'] = 'https://user:password@example.com/postfixadmin/';
+        Config::getInstance()->setAll($config);
+
+        $this->expectException(RuntimeException::class);
+        getPasswordRecoverySiteUrl();
+    }
 }

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -145,7 +145,21 @@ class LoginTest extends \PHPUnit\Framework\TestCase
         $login = new Login('mailbox');
         $this->assertFalse($login->generatePasswordRecoveryCode(''));
         $this->assertFalse($login->generatePasswordRecoveryCode('doesnotexist'));
-        $this->assertNotEmpty($login->generatePasswordRecoveryCode('test@example.com'));
+        $token = $login->generatePasswordRecoveryCode('test@example.com');
+        $this->assertNotEmpty($token);
+        $this->assertFalse($login->generatePasswordRecoveryCode('test@example.com'));
+
+        db_execute(
+            "UPDATE " . table_by_key('mailbox') . " SET token_validity = :validity WHERE username = :username",
+            [
+                'validity' => date('Y-m-d H:i:s', strtotime('+54 minutes')),
+                'username' => 'test@example.com',
+            ]
+        );
+
+        $replacement = $login->generatePasswordRecoveryCode('test@example.com');
+        $this->assertIsString($replacement);
+        $this->assertNotSame($token, $replacement);
     }
 
     public function testAddAppPasswordIncorrectPassword()

--- a/tests/PasswordRecoveryResponseTest.php
+++ b/tests/PasswordRecoveryResponseTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class PasswordRecoveryResponseTest extends TestCase
+{
+    public function testRecoveryRequestDoesNotRevealDeliveryAvailability(): void
+    {
+        $controller = file_get_contents(__DIR__ . '/../public/users/password-recover.php');
+
+        $this->assertStringNotContainsString('Location: password-change.php?username=', $controller);
+        $this->assertStringContainsString("flash_info(Config::Lang('pPassword_recovery_processed'))", $controller);
+    }
+}


### PR DESCRIPTION
Require a validated canonical site_url for recovery links, keep responses uniform, and persist a five-minute per-account request limit.

This ports the behavior of PR #1130 while preserving PHP 7.4 compatibility and the 4.x database boolean handling.

Tests: focused Login and recovery URL tests, response regression check, PHP lint, PHP-CS-Fixer, and diff checks.

Refs #1128