### PR TITLE
4.x: scope Roundcube TOTP preference updates

### DIFF
--- a/scripts/examples/sync-roundcubemail-totp.php
+++ b/scripts/examples/sync-roundcubemail-totp.php
@@ -2,6 +2,11 @@
 <?php
 
 // Get positional arguments
+if ($argc !== 3) {
+    fwrite(STDERR, "Usage: {$argv[0]} <username> <domain>\n");
+    exit(1);
+}
+
 $USERNAME = $argv[1];
 $DOMAIN = $argv[2];
 
@@ -15,7 +20,7 @@ include_once "/etc/postfixadmin/rcm-totp-sync.php";
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = new mysqli($CONFIG["host"], $CONFIG["user"], $CONFIG["password"], $CONFIG["database"]);
 
-$stmt = $mysqli->prepare("SELECT preferences FROM users WHERE username=?");
+$stmt = $mysqli->prepare("SELECT user_id, preferences FROM users WHERE username=?");
 $stmt->bind_param("s", $USERNAME);
 $stmt->execute();
 $result = $stmt->get_result();
@@ -23,10 +28,15 @@ $result = $stmt->get_result();
 if ($result->num_rows == 1) {
     echo "Updating TOTP secret for $USERNAME\n";
     $row = $result->fetch_assoc();
-    $preferences = unserialize($row['preferences']);
+    $preferences = unserialize($row['preferences'], ['allowed_classes' => false]);
+    if (!is_array($preferences)) {
+        $preferences = [];
+    }
     $preferences['twofactor_gauthenticator']['secret'] = $SHARED_SECRET;
-    $stmt_update = $mysqli->prepare("UPDATE users SET preferences=?");
-    $stmt_update->bind_param("s", serialize($preferences));
+    $serialized_preferences = serialize($preferences);
+    $user_id = (int)$row['user_id'];
+    $stmt_update = $mysqli->prepare("UPDATE users SET preferences=? WHERE user_id=?");
+    $stmt_update->bind_param("si", $serialized_preferences, $user_id);
     $stmt_update->execute();
 } else {
     echo "Could not find user $USERNAME in Roundcubemail.\n";

--- a/tests/SyncRoundcubemailTotpScriptTest.php
+++ b/tests/SyncRoundcubemailTotpScriptTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SyncRoundcubemailTotpScriptTest extends TestCase
+{
+    private string $script;
+
+    protected function setUp(): void
+    {
+        $this->script = file_get_contents(__DIR__ . '/../scripts/examples/sync-roundcubemail-totp.php');
+    }
+
+    public function testUpdateIsLimitedToTheSelectedUser(): void
+    {
+        $this->assertStringContainsString('UPDATE users SET preferences=? WHERE user_id=?', $this->script);
+    }
+
+    public function testSerializedPreferencesCannotInstantiateClasses(): void
+    {
+        $this->assertStringContainsString("['allowed_classes' => false]", $this->script);
+    }
+}


### PR DESCRIPTION
Limit the Roundcube preference update to the selected user and prevent serialized preferences from instantiating classes.

This ports PR #1133 with PHP 7.4 compatibility and validates the script arguments before accessing them.

Tests: focused script regression checks, PHP lint, PHP-CS-Fixer, and diff checks.

Refs #1128