### PR TITLE
4.x: escape viewlog output by default

### DIFF
--- a/public/viewlog.php
+++ b/public/viewlog.php
@@ -158,7 +158,7 @@ $url = explode("?",(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "ht
 
 $smarty->assign('domain_list', $list_domains);
 $smarty->assign('domain_selected', $fDomain);
-$smarty->assign('tLog', $tLog, false);
+$smarty->assign('tLog', $tLog);
 $smarty->assign('fDomain', $fDomain);
 
 $smarty->assign('number_of_pages', $number_of_pages);

--- a/templates/viewlog.tpl
+++ b/templates/viewlog.tpl
@@ -21,17 +21,19 @@
             <th>{$PALANG.pViewlog_action}</th>
             <th>{$PALANG.pViewlog_data}</th>
             </tr>
-            {assign var="PALANG_pViewlog_data" value=$PALANG.pViewlog_data}
-
             {foreach from=$tLog item=item}
                 {assign var=log_data value=$item.data|truncate:35:"...":true}
-                {assign var=item_data value=$item.data}
-                {$smarty.config.tr_hilightoff|replace:'>':" style=\"cursor:pointer;\" onclick=\"alert('$PALANG_pViewlog_data = $item_data')\">"}
+                {$smarty.config.tr_hilightoff}
                 <td nowrap="nowrap">{$item.timestamp}</td>
                 <td nowrap="nowrap">{$item.username}</td>
                 <td nowrap="nowrap">{$item.domain}</td>
                 <td nowrap="nowrap">{$item.action}</td>
-                <td nowrap="nowrap">{$log_data}</td>
+                <td>
+                    <details>
+                        <summary>{$log_data}</summary>
+                        <div style="overflow-wrap: anywhere;">{$item.data}</div>
+                    </details>
+                </td>
                 </tr>
             {/foreach}
         </table>

--- a/tests/ViewlogOutputSecurityTest.php
+++ b/tests/ViewlogOutputSecurityTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ViewlogOutputSecurityTest extends TestCase
+{
+    public function testControllerUsesDefaultOutputSanitisation(): void
+    {
+        $controller = file_get_contents(__DIR__ . '/../public/viewlog.php');
+
+        $this->assertStringContainsString("assign('tLog', \$tLog);", $controller);
+        $this->assertStringNotContainsString("assign('tLog', \$tLog, false)", $controller);
+    }
+
+    public function testTemplateDoesNotEmbedLogDataInJavascript(): void
+    {
+        $template = file_get_contents(__DIR__ . '/../templates/viewlog.tpl');
+
+        $this->assertStringNotContainsString('alert(', $template);
+        $this->assertStringNotContainsString('assign var=item_data', $template);
+        $this->assertStringContainsString('<details>', $template);
+    }
+}


### PR DESCRIPTION
Restore default output sanitisation for viewlog records and replace the inline JavaScript detail popup with native details markup.

This ports PR #1134 while preserving Smarty 3/4 and Bootstrap 3 compatibility.

Tests: focused output regression checks, PHP lint, PHP-CS-Fixer, Smarty rendering, and diff checks.

Refs #1128